### PR TITLE
Add apint to README as another alternative

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,9 +42,11 @@ table offers a brief comparison to a few alternatives.
 | [`ramp`]         | Apache-2.0     | nightly   | rust and inline assembly |
 | [`rug`]          | LGPL-3.0+      | 1.18      | bundles [GMP] via [`gmp-mpfr-sys`] |
 | [`rust-gmp`]     | MIT            | stable?   | links to [GMP] |
+| [`apint`]        | MIT/Apache-2.0 | nightly   | pure rust (unfinished) |
 
 [GMP]: https://gmplib.org/
 [`gmp-mpfr-sys`]: https://crates.io/crates/gmp-mpfr-sys
 [`rug`]: https://crates.io/crates/rug
 [`rust-gmp`]: https://crates.io/crates/rust-gmp
 [`ramp`]: https://crates.io/crates/ramp
+[`apint`]: https://crates.io/crates/apint


### PR DESCRIPTION
The ApInt crate is a pure rust implementation for arbitrary fixed bitwidth modulo arithmetics of integers with a focus on correctness and efficiency - especially for smaller bit widths. It features a generic signless `ApInt` as well as signed counterparts `Int` (signed int) and `UInt` (unsigned int) that are thin wrappers around it. The implementation is unfinished in some parts but that should be fixed over time.

Link to crate at crates.io: https://crates.io/crates/apint
Link to repo at GitHub: https://github.com/robbepop/apint