### PR TITLE
Add to_slice and to_vec functions

### DIFF
--- a/src/bigint.rs
+++ b/src/bigint.rs
@@ -1540,6 +1540,42 @@ impl BigInt {
         BigUint::from_radix_le(buf, radix).map(|u| BigInt::from_biguint(sign, u))
     }
 
+    /// Returns the representation of the `BigInt` in little-endian base 2<sup>32</sup>.
+    ///
+    /// # Examples
+    ///
+    ///
+    /// ```
+    /// use num_bigint::{Sign, BigInt, BigDigit};
+    ///
+    /// let sign = Sign::Plus;
+    /// let slice: &[BigDigit] = &[1, 2, 3, 4];
+    /// let i = BigInt::from_slice(sign, slice);
+    /// assert_eq!(i.to_slice(), (sign, slice));
+    /// ```
+    #[inline]
+    pub fn to_slice(&self) -> (Sign, &[BigDigit]) {
+        (self.sign, self.data.to_slice())
+    }
+
+    /// Returns the representation of the `BigInt` in little-endian base 2<sup>32</sup>.
+    ///
+    /// # Examples
+    ///
+    ///
+    /// ```
+    /// use num_bigint::{Sign, BigInt};
+    ///
+    /// let sign = Sign::Plus;
+    /// let vec = vec![1, 2, 3, 4];
+    /// let i = BigInt::from_slice(sign, &vec);
+    /// assert_eq!(i.to_vec(), (sign, vec));
+    /// ```
+    #[inline]
+    pub fn to_vec(self) -> (Sign, Vec<BigDigit>) {
+        (self.sign, self.data.to_vec())
+    }
+
     /// Returns the sign and the byte representation of the `BigInt` in big-endian byte order.
     ///
     /// # Examples

--- a/src/biguint.rs
+++ b/src/biguint.rs
@@ -1539,6 +1539,40 @@ impl BigUint {
         }
     }
 
+    /// Returns the representation of the `BigUint` in little-endian base 2<sup>32</sup>.
+    ///
+    /// # Examples
+    ///
+    ///
+    /// ```
+    /// use num_bigint::BigUint;
+    ///
+    /// let slice = &[1, 2, 3, 4];
+    /// let i = BigUint::from_slice(slice);
+    /// assert_eq!(i.to_slice(), slice);
+    /// ```
+    #[inline]
+    pub fn to_slice(&self) -> &[BigDigit] {
+        &self.data
+    }
+
+    /// Returns the representation of the `BigUint` in little-endian base 2<sup>32</sup>.
+    ///
+    /// # Examples
+    ///
+    ///
+    /// ```
+    /// use num_bigint::BigUint;
+    ///
+    /// let slice = &[1, 2, 3, 4];
+    /// let i = BigUint::from_slice(slice);
+    /// assert_eq!(i.to_vec(), slice);
+    /// ```
+    #[inline]
+    pub fn to_vec(self) -> Vec<BigDigit> {
+        self.data
+    }
+
     /// Returns the integer formatted as a string in the given radix.
     /// `radix` must be in the range `2...36`.
     ///


### PR DESCRIPTION
I needed to convert to/from mpz_t. While converting into is relativly simple due to `from_slice` function the invert requires allocation of array with base 2<sup>8</sup> making it less efficient (requiring 2 copies and 2 convertions from/to 8 bit instead of 1 or 0).

Those functions would allow inspecting representation of function without need of allocating and creating additional copies.