### PR TITLE
Implement Roots for BigInt and BigUint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ name = "shootout-pidigits"
 [dependencies]
 
 [dependencies.num-integer]
-version = "0.1.38"
+version = "0.1.39"
 default-features = false
 
 [dependencies.num-traits]

--- a/benches/bigint.rs
+++ b/benches/bigint.rs
@@ -4,13 +4,14 @@
 extern crate test;
 extern crate num_bigint;
 extern crate num_traits;
+extern crate num_integer;
 extern crate rand;
 
 use std::mem::replace;
 use test::Bencher;
 use num_bigint::{BigInt, BigUint, RandBigInt};
 use num_traits::{Zero, One, FromPrimitive, Num};
-use rand::{SeedableRng, StdRng};
+use rand::{SeedableRng, StdRng, Rng};
 
 fn get_rng() -> StdRng {
     let mut seed = [0; 32];
@@ -341,4 +342,33 @@ fn modpow_even(b: &mut Bencher) {
     let m = BigUint::from_str_radix(RFC3526_2048BIT_MODP_GROUP, 16).unwrap() - 1u32;
 
     b.iter(|| base.modpow(&e, &m));
+}
+
+#[bench]
+fn roots_sqrt(b: &mut Bencher) {
+    let mut rng = get_rng();
+    let x = rng.gen_biguint(2048);
+
+    b.iter(|| x.sqrt());
+}
+
+#[bench]
+fn roots_cbrt(b: &mut Bencher) {
+    let mut rng = get_rng();
+    let x = rng.gen_biguint(2048);
+
+    b.iter(|| x.cbrt());
+}
+
+#[bench]
+fn roots_nth(b: &mut Bencher) {
+    let mut rng = get_rng();
+    let x = rng.gen_biguint(2048);
+    // Although n is u32, here we limit it to the set of u8 values since it
+    // hugely impacts the performance of nth_root due to exponentiation to
+    // the power of n-1. Using very large values for n is also not very realistic,
+    // and any n > x's bit size produces 1 as a result anyway.
+    let n: u8 = rng.gen();
+
+    b.iter(|| { x.nth_root(n as u32) });
 }

--- a/benches/bigint.rs
+++ b/benches/bigint.rs
@@ -11,7 +11,7 @@ use std::mem::replace;
 use test::Bencher;
 use num_bigint::{BigInt, BigUint, RandBigInt};
 use num_traits::{Zero, One, FromPrimitive, Num};
-use rand::{SeedableRng, StdRng, Rng};
+use rand::{SeedableRng, StdRng};
 
 fn get_rng() -> StdRng {
     let mut seed = [0; 32];
@@ -361,14 +361,9 @@ fn roots_cbrt(b: &mut Bencher) {
 }
 
 #[bench]
-fn roots_nth(b: &mut Bencher) {
+fn roots_nth_100(b: &mut Bencher) {
     let mut rng = get_rng();
     let x = rng.gen_biguint(2048);
-    // Although n is u32, here we limit it to the set of u8 values since it
-    // hugely impacts the performance of nth_root due to exponentiation to
-    // the power of n-1. Using very large values for n is also not very realistic,
-    // and any n > x's bit size produces 1 as a result anyway.
-    let n: u8 = rng.gen();
 
-    b.iter(|| { x.nth_root(n as u32) });
+    b.iter(|| x.nth_root(100));
 }

--- a/src/bigint.rs
+++ b/src/bigint.rs
@@ -2559,19 +2559,19 @@ impl BigInt {
     }
 
     /// Returns the truncated principal square root of `self` --
-    /// see [Roots::sqrt](Roots::sqrt).
+    /// see [Roots::sqrt](https://docs.rs/num-integer/0.1/num_integer/trait.Roots.html#method.sqrt).
     pub fn sqrt(&self) -> Self {
         Roots::sqrt(self)
     }
 
     /// Returns the truncated principal cube root of `self` --
-    /// see [Roots::cbrt](Roots::cbrt).
+    /// see [Roots::cbrt](https://docs.rs/num-integer/0.1/num_integer/trait.Roots.html#method.cbrt).
     pub fn cbrt(&self) -> Self {
         Roots::cbrt(self)
     }
 
     /// Returns the truncated principal `n`th root of `self` --
-    /// See [Roots::nth_root](Roots::nth_root).
+    /// See [Roots::nth_root](https://docs.rs/num-integer/0.1/num_integer/trait.Roots.html#tymethod.nth_root).
     pub fn nth_root(&self, n: u32) -> Self {
         Roots::nth_root(self, n)
     }

--- a/src/bigint.rs
+++ b/src/bigint.rs
@@ -16,7 +16,7 @@ use std::iter::{Product, Sum};
 #[cfg(feature = "serde")]
 use serde;
 
-use integer::Integer;
+use integer::{Integer, Roots};
 use traits::{ToPrimitive, FromPrimitive, Num, CheckedAdd, CheckedSub,
              CheckedMul, CheckedDiv, Signed, Zero, One};
 
@@ -1802,6 +1802,15 @@ impl Integer for BigInt {
     }
 }
 
+impl Roots for BigInt {
+    fn nth_root(&self, n: u32) -> Self {
+        assert!(!(self.is_negative() && n.is_even()),
+                "n-th root is undefined for number (n={})", n);
+
+        BigInt::from_biguint(self.sign, self.data.nth_root(n))
+    }
+}
+
 impl ToPrimitive for BigInt {
     #[inline]
     fn to_i64(&self) -> Option<i64> {
@@ -2537,6 +2546,25 @@ impl BigInt {
             (true, true) => (Minus, result),
         };
         BigInt::from_biguint(sign, mag)
+    }
+
+    /// Returns the truncated principal square root of `self` --
+    /// see [Roots::sqrt](Roots::sqrt).
+    // struct.BigInt.html#trait.Roots
+    pub fn sqrt(&self) -> Self {
+        Roots::sqrt(self)
+    }
+
+    /// Returns the truncated principal cube root of `self` --
+    /// see [Roots::cbrt](Roots::cbrt).
+    pub fn cbrt(&self) -> Self {
+        Roots::cbrt(self)
+    }
+
+    /// Returns the truncated principal `n`th root of `self` --
+    /// See [Roots::nth_root](Roots::nth_root).
+    pub fn nth_root(&self, n: u32) -> Self {
+        Roots::nth_root(self, n)
     }
 }
 

--- a/src/bigint.rs
+++ b/src/bigint.rs
@@ -2560,7 +2560,6 @@ impl BigInt {
 
     /// Returns the truncated principal square root of `self` --
     /// see [Roots::sqrt](Roots::sqrt).
-    // struct.BigInt.html#trait.Roots
     pub fn sqrt(&self) -> Self {
         Roots::sqrt(self)
     }

--- a/src/bigint.rs
+++ b/src/bigint.rs
@@ -1805,9 +1805,19 @@ impl Integer for BigInt {
 impl Roots for BigInt {
     fn nth_root(&self, n: u32) -> Self {
         assert!(!(self.is_negative() && n.is_even()),
-                "n-th root is undefined for number (n={})", n);
+                "root of degree {} is imaginary", n);
 
         BigInt::from_biguint(self.sign, self.data.nth_root(n))
+    }
+
+    fn sqrt(&self) -> Self {
+        assert!(!self.is_negative(), "square root is imaginary");
+
+        BigInt::from_biguint(self.sign, self.data.sqrt())
+    }
+
+    fn cbrt(&self) -> Self {
+        BigInt::from_biguint(self.sign, self.data.cbrt())
     }
 }
 

--- a/src/biguint.rs
+++ b/src/biguint.rs
@@ -1839,19 +1839,19 @@ impl BigUint {
     }
 
     /// Returns the truncated principal square root of `self` --
-    /// see [Roots::sqrt](Roots::sqrt)
+    /// see [Roots::sqrt](https://docs.rs/num-integer/0.1/num_integer/trait.Roots.html#method.sqrt)
     pub fn sqrt(&self) -> Self {
         Roots::sqrt(self)
     }
 
     /// Returns the truncated principal cube root of `self` --
-    /// see [Roots::cbrt](Roots::cbrt).
+    /// see [Roots::cbrt](https://docs.rs/num-integer/0.1/num_integer/trait.Roots.html#method.cbrt).
     pub fn cbrt(&self) -> Self {
         Roots::cbrt(self)
     }
 
     /// Returns the truncated principal `n`th root of `self` --
-    /// see [Roots::nth_root](Roots::nth_root).
+    /// see [Roots::nth_root](https://docs.rs/num-integer/0.1/num_integer/trait.Roots.html#tymethod.nth_root).
     pub fn nth_root(&self, n: u32) -> Self {
         Roots::nth_root(self, n)
     }

--- a/src/biguint.rs
+++ b/src/biguint.rs
@@ -1049,8 +1049,7 @@ impl Roots for BigUint {
         let n = n as usize;
         let n_min_1 = n - 1;
 
-        let bit_len = self.len() * big_digit::BITS;
-        let guess = BigUint::one() << (bit_len/n + 1);
+        let guess = BigUint::one() << (self.bits()/n + 1);
 
         let mut u = guess;
         let mut s: BigUint;
@@ -1075,8 +1074,7 @@ impl Roots for BigUint {
             return self.clone()
         }
 
-        let bit_len = self.len() * big_digit::BITS;
-        let guess = BigUint::one() << (bit_len/2 + 1);
+        let guess = BigUint::one() << (self.bits()/2 + 1);
 
         let mut u = guess;
         let mut s: BigUint;
@@ -1098,8 +1096,7 @@ impl Roots for BigUint {
             return self.clone()
         }
 
-        let bit_len = self.len() * big_digit::BITS;
-        let guess = BigUint::one() << (bit_len/3 + 1);
+        let guess = BigUint::one() << (self.bits()/3 + 1);
 
         let mut u = guess;
         let mut s: BigUint;

--- a/tests/roots.rs
+++ b/tests/roots.rs
@@ -4,46 +4,53 @@ extern crate num_traits;
 
 mod biguint {
     use num_bigint::BigUint;
-    use num_traits::FromPrimitive;
+    use num_traits::pow;
     use std::str::FromStr;
 
-    fn check(x: i32, n: u32, expected: i32) {
-        let big_x: BigUint = FromPrimitive::from_i32(x).unwrap();
-        let big_expected: BigUint = FromPrimitive::from_i32(expected).unwrap();
+    fn check(x: u64, n: u32) {
+        let big_x = BigUint::from(x);
+        let res = big_x.nth_root(n);
 
-        assert_eq!(big_x.nth_root(n), big_expected);
+        if n == 2 {
+            assert_eq!(&res, &big_x.sqrt())
+        } else if n == 3 {
+            assert_eq!(&res, &big_x.cbrt())
+        }
+
+        assert!(pow(res.clone(), n as usize) <= big_x);
+        assert!(pow(res.clone() + 1u32, n as usize) > big_x);
     }
 
     #[test]
     fn test_sqrt() {
-        check(99, 2, 9);
-        check(100, 2, 10);
-        check(120, 2, 10);
+        check(99, 2);
+        check(100, 2);
+        check(120, 2);
     }
 
     #[test]
     fn test_cbrt() {
-        check(8, 3, 2);
-        check(26, 3, 2);
+        check(8, 3);
+        check(26, 3);
     }
 
     #[test]
     fn test_nth_root() {
-        check(0, 1, 0);
-        check(10, 1, 10);
-        check(100, 4, 3);
+        check(0, 1);
+        check(10, 1);
+        check(100, 4);
     }
 
     #[test]
     #[should_panic]
     fn test_nth_root_n_is_zero() {
-        check(4, 0, 0);
+        check(4, 0);
     }
 
     #[test]
     fn test_nth_root_big() {
-        let x: BigUint = FromStr::from_str("123_456_789").unwrap();
-        let expected : BigUint = FromPrimitive::from_i32(6).unwrap();
+        let x = BigUint::from_str("123_456_789").unwrap();
+        let expected = BigUint::from(6u32);
 
         assert_eq!(x.nth_root(10), expected);
     }
@@ -51,34 +58,47 @@ mod biguint {
 
 mod bigint {
     use num_bigint::BigInt;
-    use num_traits::FromPrimitive;
+    use num_traits::{Signed, pow};
 
-    fn check(x: i32, n: u32, expected: i32) {
-        let big_x: BigInt = FromPrimitive::from_i32(x).unwrap();
-        let big_expected: BigInt = FromPrimitive::from_i32(expected).unwrap();
+    fn check(x: i64, n: u32) {
+        let big_x = BigInt::from(x);
+        let res = big_x.nth_root(n);
 
-        assert_eq!(big_x.nth_root(n), big_expected);
+        if n == 2 {
+            assert_eq!(&res, &big_x.sqrt())
+        } else if n == 3 {
+            assert_eq!(&res, &big_x.cbrt())
+        }
+
+        if big_x.is_negative() {
+            assert!(pow(res.clone() - 1u32, n as usize) < big_x);
+            assert!(pow(res.clone(), n as usize) >= big_x);
+        } else {
+            assert!(pow(res.clone(), n as usize) <= big_x);
+            assert!(pow(res.clone() + 1u32, n as usize) > big_x);
+        }
     }
 
     #[test]
     fn test_nth_root() {
-        check(-100, 3, -4);
+        check(-100, 3);
     }
 
     #[test]
     #[should_panic]
     fn test_nth_root_x_neg_n_even() {
-        check(-100, 4, 0);
+        check(-100, 4);
     }
 
     #[test]
     #[should_panic]
     fn test_sqrt_x_neg() {
-        check(-4, 2, -2);
+        check(-4, 2);
     }
 
     #[test]
     fn test_cbrt() {
-        check(-8, 3, -2);
+        check(8, 3);
+        check(-8, 3);
     }
 }

--- a/tests/roots.rs
+++ b/tests/roots.rs
@@ -1,0 +1,84 @@
+extern crate num_bigint;
+extern crate num_integer;
+extern crate num_traits;
+
+mod biguint {
+    use num_bigint::BigUint;
+    use num_traits::FromPrimitive;
+    use std::str::FromStr;
+
+    fn check(x: i32, n: u32, expected: i32) {
+        let big_x: BigUint = FromPrimitive::from_i32(x).unwrap();
+        let big_expected: BigUint = FromPrimitive::from_i32(expected).unwrap();
+
+        assert_eq!(big_x.nth_root(n), big_expected);
+    }
+
+    #[test]
+    fn test_sqrt() {
+        check(99, 2, 9);
+        check(100, 2, 10);
+        check(120, 2, 10);
+    }
+
+    #[test]
+    fn test_cbrt() {
+        check(8, 3, 2);
+        check(26, 3, 2);
+    }
+
+    #[test]
+    fn test_nth_root() {
+        check(0, 1, 0);
+        check(10, 1, 10);
+        check(100, 4, 3);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_nth_root_n_is_zero() {
+        check(4, 0, 0);
+    }
+
+    #[test]
+    fn test_nth_root_big() {
+        let x: BigUint = FromStr::from_str("123_456_789").unwrap();
+        let expected : BigUint = FromPrimitive::from_i32(6).unwrap();
+
+        assert_eq!(x.nth_root(10), expected);
+    }
+}
+
+mod bigint {
+    use num_bigint::BigInt;
+    use num_traits::FromPrimitive;
+
+    fn check(x: i32, n: u32, expected: i32) {
+        let big_x: BigInt = FromPrimitive::from_i32(x).unwrap();
+        let big_expected: BigInt = FromPrimitive::from_i32(expected).unwrap();
+
+        assert_eq!(big_x.nth_root(n), big_expected);
+    }
+
+    #[test]
+    fn test_nth_root() {
+        check(-100, 3, -4);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_nth_root_x_neg_n_even() {
+        check(-100, 4, 0);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_sqrt_x_neg() {
+        check(-4, 2, -2);
+    }
+
+    #[test]
+    fn test_cbrt() {
+        check(-8, 3, -2);
+    }
+}


### PR DESCRIPTION
Supersedes #51 .

Since there is now a `Roots` trait with `sqrt`, `cbrt` and `nth_root` methods in the `num-integer` crate, this PR implements it for `BigInt` and `BigUint` types. I also added inherent methods on both types to allow the users access to all these functions without having to import `Roots`.

PS: `nth_root` currently  uses `num_traits::pow`. Should we perhaps wait for #54 to get merged, and then replace the call to use the new `pow::Pow` implementation on `BigUint`?