### PR TITLE
Update to rand 0.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: rust
 rust:
   - 1.15.0
-  - 1.20.0
-  - 1.25.0
+  - 1.22.0
+  - 1.26.0
   - stable
   - beta
   - nightly

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,9 @@ publish = false
 readme = "README.md"
 build = "build.rs"
 
+[package.metadata.docs.rs]
+features = ["std", "serde", "rand"]
+
 [[bench]]
 name = "bigint"
 
@@ -40,6 +43,7 @@ default-features = false
 optional = true
 version = "0.5"
 default-features = false
+features = ["std"]
 
 [dependencies.serde]
 optional = true
@@ -49,9 +53,6 @@ features = ["std"]
 
 [dev-dependencies.serde_test]
 version = "1.0"
-
-[dev-dependencies.rand]
-version = "0.5"
 
 [features]
 default = ["std"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ default-features = false
 
 [dependencies.rand]
 optional = true
-version = "0.4"
+version = "0.5"
 default-features = false
 
 [dependencies.serde]
@@ -51,7 +51,7 @@ features = ["std"]
 version = "1.0"
 
 [dev-dependencies.rand]
-version = "0.4"
+version = "0.5"
 
 [features]
 default = ["std"]

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -11,6 +11,7 @@
 - [`BigInt` now supports assignment operators][41] like `AddAssign`.
 - [`BigInt` and `BigUint` now support conversions with `i128` and `u128`][44],
   if sufficient compiler support is detected.
+- [`BigInt` and `BigUint` now implement rand's `SampleUniform` trait][48].
 - The release also includes other miscellaneous improvements to performance.
 
 ### Breaking Changes
@@ -18,9 +19,10 @@
 - [`num-bigint` now requires rustc 1.15 or greater][23].
 - [The crate now has a `std` feature, and won't build without it][46].  This is
   in preparation for someday supporting `#![no_std]` with `alloc`.
-- [The `rand` and `serde` dependencies have been updated to 0.4 and 1.0][24]
-  respectively, and neither are enabled by default.  The `rustc-serialize` crate
-  is no longer supported by `num-bigint`.
+- [The `serde` dependency has been updated to 1.0][24], still disabled by
+  default.  The `rustc-serialize` crate is no longer supported by `num-bigint`.
+- [The `rand` dependency has been updated to 0.5][48], now disabled by default.
+  This requires rustc 1.22 or greater for `rand`'s own requirement.
 - [`Shr for BigInt` now rounds down][8] rather than toward zero, matching the
   behavior of the primitive integers for negative values.
 - [`ParseBigIntError` is now an opaque type][37].
@@ -41,6 +43,7 @@
 [41]: https://github.com/rust-num/num-bigint/pull/41
 [44]: https://github.com/rust-num/num-bigint/pull/44
 [46]: https://github.com/rust-num/num-bigint/pull/46
+[48]: https://github.com/rust-num/num-bigint/pull/48
 
 # Release 0.1.44
 

--- a/ci/rustup.sh
+++ b/ci/rustup.sh
@@ -1,11 +1,11 @@
 #!/bin/sh
 # Use rustup to locally run the same suite of tests as .travis.yml.
-# (You should first install/update 1.15.0, stable, beta, and nightly.)
+# (You should first install/update all versions listed below.)
 
 set -ex
 
 export TRAVIS_RUST_VERSION
-for TRAVIS_RUST_VERSION in 1.15.0 1.20.0 1.25.0 stable beta nightly; do
+for TRAVIS_RUST_VERSION in 1.15.0 1.22.0 1.26.0 stable beta nightly; do
     run="rustup run $TRAVIS_RUST_VERSION"
     $run cargo build --verbose
     $run $PWD/ci/test_full.sh

--- a/ci/test_full.sh
+++ b/ci/test_full.sh
@@ -4,8 +4,11 @@ set -ex
 
 echo Testing num-bigint on rustc ${TRAVIS_RUST_VERSION}
 
-FEATURES="rand serde"
-if [[ "$TRAVIS_RUST_VERSION" =~ ^(nightly|beta|stable)$ ]]; then
+FEATURES="serde"
+if [[ "$TRAVIS_RUST_VERSION" =~ ^(nightly|beta|stable|1.26.0|1.22.0)$ ]]; then
+  FEATURES="$FEATURES rand"
+fi
+if [[ "$TRAVIS_RUST_VERSION" =~ ^(nightly|beta|stable|1.26.0)$ ]]; then
   FEATURES="$FEATURES i128"
 fi
 

--- a/src/bigint.rs
+++ b/src/bigint.rs
@@ -109,6 +109,14 @@ pub struct BigInt {
     data: BigUint,
 }
 
+/// Return the magnitude of a `BigInt`.
+///
+/// This is in a private module, pseudo pub(crate)
+#[cfg(feature = "rand")]
+pub fn magnitude(i: &BigInt) -> &BigUint {
+    &i.data
+}
+
 impl PartialEq for BigInt {
     #[inline]
     fn eq(&self, other: &BigInt) -> bool {

--- a/src/bigint.rs
+++ b/src/bigint.rs
@@ -117,6 +117,14 @@ pub fn magnitude(i: &BigInt) -> &BigUint {
     &i.data
 }
 
+/// Return the owned magnitude of a `BigInt`.
+///
+/// This is in a private module, pseudo pub(crate)
+#[cfg(feature = "rand")]
+pub fn into_magnitude(i: BigInt) -> BigUint {
+    i.data
+}
+
 impl PartialEq for BigInt {
     #[inline]
     fn eq(&self, other: &BigInt) -> bool {

--- a/src/bigint.rs
+++ b/src/bigint.rs
@@ -16,12 +16,6 @@ use std::iter::{Product, Sum};
 #[cfg(feature = "serde")]
 use serde;
 
-// Some of the tests of non-RNG-based functionality are randomized using the
-// RNG-based functionality, so the RNG-based functionality needs to be enabled
-// for tests.
-#[cfg(any(feature = "rand", test))]
-use rand::Rng;
-
 use integer::Integer;
 use traits::{ToPrimitive, FromPrimitive, Num, CheckedAdd, CheckedSub,
              CheckedMul, CheckedDiv, Signed, Zero, One};
@@ -2129,89 +2123,6 @@ impl_to_bigint!(u128, FromPrimitive::from_u128);
 
 impl_to_bigint!(f32, FromPrimitive::from_f32);
 impl_to_bigint!(f64, FromPrimitive::from_f64);
-
-pub trait RandBigInt {
-    /// Generate a random `BigUint` of the given bit size.
-    fn gen_biguint(&mut self, bit_size: usize) -> BigUint;
-
-    /// Generate a random BigInt of the given bit size.
-    fn gen_bigint(&mut self, bit_size: usize) -> BigInt;
-
-    /// Generate a random `BigUint` less than the given bound. Fails
-    /// when the bound is zero.
-    fn gen_biguint_below(&mut self, bound: &BigUint) -> BigUint;
-
-    /// Generate a random `BigUint` within the given range. The lower
-    /// bound is inclusive; the upper bound is exclusive. Fails when
-    /// the upper bound is not greater than the lower bound.
-    fn gen_biguint_range(&mut self, lbound: &BigUint, ubound: &BigUint) -> BigUint;
-
-    /// Generate a random `BigInt` within the given range. The lower
-    /// bound is inclusive; the upper bound is exclusive. Fails when
-    /// the upper bound is not greater than the lower bound.
-    fn gen_bigint_range(&mut self, lbound: &BigInt, ubound: &BigInt) -> BigInt;
-}
-
-#[cfg(any(feature = "rand", test))]
-impl<R: Rng> RandBigInt for R {
-    fn gen_biguint(&mut self, bit_size: usize) -> BigUint {
-        use super::big_digit::BITS;
-        let (digits, rem) = bit_size.div_rem(&BITS);
-        let mut data = Vec::with_capacity(digits + 1);
-        for _ in 0..digits {
-            data.push(self.gen());
-        }
-        if rem > 0 {
-            let final_digit: BigDigit = self.gen();
-            data.push(final_digit >> (BITS - rem));
-        }
-        BigUint::new(data)
-    }
-
-    fn gen_bigint(&mut self, bit_size: usize) -> BigInt {
-        // Generate a random BigUint...
-        let biguint = self.gen_biguint(bit_size);
-        // ...and then randomly assign it a Sign...
-        let sign = if biguint.is_zero() {
-            // ...except that if the BigUint is zero, we need to try
-            // again with probability 0.5. This is because otherwise,
-            // the probability of generating a zero BigInt would be
-            // double that of any other number.
-            if self.gen() {
-                return self.gen_bigint(bit_size);
-            } else {
-                NoSign
-            }
-        } else if self.gen() {
-            Plus
-        } else {
-            Minus
-        };
-        BigInt::from_biguint(sign, biguint)
-    }
-
-    fn gen_biguint_below(&mut self, bound: &BigUint) -> BigUint {
-        assert!(!bound.is_zero());
-        let bits = bound.bits();
-        loop {
-            let n = self.gen_biguint(bits);
-            if n < *bound {
-                return n;
-            }
-        }
-    }
-
-    fn gen_biguint_range(&mut self, lbound: &BigUint, ubound: &BigUint) -> BigUint {
-        assert!(*lbound < *ubound);
-        return lbound + self.gen_biguint_below(&(ubound - lbound));
-    }
-
-    fn gen_bigint_range(&mut self, lbound: &BigInt, ubound: &BigInt) -> BigInt {
-        assert!(*lbound < *ubound);
-        let delta = (ubound - lbound).to_biguint().unwrap();
-        return lbound + self.gen_biguint_below(&delta).to_bigint().unwrap();
-    }
-}
 
 impl BigInt {
     /// Creates and initializes a BigInt.

--- a/src/bigrand.rs
+++ b/src/bigrand.rs
@@ -52,25 +52,27 @@ impl<R: Rng> RandBigInt for R {
     }
 
     fn gen_bigint(&mut self, bit_size: usize) -> BigInt {
-        // Generate a random BigUint...
-        let biguint = self.gen_biguint(bit_size);
-        // ...and then randomly assign it a Sign...
-        let sign = if biguint.is_zero() {
-            // ...except that if the BigUint is zero, we need to try
-            // again with probability 0.5. This is because otherwise,
-            // the probability of generating a zero BigInt would be
-            // double that of any other number.
-            if self.gen() {
-                return self.gen_bigint(bit_size);
+        loop {
+            // Generate a random BigUint...
+            let biguint = self.gen_biguint(bit_size);
+            // ...and then randomly assign it a Sign...
+            let sign = if biguint.is_zero() {
+                // ...except that if the BigUint is zero, we need to try
+                // again with probability 0.5. This is because otherwise,
+                // the probability of generating a zero BigInt would be
+                // double that of any other number.
+                if self.gen() {
+                    continue;
+                } else {
+                    NoSign
+                }
+            } else if self.gen() {
+                Plus
             } else {
-                NoSign
-            }
-        } else if self.gen() {
-            Plus
-        } else {
-            Minus
-        };
-        BigInt::from_biguint(sign, biguint)
+                Minus
+            };
+            return BigInt::from_biguint(sign, biguint);
+        }
     }
 
     fn gen_biguint_below(&mut self, bound: &BigUint) -> BigUint {

--- a/src/bigrand.rs
+++ b/src/bigrand.rs
@@ -1,0 +1,97 @@
+//! Randomization of big integers
+
+// Some of the tests of non-RNG-based functionality are randomized using the
+// RNG-based functionality, so the RNG-based functionality needs to be enabled
+// for tests.
+use rand::Rng;
+
+use BigInt;
+use BigUint;
+use Sign::*;
+use big_digit::BigDigit;
+
+use traits::Zero;
+use integer::Integer;
+
+pub trait RandBigInt {
+    /// Generate a random `BigUint` of the given bit size.
+    fn gen_biguint(&mut self, bit_size: usize) -> BigUint;
+
+    /// Generate a random BigInt of the given bit size.
+    fn gen_bigint(&mut self, bit_size: usize) -> BigInt;
+
+    /// Generate a random `BigUint` less than the given bound. Fails
+    /// when the bound is zero.
+    fn gen_biguint_below(&mut self, bound: &BigUint) -> BigUint;
+
+    /// Generate a random `BigUint` within the given range. The lower
+    /// bound is inclusive; the upper bound is exclusive. Fails when
+    /// the upper bound is not greater than the lower bound.
+    fn gen_biguint_range(&mut self, lbound: &BigUint, ubound: &BigUint) -> BigUint;
+
+    /// Generate a random `BigInt` within the given range. The lower
+    /// bound is inclusive; the upper bound is exclusive. Fails when
+    /// the upper bound is not greater than the lower bound.
+    fn gen_bigint_range(&mut self, lbound: &BigInt, ubound: &BigInt) -> BigInt;
+}
+
+#[cfg(any(feature = "rand", test))]
+impl<R: Rng> RandBigInt for R {
+    fn gen_biguint(&mut self, bit_size: usize) -> BigUint {
+        use super::big_digit::BITS;
+        let (digits, rem) = bit_size.div_rem(&BITS);
+        let mut data = Vec::with_capacity(digits + 1);
+        for _ in 0..digits {
+            data.push(self.gen());
+        }
+        if rem > 0 {
+            let final_digit: BigDigit = self.gen();
+            data.push(final_digit >> (BITS - rem));
+        }
+        BigUint::new(data)
+    }
+
+    fn gen_bigint(&mut self, bit_size: usize) -> BigInt {
+        // Generate a random BigUint...
+        let biguint = self.gen_biguint(bit_size);
+        // ...and then randomly assign it a Sign...
+        let sign = if biguint.is_zero() {
+            // ...except that if the BigUint is zero, we need to try
+            // again with probability 0.5. This is because otherwise,
+            // the probability of generating a zero BigInt would be
+            // double that of any other number.
+            if self.gen() {
+                return self.gen_bigint(bit_size);
+            } else {
+                NoSign
+            }
+        } else if self.gen() {
+            Plus
+        } else {
+            Minus
+        };
+        BigInt::from_biguint(sign, biguint)
+    }
+
+    fn gen_biguint_below(&mut self, bound: &BigUint) -> BigUint {
+        assert!(!bound.is_zero());
+        let bits = bound.bits();
+        loop {
+            let n = self.gen_biguint(bits);
+            if n < *bound {
+                return n;
+            }
+        }
+    }
+
+    fn gen_biguint_range(&mut self, lbound: &BigUint, ubound: &BigUint) -> BigUint {
+        assert!(*lbound < *ubound);
+        return lbound + self.gen_biguint_below(&(ubound - lbound));
+    }
+
+    fn gen_bigint_range(&mut self, lbound: &BigInt, ubound: &BigInt) -> BigInt {
+        assert!(*lbound < *ubound);
+        let delta = (ubound - lbound).to_biguint().unwrap();
+        return lbound + BigInt::from(self.gen_biguint_below(&delta))
+    }
+}

--- a/src/bigrand.rs
+++ b/src/bigrand.rs
@@ -8,7 +8,9 @@ use rand::Rng;
 use BigInt;
 use BigUint;
 use Sign::*;
+
 use big_digit::BigDigit;
+use bigint::magnitude;
 
 use traits::Zero;
 use integer::Integer;
@@ -88,12 +90,22 @@ impl<R: Rng> RandBigInt for R {
 
     fn gen_biguint_range(&mut self, lbound: &BigUint, ubound: &BigUint) -> BigUint {
         assert!(*lbound < *ubound);
-        return lbound + self.gen_biguint_below(&(ubound - lbound));
+        if lbound.is_zero() {
+            self.gen_biguint_below(ubound)
+        } else {
+            lbound + self.gen_biguint_below(&(ubound - lbound))
+        }
     }
 
     fn gen_bigint_range(&mut self, lbound: &BigInt, ubound: &BigInt) -> BigInt {
         assert!(*lbound < *ubound);
-        let delta = (ubound - lbound).to_biguint().unwrap();
-        return lbound + BigInt::from(self.gen_biguint_below(&delta))
+        if lbound.is_zero() {
+            BigInt::from(self.gen_biguint_below(magnitude(&ubound)))
+        } else if ubound.is_zero() {
+            lbound + BigInt::from(self.gen_biguint_below(magnitude(&lbound)))
+        } else {
+            let delta = ubound - lbound;
+            lbound + BigInt::from(self.gen_biguint_below(magnitude(&delta)))
+        }
     }
 }

--- a/src/bigrand.rs
+++ b/src/bigrand.rs
@@ -1,8 +1,5 @@
 //! Randomization of big integers
 
-// Some of the tests of non-RNG-based functionality are randomized using the
-// RNG-based functionality, so the RNG-based functionality needs to be enabled
-// for tests.
 use rand::Rng;
 
 use BigInt;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -163,7 +163,7 @@ pub use bigint::BigInt;
 pub use bigint::ToBigInt;
 
 #[cfg(feature = "rand")]
-pub use bigrand::RandBigInt;
+pub use bigrand::{RandBigInt, UniformBigUint};
 
 mod big_digit {
     /// A `BigDigit` is a `BigUint`'s composing element.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -80,7 +80,7 @@
 // reserving this ability with the "std" feature now, and compilation will fail without.
 #![cfg_attr(not(feature = "std"), no_std)]
 
-#[cfg(any(feature = "rand", test))]
+#[cfg(feature = "rand")]
 extern crate rand;
 #[cfg(feature = "serde")]
 extern crate serde;
@@ -90,6 +90,15 @@ extern crate num_traits as traits;
 
 use std::error::Error;
 use std::fmt;
+
+#[macro_use]
+mod macros;
+
+mod biguint;
+mod bigint;
+
+#[cfg(feature = "rand")]
+mod bigrand;
 
 #[cfg(target_pointer_width = "32")]
 type UsizePromotion = u32;
@@ -146,19 +155,15 @@ impl Error for ParseBigIntError {
     }
 }
 
-#[macro_use]
-mod macros;
-
-mod biguint;
-mod bigint;
-
 pub use biguint::BigUint;
 pub use biguint::ToBigUint;
 
 pub use bigint::Sign;
 pub use bigint::BigInt;
 pub use bigint::ToBigInt;
-pub use bigint::RandBigInt;
+
+#[cfg(feature = "rand")]
+pub use bigrand::RandBigInt;
 
 mod big_digit {
     /// A `BigDigit` is a `BigUint`'s composing element.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -163,7 +163,7 @@ pub use bigint::BigInt;
 pub use bigint::ToBigInt;
 
 #[cfg(feature = "rand")]
-pub use bigrand::{RandBigInt, UniformBigUint};
+pub use bigrand::{RandBigInt, UniformBigUint, UniformBigInt};
 
 mod big_digit {
     /// A `BigDigit` is a `BigUint`'s composing element.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,6 +47,7 @@
 //! It's easy to generate large random numbers:
 //!
 //! ```rust
+//! # #[cfg(feature = "rand")]
 //! extern crate rand;
 //! extern crate num_bigint as bigint;
 //!

--- a/tests/bigint.rs
+++ b/tests/bigint.rs
@@ -1,6 +1,7 @@
 extern crate num_bigint;
 extern crate num_integer;
 extern crate num_traits;
+#[cfg(feature = "rand")]
 extern crate rand;
 
 use num_bigint::BigUint;
@@ -1021,11 +1022,13 @@ fn test_negative_shr() {
 }
 
 #[test]
+#[cfg(feature = "rand")]
 fn test_random_shr() {
     use rand::Rng;
+    use rand::distributions::Standard;
     let mut rng = rand::thread_rng();
 
-    for p in rng.gen_iter::<i64>().take(1000) {
+    for p in rng.sample_iter::<i64, _>(&Standard).take(1000) {
         let big = BigInt::from(p);
         let bigger = &big << 1000;
         assert_eq!(&bigger >> 1000, big);

--- a/tests/biguint.rs
+++ b/tests/biguint.rs
@@ -1,7 +1,6 @@
 extern crate num_bigint;
 extern crate num_integer;
 extern crate num_traits;
-extern crate rand;
 
 use num_integer::Integer;
 use num_bigint::{BigUint, ToBigUint};

--- a/tests/rand.rs
+++ b/tests/rand.rs
@@ -8,6 +8,8 @@ mod biguint {
     use num_bigint::{BigUint, RandBigInt};
     use num_traits::Zero;
     use rand::thread_rng;
+    use rand::Rng;
+    use rand::distributions::Uniform;
 
     #[test]
     fn test_rand() {
@@ -53,6 +55,29 @@ mod biguint {
         let u = BigUint::from(3513u32);
         // Switching u and l should fail:
         let _n: BigUint = rng.gen_biguint_range(&u, &l);
+    }
+
+    #[test]
+    fn test_rand_uniform() {
+        let mut rng = thread_rng();
+
+        let tiny = Uniform::new(BigUint::from(236u32), BigUint::from(237u32));
+        for _ in 0..10 {
+            assert_eq!(rng.sample(&tiny), BigUint::from(236u32));
+        }
+
+        let l = BigUint::from(403469000u32 + 2352);
+        let u = BigUint::from(403469000u32 + 3513);
+        let below = Uniform::new(BigUint::zero(), u.clone());
+        let range = Uniform::new(l.clone(), u.clone());
+        for _ in 0..1000 {
+            let n: BigUint = rng.sample(&below);
+            assert!(n < u);
+
+            let n: BigUint = rng.sample(&range);
+            assert!(n >= l);
+            assert!(n < u);
+        }
     }
 }
 

--- a/tests/rand.rs
+++ b/tests/rand.rs
@@ -5,9 +5,9 @@ extern crate num_traits;
 extern crate rand;
 
 mod biguint {
-    use rand::thread_rng;
     use num_bigint::{BigUint, RandBigInt};
-    use num_traits::{FromPrimitive, Zero};
+    use num_traits::Zero;
+    use rand::thread_rng;
 
     #[test]
     fn test_rand() {
@@ -21,13 +21,14 @@ mod biguint {
         let mut rng = thread_rng();
 
         for _ in 0..10 {
-            assert_eq!(rng.gen_bigint_range(&FromPrimitive::from_usize(236).unwrap(),
-                                            &FromPrimitive::from_usize(237).unwrap()),
-                       FromPrimitive::from_usize(236).unwrap());
+            assert_eq!(
+                rng.gen_biguint_range(&BigUint::from(236u32), &BigUint::from(237u32)),
+                BigUint::from(236u32)
+            );
         }
 
-        let l = FromPrimitive::from_usize(403469000 + 2352).unwrap();
-        let u = FromPrimitive::from_usize(403469000 + 3513).unwrap();
+        let l = BigUint::from(403469000u32 + 2352);
+        let u = BigUint::from(403469000u32 + 3513);
         for _ in 0..1000 {
             let n: BigUint = rng.gen_biguint_below(&u);
             assert!(n < u);
@@ -41,25 +42,24 @@ mod biguint {
     #[test]
     #[should_panic]
     fn test_zero_rand_range() {
-        thread_rng().gen_biguint_range(&FromPrimitive::from_usize(54).unwrap(),
-                                       &FromPrimitive::from_usize(54).unwrap());
+        thread_rng().gen_biguint_range(&BigUint::from(54u32), &BigUint::from(54u32));
     }
 
     #[test]
     #[should_panic]
     fn test_negative_rand_range() {
         let mut rng = thread_rng();
-        let l = FromPrimitive::from_usize(2352).unwrap();
-        let u = FromPrimitive::from_usize(3513).unwrap();
+        let l = BigUint::from(2352u32);
+        let u = BigUint::from(3513u32);
         // Switching u and l should fail:
         let _n: BigUint = rng.gen_biguint_range(&u, &l);
     }
 }
 
 mod bigint {
-    use rand::thread_rng;
     use num_bigint::{BigInt, RandBigInt};
-    use num_traits::{FromPrimitive, Zero};
+    use num_traits::Zero;
+    use rand::thread_rng;
 
     #[test]
     fn test_rand() {
@@ -73,9 +73,10 @@ mod bigint {
         let mut rng = thread_rng();
 
         for _ in 0..10 {
-            assert_eq!(rng.gen_bigint_range(&FromPrimitive::from_usize(236).unwrap(),
-            &FromPrimitive::from_usize(237).unwrap()),
-            FromPrimitive::from_usize(236).unwrap());
+            assert_eq!(
+                rng.gen_bigint_range(&BigInt::from(236), &BigInt::from(237)),
+                BigInt::from(236)
+            );
         }
 
         fn check(l: BigInt, u: BigInt) {
@@ -86,8 +87,8 @@ mod bigint {
                 assert!(n < u);
             }
         }
-        let l: BigInt = FromPrimitive::from_usize(403469000 + 2352).unwrap();
-        let u: BigInt = FromPrimitive::from_usize(403469000 + 3513).unwrap();
+        let l: BigInt = BigInt::from(403469000 + 2352);
+        let u: BigInt = BigInt::from(403469000 + 3513);
         check(l.clone(), u.clone());
         check(-l.clone(), u.clone());
         check(-u.clone(), -l.clone());
@@ -96,16 +97,15 @@ mod bigint {
     #[test]
     #[should_panic]
     fn test_zero_rand_range() {
-        thread_rng().gen_bigint_range(&FromPrimitive::from_isize(54).unwrap(),
-        &FromPrimitive::from_isize(54).unwrap());
+        thread_rng().gen_bigint_range(&BigInt::from(54), &BigInt::from(54));
     }
 
     #[test]
     #[should_panic]
     fn test_negative_rand_range() {
         let mut rng = thread_rng();
-        let l = FromPrimitive::from_usize(2352).unwrap();
-        let u = FromPrimitive::from_usize(3513).unwrap();
+        let l = BigInt::from(2352);
+        let u = BigInt::from(3513);
         // Switching u and l should fail:
         let _n: BigInt = rng.gen_bigint_range(&u, &l);
     }

--- a/tests/rand.rs
+++ b/tests/rand.rs
@@ -85,6 +85,8 @@ mod bigint {
     use num_bigint::{BigInt, RandBigInt};
     use num_traits::Zero;
     use rand::thread_rng;
+    use rand::Rng;
+    use rand::distributions::Uniform;
 
     #[test]
     fn test_rand() {
@@ -133,5 +135,30 @@ mod bigint {
         let u = BigInt::from(3513);
         // Switching u and l should fail:
         let _n: BigInt = rng.gen_bigint_range(&u, &l);
+    }
+
+    #[test]
+    fn test_rand_uniform() {
+        let mut rng = thread_rng();
+
+        let tiny = Uniform::new(BigInt::from(236u32), BigInt::from(237u32));
+        for _ in 0..10 {
+            assert_eq!(rng.sample(&tiny), BigInt::from(236u32));
+        }
+
+        fn check(l: BigInt, u: BigInt) {
+            let mut rng = thread_rng();
+            let range = Uniform::new(l.clone(), u.clone());
+            for _ in 0..1000 {
+                let n: BigInt = rng.sample(&range);
+                assert!(n >= l);
+                assert!(n < u);
+            }
+        }
+        let l: BigInt = BigInt::from(403469000 + 2352);
+        let u: BigInt = BigInt::from(403469000 + 3513);
+        check(l.clone(), u.clone());
+        check(-l.clone(), u.clone());
+        check(-u.clone(), -l.clone());
     }
 }

--- a/tests/torture.rs
+++ b/tests/torture.rs
@@ -6,13 +6,13 @@ extern crate rand;
 
 use num_bigint::RandBigInt;
 use num_traits::Zero;
-use rand::{SeedableRng, StdRng, Rng};
+use rand::prelude::*;
 
 fn test_mul_divide_torture_count(count: usize) {
 
     let bits_max = 1 << 12;
-    let seed: &[_] = &[1, 2, 3, 4];
-    let mut rng: StdRng = SeedableRng::from_seed(seed);
+    let seed = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16];
+    let mut rng = SmallRng::from_seed(seed);
 
     for _ in 0..count {
         // Test with numbers of random sizes:


### PR DESCRIPTION
This closes #47, choosing to *only* support rand 0.5 (and only for their supported rustc 1.22+).

The `RandBigInt` trait still exists as an extension to all `Rng` types.  It's no longer defined at all when the "rand" feature is not enabled.  That was a misbehavior before, as enabling "rand" adds a blanket implementation, which would be a breaking change just by toggling the feature.

`BigUint` and `BigInt` now implement `SampleUniform` too, which lets them work natively with `Rng::gen_range`, `Rng::sample`, and `Uniform` in general.