### PR TITLE
Add a mandatory "std" feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,22 +35,25 @@ default-features = false
 [dependencies.num-traits]
 version = "0.2.4"
 default-features = false
-features = ["std"]
 
 [dependencies.rand]
 optional = true
 version = "0.4"
+default-features = false
 
 [dependencies.serde]
 optional = true
 version = "1.0"
+default-features = false
+features = ["std"]
 
-[dev-dependencies]
-serde_test = "1.0"
+[dev-dependencies.serde_test]
+version = "1.0"
 
 [dev-dependencies.rand]
 version = "0.4"
 
 [features]
-default = []
+default = ["std"]
 i128 = ["num-integer/i128", "num-traits/i128"]
+std = ["num-integer/std", "num-traits/std"]

--- a/README.md
+++ b/README.md
@@ -24,6 +24,11 @@ extern crate num_bigint;
 
 ## Features
 
+The `std` crate feature is mandatory and enabled by default.  If you depend on
+`num-bigint` with `default-features = false`, you must manually enable the
+`std` feature yourself.  In the future, we hope to support `#![no_std]` with
+the `alloc` crate when `std` is not enabled.
+
 Implementations for `i128` and `u128` are only available with Rust 1.26 and
 later.  The build script automatically detects this, but you can make it
 mandatory by enabling the `i128` crate feature.

--- a/ci/test_full.sh
+++ b/ci/test_full.sh
@@ -4,29 +4,25 @@ set -ex
 
 echo Testing num-bigint on rustc ${TRAVIS_RUST_VERSION}
 
+FEATURES="rand serde"
+if [[ "$TRAVIS_RUST_VERSION" =~ ^(nightly|beta|stable)$ ]]; then
+  FEATURES="$FEATURES i128"
+fi
+
 # num-bigint should build and test everywhere.
 cargo build --verbose
 cargo test --verbose
 
 # It should build with minimal features too.
-cargo build --no-default-features
-cargo test --no-default-features
+cargo build --no-default-features --features="std"
+cargo test --no-default-features --features="std"
 
 # Each isolated feature should also work everywhere.
-for feature in rand serde; do
-  cargo build --verbose --no-default-features --features="$feature"
-  cargo test --verbose --no-default-features --features="$feature"
+for feature in $FEATURES; do
+  cargo build --verbose --no-default-features --features="std $feature"
+  cargo test --verbose --no-default-features --features="std $feature"
 done
 
-# test `i128` and all features together
-if [[ "$TRAVIS_RUST_VERSION" =~ ^(nightly|beta|stable)$ ]]; then
-  cargo build --verbose --features=i128
-  cargo test --verbose --features=i128
-
-  cargo build --all-features
-  cargo test --all-features
-else
-  # all except `i128`
-  cargo build --features="rand serde"
-  cargo test --features="rand serde"
-fi
+# test all supported features together
+cargo build --features="std $FEATURES"
+cargo test --features="std $FEATURES"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,12 +74,14 @@
 //!
 //! The `num-bigint` crate is tested for rustc 1.15 and greater.
 
-#![doc(html_root_url = "https://docs.rs/num-bigint/0.1")]
+#![doc(html_root_url = "https://docs.rs/num-bigint/0.2")]
+
+// We don't actually support `no_std` yet, and probably won't until `alloc` is stable.  We're just
+// reserving this ability with the "std" feature now, and compilation will fail without.
+#![cfg_attr(not(feature = "std"), no_std)]
 
 #[cfg(any(feature = "rand", test))]
 extern crate rand;
-#[cfg(feature = "rustc-serialize")]
-extern crate rustc_serialize;
 #[cfg(feature = "serde")]
 extern crate serde;
 


### PR DESCRIPTION
We don't actually support `no_std` yet, and probably won't until `alloc`
is stable.  We're just reserving this ability with the "std" feature
now, and compilation will fail without.