### PR TITLE
Update README.md alternatives section for apint

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ table offers a brief comparison to a few alternatives.
 | [`ramp`]         | Apache-2.0     | nightly   | rust and inline assembly |
 | [`rug`]          | LGPL-3.0+      | 1.18      | bundles [GMP] via [`gmp-mpfr-sys`] |
 | [`rust-gmp`]     | MIT            | stable?   | links to [GMP] |
-| [`apint`]        | MIT/Apache-2.0 | nightly   | pure rust (unfinished) |
+| [`apint`]        | MIT/Apache-2.0 | 1.26      | pure rust (unfinished) |
 
 [GMP]: https://gmplib.org/
 [`gmp-mpfr-sys`]: https://crates.io/crates/gmp-mpfr-sys


### PR DESCRIPTION
The apint crate is stable as of Rust version 1.26.