### PR TITLE
Make Shr for negative BigInt round down, like primitives do

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,9 +1,12 @@
 # Release 0.2.0 (pending)
 
 - :warning: [num-bigint now requires rustc 1.15 or greater][23].
+- :warning: [`Shr for BigInt` now rounds down][8] rather than toward zero,
+  matching the behavior of the primitive integers for negative values.
 
 **Contributors**: @cuviper
 
+[8]: https://github.com/rust-num/num-bigint/pull/8
 [23]: https://github.com/rust-num/num-bigint/pull/23
 
 

--- a/src/bigint.rs
+++ b/src/bigint.rs
@@ -228,12 +228,23 @@ impl<'a> Shl<usize> for &'a BigInt {
     }
 }
 
+// Negative values need a rounding adjustment if there are any ones in the
+// bits that are getting shifted out.
+fn shr_round_down(i: &BigInt, rhs: usize) -> bool {
+    i.is_negative() &&
+        biguint::trailing_zeros(&i.data)
+            .map(|n| n < rhs)
+            .unwrap_or(false)
+}
+
 impl Shr<usize> for BigInt {
     type Output = BigInt;
 
     #[inline]
     fn shr(self, rhs: usize) -> BigInt {
-        BigInt::from_biguint(self.sign, self.data >> rhs)
+        let round_down = shr_round_down(&self, rhs);
+        let data = self.data >> rhs;
+        BigInt::from_biguint(self.sign, if round_down { data + 1u8 } else { data })
     }
 }
 
@@ -242,7 +253,9 @@ impl<'a> Shr<usize> for &'a BigInt {
 
     #[inline]
     fn shr(self, rhs: usize) -> BigInt {
-        BigInt::from_biguint(self.sign, &self.data >> rhs)
+        let round_down = shr_round_down(&self, rhs);
+        let data = &self.data >> rhs;
+        BigInt::from_biguint(self.sign, if round_down { data + 1u8 } else { data })
     }
 }
 

--- a/src/tests/bigint.rs
+++ b/src/tests/bigint.rs
@@ -1192,3 +1192,28 @@ fn test_negative_rand_range() {
     // Switching u and l should fail:
     let _n: BigInt = rng.gen_bigint_range(&u, &l);
 }
+
+#[test]
+fn test_negative_shr() {
+    assert_eq!(BigInt::from(-1) >> 1, BigInt::from(-1));
+    assert_eq!(BigInt::from(-2) >> 1, BigInt::from(-1));
+    assert_eq!(BigInt::from(-3) >> 1, BigInt::from(-2));
+    assert_eq!(BigInt::from(-3) >> 2, BigInt::from(-1));
+}
+
+#[test]
+fn test_random_shr() {
+    use rand::Rng;
+    let mut rng = thread_rng();
+
+    for p in rng.gen_iter::<i64>().take(1000) {
+        let big = BigInt::from(p);
+        let bigger = &big << 1000;
+        assert_eq!(&bigger >> 1000, big);
+        for i in 0..64 {
+            let answer = BigInt::from(p >> i);
+            assert_eq!(&big >> i, answer);
+            assert_eq!(&bigger >> (1000 + i), answer);
+        }
+    }
+}


### PR DESCRIPTION
Primitive integers always round down when shifting right, but `BigInt`
was effectively rounding toward zero, because it just kept its sign and
used the `BigUint` magnitude rounded down (always toward zero).

Now we adjust the result of shifting negative values, and explicitly
test that it matches the result for primitive integers.

Fixes #1.