### PR TITLE
Implement assignment operators for BigInt

### DIFF
--- a/src/biguint.rs
+++ b/src/biguint.rs
@@ -378,7 +378,8 @@ impl<'a> Shl<usize> for &'a BigUint {
 impl ShlAssign<usize> for BigUint {
     #[inline]
     fn shl_assign(&mut self, rhs: usize) {
-        *self = biguint_shl(Cow::Borrowed(&*self), rhs);
+        let n = mem::replace(self, BigUint::zero());
+        *self = n << rhs;
     }
 }
 

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -266,6 +266,13 @@ macro_rules! promote_signed_scalars {
     }
 }
 
+macro_rules! promote_signed_scalars_assign {
+    (impl $imp:ident for $res:ty, $method:ident) => {
+        promote_scalars_assign!(impl $imp<i32> for $res, $method, i8, i16);
+        promote_scalars_assign!(impl $imp<UsizePromotion> for $res, $method, isize);
+    }
+}
+
 // Forward everything to ref-ref, when reusing storage is not helpful
 macro_rules! forward_all_binop_to_ref_ref {
     (impl $imp:ident for $res:ty, $method:ident) => {
@@ -312,6 +319,13 @@ macro_rules! promote_all_scalars {
     (impl $imp:ident for $res:ty, $method:ident) => {
         promote_unsigned_scalars!(impl $imp for $res, $method);
         promote_signed_scalars!(impl $imp for $res, $method);
+    }
+}
+
+macro_rules! promote_all_scalars_assign {
+    (impl $imp:ident for $res:ty, $method:ident) => {
+        promote_unsigned_scalars_assign!(impl $imp for $res, $method);
+        promote_signed_scalars_assign!(impl $imp for $res, $method);
     }
 }
 

--- a/tests/bigint.rs
+++ b/tests/bigint.rs
@@ -522,6 +522,15 @@ fn test_add() {
         assert_op!(b + nc == na);
         assert_op!(na + nb == nc);
         assert_op!(a + na == Zero::zero());
+
+        assert_assign_op!(a += b == c);
+        assert_assign_op!(b += a == c);
+        assert_assign_op!(c += na == b);
+        assert_assign_op!(c += nb == a);
+        assert_assign_op!(a += nc == nb);
+        assert_assign_op!(b += nc == na);
+        assert_assign_op!(na += nb == nc);
+        assert_assign_op!(a += na == Zero::zero());
     }
 }
 
@@ -542,6 +551,15 @@ fn test_sub() {
         assert_op!(a - nb == c);
         assert_op!(nc - na == nb);
         assert_op!(a - a == Zero::zero());
+
+        assert_assign_op!(c -= a == b);
+        assert_assign_op!(c -= b == a);
+        assert_assign_op!(nb -= a == nc);
+        assert_assign_op!(na -= b == nc);
+        assert_assign_op!(b -= na == c);
+        assert_assign_op!(a -= nb == c);
+        assert_assign_op!(nc -= na == nb);
+        assert_assign_op!(a -= a == Zero::zero());
     }
 }
 
@@ -560,6 +578,13 @@ fn test_mul() {
 
         assert_op!(na * b == nc);
         assert_op!(nb * a == nc);
+
+        assert_assign_op!(a *= b == c);
+        assert_assign_op!(b *= a == c);
+        assert_assign_op!(na *= nb == c);
+
+        assert_assign_op!(na *= b == nc);
+        assert_assign_op!(nb *= a == nc);
     }
 
     for elm in DIV_REM_QUADRUPLES.iter() {
@@ -645,6 +670,8 @@ fn test_div_rem() {
         let (a, b, ans_q, ans_r) = (a.clone(), b.clone(), ans_q.clone(), ans_r.clone());
         assert_op!(a / b == ans_q);
         assert_op!(a % b == ans_r);
+        assert_assign_op!(a /= b == ans_q);
+        assert_assign_op!(a %= b == ans_r);
     }
 
     fn check(a: &BigInt, b: &BigInt, q: &BigInt, r: &BigInt) {


### PR DESCRIPTION
All of these operators were already implemented for `BigUint`, so
now `BigInt` support the same use.

Closes #7.