### PR TITLE
Implementation of std::iter::{Product, Sum}

### DIFF
--- a/src/bigint.rs
+++ b/src/bigint.rs
@@ -6,6 +6,7 @@ use std::cmp::Ordering::{self, Less, Greater, Equal};
 use std::{i64, u64};
 #[allow(unused_imports)]
 use std::ascii::AsciiExt;
+use std::iter::{Product, Sum};
 
 #[cfg(feature = "serde")]
 use serde;
@@ -1778,6 +1779,9 @@ impl BigInt {
         BigInt::from_biguint(sign, mag)
     }
 }
+
+impl_sum_iter_type!(BigInt);
+impl_product_iter_type!(BigInt);
 
 /// Perform in-place two's complement of the given binary representation,
 /// in little-endian byte order.

--- a/src/biguint.rs
+++ b/src/biguint.rs
@@ -1,6 +1,6 @@
 use std::borrow::Cow;
 use std::default::Default;
-use std::iter::repeat;
+use std::iter::{repeat, Product, Sum};
 use std::ops::{Add, BitAnd, BitOr, BitXor, Div, Mul, Neg, Rem, Shl, Shr, Sub,
                AddAssign, BitAndAssign, BitOrAssign, BitXorAssign, DivAssign,
                MulAssign, RemAssign, ShlAssign, ShrAssign, SubAssign};
@@ -1689,6 +1689,9 @@ pub fn trailing_zeros(u: &BigUint) -> Option<usize> {
         .find(|&(_, &digit)| digit != 0)
         .map(|(i, digit)| i * big_digit::BITS + digit.trailing_zeros() as usize)
 }
+
+impl_sum_iter_type!(BigUint);
+impl_product_iter_type!(BigUint);
 
 #[cfg(feature = "serde")]
 impl serde::Serialize for BigUint {

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -314,3 +314,45 @@ macro_rules! promote_all_scalars {
         promote_signed_scalars!(impl $imp for $res, $method);
     }
 }
+
+macro_rules! impl_sum_iter_type {
+    ($res:ty) => {
+        impl Sum for $res {
+            impl_sum_iter_type!($res, $res);
+        }
+
+        impl<'a> Sum<&'a $res> for $res {
+            impl_sum_iter_type!($res, &'a $res);
+        }
+    };
+
+    ($res:ty, $item:ty) => {
+        fn sum<I>(iter: I) -> Self
+        where
+            I: Iterator<Item = $item>
+        {
+            iter.fold(Zero::zero(), <$res>::add)
+        }
+    };
+}
+
+macro_rules! impl_product_iter_type {
+    ($res:ty) => {
+        impl Product for $res {
+            impl_product_iter_type!($res, $res);
+        }
+
+        impl<'a> Product<&'a $res> for $res {
+            impl_product_iter_type!($res, &'a $res);
+        }
+    };
+
+    ($res:ty, $item:ty) => {
+        fn product<I>(iter: I) -> Self
+        where
+            I: Iterator<Item = $item>
+        {
+            iter.fold(One::one(), <$res>::mul)
+        }
+    };
+}

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -319,7 +319,7 @@ macro_rules! impl_sum_iter_type {
     ($res:ty) => {
         impl<T> Sum<T> for $res
         where
-            $res: Add<T, Output=Self>
+            $res: Add<T, Output=$res>
         {
             fn sum<I>(iter: I) -> Self
             where
@@ -335,7 +335,7 @@ macro_rules! impl_product_iter_type {
     ($res:ty) => {
         impl<T> Product<T> for $res
         where
-            $res: Mul<T, Output=Self>
+            $res: Mul<T, Output=$res>
         {
             fn product<I>(iter: I) -> Self
             where

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -317,42 +317,32 @@ macro_rules! promote_all_scalars {
 
 macro_rules! impl_sum_iter_type {
     ($res:ty) => {
-        impl Sum for $res {
-            impl_sum_iter_type!($res, $res);
-        }
-
-        impl<'a> Sum<&'a $res> for $res {
-            impl_sum_iter_type!($res, &'a $res);
-        }
-    };
-
-    ($res:ty, $item:ty) => {
-        fn sum<I>(iter: I) -> Self
+        impl<T> Sum<T> for $res
         where
-            I: Iterator<Item = $item>
+            $res: Add<T, Output=Self>
         {
-            iter.fold(Zero::zero(), <$res>::add)
+            fn sum<I>(iter: I) -> Self
+            where
+                I: Iterator<Item = T>
+            {
+                iter.fold(Zero::zero(), <$res>::add)
+            }
         }
     };
 }
 
 macro_rules! impl_product_iter_type {
     ($res:ty) => {
-        impl Product for $res {
-            impl_product_iter_type!($res, $res);
-        }
-
-        impl<'a> Product<&'a $res> for $res {
-            impl_product_iter_type!($res, &'a $res);
-        }
-    };
-
-    ($res:ty, $item:ty) => {
-        fn product<I>(iter: I) -> Self
+        impl<T> Product<T> for $res
         where
-            I: Iterator<Item = $item>
+            $res: Mul<T, Output=Self>
         {
-            iter.fold(One::one(), <$res>::mul)
+            fn product<I>(iter: I) -> Self
+            where
+                I: Iterator<Item = T>
+            {
+                iter.fold(One::one(), <$res>::mul)
+            }
         }
     };
 }

--- a/src/tests/bigint.rs
+++ b/src/tests/bigint.rs
@@ -1217,3 +1217,35 @@ fn test_random_shr() {
         }
     }
 }
+#[test]
+fn test_iter_sum() {
+    let result: BigInt = FromPrimitive::from_isize(-1234567).unwrap();
+    let data: Vec<BigInt> = vec![
+        FromPrimitive::from_i32(-1000000).unwrap(),
+        FromPrimitive::from_i32(-200000).unwrap(),
+        FromPrimitive::from_i32(-30000).unwrap(),
+        FromPrimitive::from_i32(-4000).unwrap(),
+        FromPrimitive::from_i32(-500).unwrap(),
+        FromPrimitive::from_i32(-60).unwrap(),
+        FromPrimitive::from_i32(-7).unwrap(),
+    ];
+
+    assert_eq!(result, data.iter().sum());
+    assert_eq!(result, data.into_iter().sum());
+}
+
+#[test]
+fn test_iter_product() {
+    let data: Vec<BigInt> = vec![
+        FromPrimitive::from_i32(1001).unwrap(),
+        FromPrimitive::from_i32(-1002).unwrap(),
+        FromPrimitive::from_i32(1003).unwrap(),
+        FromPrimitive::from_i32(-1004).unwrap(),
+        FromPrimitive::from_i32(1005).unwrap(),
+    ];
+    let result = data.get(0).unwrap() * data.get(1).unwrap() * data.get(2).unwrap()
+        * data.get(3).unwrap() * data.get(4).unwrap();
+
+    assert_eq!(result, data.iter().product());
+    assert_eq!(result, data.into_iter().product());
+}

--- a/src/tests/bigint.rs
+++ b/src/tests/bigint.rs
@@ -1249,3 +1249,23 @@ fn test_iter_product() {
     assert_eq!(result, data.iter().product());
     assert_eq!(result, data.into_iter().product());
 }
+
+#[test]
+fn test_iter_sum_generic() {
+    let result: BigInt = FromPrimitive::from_isize(-1234567).unwrap();
+    let data = vec![-1000000, -200000, -30000, -4000, -500, -60, -7];
+
+    assert_eq!(result, data.iter().sum());
+    assert_eq!(result, data.into_iter().sum());
+}
+
+#[test]
+fn test_iter_product_generic() {
+    let data = vec![1001, -1002, 1003, -1004, 1005];
+    let result = data[0].to_bigint().unwrap() * data[1].to_bigint().unwrap()
+        * data[2].to_bigint().unwrap() * data[3].to_bigint().unwrap()
+        * data[4].to_bigint().unwrap();
+
+    assert_eq!(result, data.iter().product());
+    assert_eq!(result, data.into_iter().product());
+}

--- a/src/tests/biguint.rs
+++ b/src/tests/biguint.rs
@@ -1709,3 +1709,23 @@ fn test_iter_product() {
     assert_eq!(result, data.iter().product());
     assert_eq!(result, data.into_iter().product());
 }
+
+#[test]
+fn test_iter_sum_generic() {
+    let result: BigUint = FromPrimitive::from_isize(1234567).unwrap();
+    let data = vec![1000000_u32, 200000, 30000, 4000, 500, 60, 7];
+
+    assert_eq!(result, data.iter().sum());
+    assert_eq!(result, data.into_iter().sum());
+}
+
+#[test]
+fn test_iter_product_generic() {
+    let data = vec![1001_u32, 1002, 1003, 1004, 1005];
+    let result = data[0].to_biguint().unwrap() * data[1].to_biguint().unwrap()
+        * data[2].to_biguint().unwrap() * data[3].to_biguint().unwrap()
+        * data[4].to_biguint().unwrap();
+
+    assert_eq!(result, data.iter().product());
+    assert_eq!(result, data.into_iter().product());
+}

--- a/src/tests/biguint.rs
+++ b/src/tests/biguint.rs
@@ -1676,3 +1676,36 @@ fn test_mul_divide_torture() {
 fn test_mul_divide_torture_long() {
     test_mul_divide_torture_count(1000000);
 }
+
+#[test]
+fn test_iter_sum() {
+    let result: BigUint = FromPrimitive::from_isize(1234567).unwrap();
+    let data: Vec<BigUint> = vec![
+        FromPrimitive::from_u32(1000000).unwrap(),
+        FromPrimitive::from_u32(200000).unwrap(),
+        FromPrimitive::from_u32(30000).unwrap(),
+        FromPrimitive::from_u32(4000).unwrap(),
+        FromPrimitive::from_u32(500).unwrap(),
+        FromPrimitive::from_u32(60).unwrap(),
+        FromPrimitive::from_u32(7).unwrap(),
+    ];
+
+    assert_eq!(result, data.iter().sum());
+    assert_eq!(result, data.into_iter().sum());
+}
+
+#[test]
+fn test_iter_product() {
+    let data: Vec<BigUint> = vec![
+        FromPrimitive::from_u32(1001).unwrap(),
+        FromPrimitive::from_u32(1002).unwrap(),
+        FromPrimitive::from_u32(1003).unwrap(),
+        FromPrimitive::from_u32(1004).unwrap(),
+        FromPrimitive::from_u32(1005).unwrap(),
+    ];
+    let result = data.get(0).unwrap() * data.get(1).unwrap() * data.get(2).unwrap()
+        * data.get(3).unwrap() * data.get(4).unwrap();
+
+    assert_eq!(result, data.iter().product());
+    assert_eq!(result, data.into_iter().product());
+}


### PR DESCRIPTION
This PR is relative to the [issue 4](https://github.com/rust-num/num-bigint/issues/4). This is a
very simple implementation, based on two macros. Maybe a more elegant
solution is possible for these, feel free to suggest.

Two tests for both `BigInt` and `BigUInt` have been added, one relative
to the `Sum`, the other to the `Product`.