### PR TITLE
Implement is_one for BigUint and BigInt.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ version = "0.1.36"
 default-features = false
 
 [dependencies.num-traits]
-version = "0.2.0"
+version = "0.2.1"
 default-features = false
 features = ["std"]
 

--- a/src/bigint.rs
+++ b/src/bigint.rs
@@ -274,6 +274,11 @@ impl One for BigInt {
     fn one() -> BigInt {
         BigInt::from_biguint(Plus, One::one())
     }
+
+    #[inline]
+    fn is_one(&self) -> bool {
+        self.sign == Plus && self.data.is_one()
+    }
 }
 
 impl Signed for BigInt {

--- a/src/biguint.rs
+++ b/src/biguint.rs
@@ -415,6 +415,11 @@ impl One for BigUint {
     fn one() -> BigUint {
         BigUint::new(vec![1])
     }
+
+    #[inline]
+    fn is_one(&self) -> bool {
+        self.data[..] == [1]
+    }
 }
 
 impl Unsigned for BigUint {}


### PR DESCRIPTION
Won't work until a newer version of `num-traits` is pushed, but I figured I'd offer these now.