### PR TITLE
reduce copying when forwarding ref-ref to val-ref

### DIFF
--- a/src/bigint.rs
+++ b/src/bigint.rs
@@ -27,7 +27,7 @@ use super::ParseBigIntError;
 use super::big_digit::{BigDigit, DoubleBigDigit};
 use biguint;
 use biguint::to_str_radix_reversed;
-use biguint::BigUint;
+use biguint::{BigUint, CloneWithCapacity};
 
 use UsizePromotion;
 use IsizePromotion;
@@ -64,6 +64,21 @@ impl Mul<Sign> for Sign {
             (Plus, Plus) | (Minus, Minus) => Plus,
             (Plus, Minus) | (Minus, Plus) => Minus,
         }
+    }
+}
+
+impl CloneWithCapacity for BigInt {
+    #[inline]
+    fn capacity(&self) -> usize {
+        self.data.capacity()
+    }
+    #[inline]
+    fn len(&self) -> usize {
+        self.data.len()
+    }
+    #[inline]
+    fn clone_with_capacity(&self, capacity: usize) -> BigInt {
+        BigInt::from_biguint(self.sign, self.data.clone_with_capacity(capacity))
     }
 }
 

--- a/src/biguint.rs
+++ b/src/biguint.rs
@@ -1689,6 +1689,29 @@ pub fn trailing_zeros(u: &BigUint) -> Option<usize> {
 impl_sum_iter_type!(BigUint);
 impl_product_iter_type!(BigUint);
 
+pub trait CloneWithCapacity {
+    fn capacity(&self) -> usize;
+    fn len(&self) -> usize;
+    fn clone_with_capacity(&self, capacity: usize) -> Self;
+}
+
+impl CloneWithCapacity for BigUint {
+    #[inline]
+    fn capacity(&self) -> usize {
+        self.data.capacity()
+    }
+    #[inline]
+    fn len(&self) -> usize {
+        self.data.len()
+    }
+    #[inline]
+    fn clone_with_capacity(&self, capacity: usize) -> BigUint {
+        let mut data = Vec::with_capacity(capacity);
+        data.extend(&self.data);
+        BigUint::new(data)
+    }
+}
+
 #[cfg(feature = "serde")]
 impl serde::Serialize for BigUint {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -23,7 +23,7 @@ macro_rules! forward_val_val_binop_commutative {
             #[inline]
             fn $method(self, other: $res) -> $res {
                 // forward to val-ref, with the larger capacity as val
-                if self.data.capacity() >= other.data.capacity() {
+                if self.capacity() >= other.capacity() {
                     $imp::$method(self, &other)
                 } else {
                     $imp::$method(other, &self)
@@ -96,11 +96,12 @@ macro_rules! forward_ref_ref_binop_commutative {
 
             #[inline]
             fn $method(self, other: &$res) -> $res {
-                // forward to val-ref, choosing the larger to clone
-                if self.data.len() >= other.data.len() {
-                    $imp::$method(self.clone(), other)
+                // forward to val-ref, cloning the smaller to reduce copying,
+                // but using larger's capacity to avoid reallocations
+                if self.len() >= other.len() {
+                    $imp::$method(other.clone_with_capacity(self.len()), self)
                 } else {
-                    $imp::$method(other.clone(), self)
+                    $imp::$method(self.clone_with_capacity(other.len()), other)
                 }
             }
         }


### PR DESCRIPTION
When ref-ref is forwarded to val-ref, currently the larger of the operands is cloned. This is good in one way as the target has the required capacity and will not need reallocation. However, it involves more copying before the actual operation starts.

With this commit, the clone will have the capacity of the larger operand, but only the data for the smaller operand is copied, saving some copying if the operand sizes are very different.

For addition I don't think this commit would result in much gain, because once the smaller operand is used up, the addition stops, so the copying is actually used. The commit shouldn't be a loss either, and maybe it could give a small gain for very large sizes, as the lower digits could maybe still be in the cache for the addition before moving on to copying the higher digits.

For some bitwise operations this could give a much larger gain. For example when performing a bitwise and of a large number with a small number, the higher digits would be copied uselessly without this commit.