### PR TITLE
Add a special case for single-digit divisors

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,9 @@ readme = "README.md"
 name = "bigint"
 
 [[bench]]
+name = "factorial"
+
+[[bench]]
 name = "gcd"
 
 [[bench]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ categories = [ "algorithms", "data-structures", "science" ]
 license = "MIT/Apache-2.0"
 name = "num-bigint"
 repository = "https://github.com/rust-num/num-bigint"
-version = "0.1.43"
+version = "0.1.44"
 readme = "README.md"
 
 [[bench]]

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,3 +1,11 @@
+# Release 0.1.44
+
+- [Division with single-digit divisors is now much faster.][42]
+
+**Contributors**: @cuviper
+
+[42]: https://github.com/rust-num/num-bigint/pull/42
+
 # Release 0.1.43
 
 - [The new `BigInt::modpow`][18] performs signed modular exponentiation, using

--- a/benches/factorial.rs
+++ b/benches/factorial.rs
@@ -1,0 +1,35 @@
+#![feature(test)]
+
+extern crate num_bigint;
+extern crate num_traits;
+extern crate test;
+
+use num_bigint::BigUint;
+use num_traits::One;
+use std::ops::{Div, Mul};
+use test::Bencher;
+
+#[bench]
+fn factorial_mul_biguint(b: &mut Bencher) {
+    b.iter(|| (1u32..1000).map(BigUint::from).fold(BigUint::one(), Mul::mul));
+}
+
+#[bench]
+fn factorial_mul_u32(b: &mut Bencher) {
+    b.iter(|| (1u32..1000).fold(BigUint::one(), Mul::mul));
+}
+
+// The division test is inspired by this blog comparison:
+// <https://tiehuis.github.io/big-integers-in-zig#division-test-single-limb>
+
+#[bench]
+fn factorial_div_biguint(b: &mut Bencher) {
+    let n: BigUint = (1u32..1000).fold(BigUint::one(), Mul::mul);
+    b.iter(|| (1u32..1000).rev().map(BigUint::from).fold(n.clone(), Div::div));
+}
+
+#[bench]
+fn factorial_div_u32(b: &mut Bencher) {
+    let n: BigUint = (1u32..1000).fold(BigUint::one(), Mul::mul);
+    b.iter(|| (1u32..1000).rev().fold(n.clone(), Div::div));
+}

--- a/src/algorithms.rs
+++ b/src/algorithms.rs
@@ -456,8 +456,12 @@ pub fn div_rem(u: &BigUint, d: &BigUint) -> (BigUint, BigUint) {
     if u.is_zero() {
         return (Zero::zero(), Zero::zero());
     }
-    if *d == One::one() {
+    if d.data == [1] {
         return (u.clone(), Zero::zero());
+    }
+    if d.data.len() == 1 {
+        let (div, rem) = div_rem_digit(u.clone(), d.data[0]);
+        return (div, rem.into());
     }
 
     // Required or the q_len calculation below can underflow:


### PR DESCRIPTION
It was pointed out in the blog post [Big Integers in Zig] that we don't
have a special case in `num-bigint` for single-digit divisors.  While
you can already get this optimization by dividing directly by `u32`,
it's easy to make small `BigUint` divisors work like this too.

    $ cargo benchcmp baseline single-div
     name                   baseline ns/iter  single-div ns/iter  diff ns/iter   diff %  speedup
     factorial_div_biguint  5,638,353         1,005,488             -4,632,865  -82.17%   x 5.61

`BigInt` will also gain from this, since it uses `BigUint` division
internally.

Running [zig-bn's facdiv-rs] shows a nice improvement too.  My i7-7700K
with Rust 1.26 goes from 4.15 seconds to just 0.65 -- a 6.38x speedup!

[Big Integers in Zig]: https://tiehuis.github.io/big-integers-in-zig#division-test-single-limb
[zig-bn's facdiv-rs]: https://github.com/tiehuis/zig-bn/tree/master/bench/facdiv/crate-facdiv-rs
