### PR TITLE
Use better initial guesses for Roots

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,9 @@ name = "factorial"
 name = "gcd"
 
 [[bench]]
+name = "roots"
+
+[[bench]]
 harness = false
 name = "shootout-pidigits"
 

--- a/benches/bigint.rs
+++ b/benches/bigint.rs
@@ -343,27 +343,3 @@ fn modpow_even(b: &mut Bencher) {
 
     b.iter(|| base.modpow(&e, &m));
 }
-
-#[bench]
-fn roots_sqrt(b: &mut Bencher) {
-    let mut rng = get_rng();
-    let x = rng.gen_biguint(2048);
-
-    b.iter(|| x.sqrt());
-}
-
-#[bench]
-fn roots_cbrt(b: &mut Bencher) {
-    let mut rng = get_rng();
-    let x = rng.gen_biguint(2048);
-
-    b.iter(|| x.cbrt());
-}
-
-#[bench]
-fn roots_nth_100(b: &mut Bencher) {
-    let mut rng = get_rng();
-    let x = rng.gen_biguint(2048);
-
-    b.iter(|| x.nth_root(100));
-}

--- a/benches/roots.rs
+++ b/benches/roots.rs
@@ -1,0 +1,176 @@
+#![feature(test)]
+#![cfg(feature = "rand")]
+
+extern crate num_bigint;
+extern crate num_traits;
+extern crate rand;
+extern crate test;
+
+use num_bigint::{BigUint, RandBigInt};
+use num_traits::Pow;
+use rand::{SeedableRng, StdRng};
+use test::Bencher;
+
+// The `big64` cases demonstrate the speed of cases where the value
+// can be converted to a `u64` primitive for faster calculation.
+//
+// The `big1k` cases demonstrate those that can convert to `f64` for
+// a better initial guess of the actual value.
+//
+// The `big2k` and `big4k` cases are too big for `f64`, and use a simpler guess.
+
+fn get_rng() -> StdRng {
+    let mut seed = [0; 32];
+    for i in 1..32 {
+        seed[usize::from(i)] = i;
+    }
+    SeedableRng::from_seed(seed)
+}
+
+fn check(x: &BigUint, n: u32) {
+    let root = x.nth_root(n);
+    if n == 2 {
+        assert_eq!(root, x.sqrt())
+    } else if n == 3 {
+        assert_eq!(root, x.cbrt())
+    }
+
+    let lo = root.pow(n);
+    assert!(lo <= *x);
+    assert_eq!(lo.nth_root(n), root);
+    assert_eq!((&lo - 1u32).nth_root(n), &root - 1u32);
+
+    let hi = (&root + 1u32).pow(n);
+    assert!(hi > *x);
+    assert_eq!(hi.nth_root(n), &root + 1u32);
+    assert_eq!((&hi - 1u32).nth_root(n), root);
+}
+
+fn bench_sqrt(b: &mut Bencher, bits: usize) {
+    let x = get_rng().gen_biguint(bits);
+    eprintln!("bench_sqrt({})", x);
+
+    check(&x, 2);
+    b.iter(|| x.sqrt());
+}
+
+#[bench]
+fn big64_sqrt(b: &mut Bencher) {
+    bench_sqrt(b, 64);
+}
+
+#[bench]
+fn big1k_sqrt(b: &mut Bencher) {
+    bench_sqrt(b, 1024);
+}
+
+#[bench]
+fn big2k_sqrt(b: &mut Bencher) {
+    bench_sqrt(b, 2048);
+}
+
+#[bench]
+fn big4k_sqrt(b: &mut Bencher) {
+    bench_sqrt(b, 4096);
+}
+
+fn bench_cbrt(b: &mut Bencher, bits: usize) {
+    let x = get_rng().gen_biguint(bits);
+    eprintln!("bench_cbrt({})", x);
+
+    check(&x, 3);
+    b.iter(|| x.cbrt());
+}
+
+#[bench]
+fn big64_cbrt(b: &mut Bencher) {
+    bench_cbrt(b, 64);
+}
+
+#[bench]
+fn big1k_cbrt(b: &mut Bencher) {
+    bench_cbrt(b, 1024);
+}
+
+#[bench]
+fn big2k_cbrt(b: &mut Bencher) {
+    bench_cbrt(b, 2048);
+}
+
+#[bench]
+fn big4k_cbrt(b: &mut Bencher) {
+    bench_cbrt(b, 4096);
+}
+
+fn bench_nth_root(b: &mut Bencher, bits: usize, n: u32) {
+    let x = get_rng().gen_biguint(bits);
+    eprintln!("bench_{}th_root({})", n, x);
+
+    check(&x, n);
+    b.iter(|| x.nth_root(n));
+}
+
+#[bench]
+fn big64_nth_10(b: &mut Bencher) {
+    bench_nth_root(b, 64, 10);
+}
+
+#[bench]
+fn big1k_nth_10(b: &mut Bencher) {
+    bench_nth_root(b, 1024, 10);
+}
+
+#[bench]
+fn big1k_nth_100(b: &mut Bencher) {
+    bench_nth_root(b, 1024, 100);
+}
+
+#[bench]
+fn big1k_nth_1000(b: &mut Bencher) {
+    bench_nth_root(b, 1024, 1000);
+}
+
+#[bench]
+fn big1k_nth_10000(b: &mut Bencher) {
+    bench_nth_root(b, 1024, 10000);
+}
+
+#[bench]
+fn big2k_nth_10(b: &mut Bencher) {
+    bench_nth_root(b, 2048, 10);
+}
+
+#[bench]
+fn big2k_nth_100(b: &mut Bencher) {
+    bench_nth_root(b, 2048, 100);
+}
+
+#[bench]
+fn big2k_nth_1000(b: &mut Bencher) {
+    bench_nth_root(b, 2048, 1000);
+}
+
+#[bench]
+fn big2k_nth_10000(b: &mut Bencher) {
+    bench_nth_root(b, 2048, 10000);
+}
+
+#[bench]
+fn big4k_nth_10(b: &mut Bencher) {
+    bench_nth_root(b, 4096, 10);
+}
+
+#[bench]
+fn big4k_nth_100(b: &mut Bencher) {
+    bench_nth_root(b, 4096, 100);
+}
+
+#[bench]
+fn big4k_nth_1000(b: &mut Bencher) {
+    bench_nth_root(b, 4096, 1000);
+}
+
+#[bench]
+fn big4k_nth_10000(b: &mut Bencher) {
+    bench_nth_root(b, 4096, 10000);
+}

--- a/tests/roots.rs
+++ b/tests/roots.rs
@@ -2,57 +2,139 @@ extern crate num_bigint;
 extern crate num_integer;
 extern crate num_traits;
 
+#[cfg(feature = "rand")]
+extern crate rand;
+
 mod biguint {
     use num_bigint::BigUint;
-    use num_traits::Pow;
-    use std::str::FromStr;
+    use num_traits::{One, Pow, Zero};
+    use std::{i32, u32};
 
-    fn check(x: u64, n: u32) {
-        let big_x = BigUint::from(x);
-        let res = big_x.nth_root(n);
+    fn check<T: Into<BigUint>>(x: T, n: u32) {
+        let x: BigUint = x.into();
+        let root = x.nth_root(n);
+        println!("check {}.nth_root({}) = {}", x, n, root);
 
         if n == 2 {
-            assert_eq!(&res, &big_x.sqrt())
+            assert_eq!(root, x.sqrt())
         } else if n == 3 {
-            assert_eq!(&res, &big_x.cbrt())
+            assert_eq!(root, x.cbrt())
         }
 
-        assert!(res.pow(n) <= big_x);
-        assert!((res + 1u32).pow(n) > big_x);
+        let lo = root.pow(n);
+        assert!(lo <= x);
+        assert_eq!(lo.nth_root(n), root);
+        if !lo.is_zero() {
+            assert_eq!((&lo - 1u32).nth_root(n), &root - 1u32);
+        }
+
+        let hi = (&root + 1u32).pow(n);
+        assert!(hi > x);
+        assert_eq!(hi.nth_root(n), &root + 1u32);
+        assert_eq!((&hi - 1u32).nth_root(n), root);
     }
 
     #[test]
     fn test_sqrt() {
-        check(99, 2);
-        check(100, 2);
-        check(120, 2);
+        check(99u32, 2);
+        check(100u32, 2);
+        check(120u32, 2);
     }
 
     #[test]
     fn test_cbrt() {
-        check(8, 3);
-        check(26, 3);
+        check(8u32, 3);
+        check(26u32, 3);
     }
 
     #[test]
     fn test_nth_root() {
-        check(0, 1);
-        check(10, 1);
-        check(100, 4);
+        check(0u32, 1);
+        check(10u32, 1);
+        check(100u32, 4);
     }
 
     #[test]
     #[should_panic]
     fn test_nth_root_n_is_zero() {
-        check(4, 0);
+        check(4u32, 0);
     }
 
     #[test]
     fn test_nth_root_big() {
-        let x = BigUint::from_str("123_456_789").unwrap();
+        let x = BigUint::from(123_456_789_u32);
         let expected = BigUint::from(6u32);
 
         assert_eq!(x.nth_root(10), expected);
+        check(x, 10);
+    }
+
+    #[test]
+    fn test_nth_root_googol() {
+        let googol = BigUint::from(10u32).pow(100u32);
+
+        // perfect divisors of 100
+        for &n in &[2, 4, 5, 10, 20, 25, 50, 100] {
+            let expected = BigUint::from(10u32).pow(100u32 / n);
+            assert_eq!(googol.nth_root(n), expected);
+            check(googol.clone(), n);
+        }
+    }
+
+    #[test]
+    fn test_nth_root_twos() {
+        const EXP: u32 = 12;
+        const LOG2: usize = 1 << EXP;
+        let x = BigUint::one() << LOG2;
+
+        // the perfect divisors are just powers of two
+        for exp in 1..EXP + 1 {
+            let n = 2u32.pow(exp);
+            let expected = BigUint::one() << (LOG2 / n as usize);
+            assert_eq!(x.nth_root(n), expected);
+            check(x.clone(), n);
+        }
+
+        // degenerate cases should return quickly
+        assert!(x.nth_root(x.bits() as u32).is_one());
+        assert!(x.nth_root(i32::MAX as u32).is_one());
+        assert!(x.nth_root(u32::MAX).is_one());
+    }
+
+    #[cfg(feature = "rand")]
+    #[test]
+    fn test_roots_rand() {
+        use num_bigint::RandBigInt;
+        use rand::{thread_rng, Rng};
+        use rand::distributions::Uniform;
+
+        let mut rng = thread_rng();
+        let bit_range = Uniform::new(0, 2048);
+        let sample_bits: Vec<_> = rng.sample_iter(&bit_range).take(100).collect();
+        for bits in sample_bits {
+            let x = rng.gen_biguint(bits);
+            for n in 2..11 {
+                check(x.clone(), n);
+            }
+            check(x.clone(), 100);
+        }
+    }
+
+    #[test]
+    fn test_roots_rand1() {
+        // A random input that found regressions
+        let s = "575981506858479247661989091587544744717244516135539456183849\
+                 986593934723426343633698413178771587697273822147578889823552\
+                 182702908597782734558103025298880194023243541613924361007059\
+                 353344183590348785832467726433749431093350684849462759540710\
+                 026019022227591412417064179299354183441181373862905039254106\
+                 4781867";
+        let x: BigUint = s.parse().unwrap();
+
+        check(x.clone(), 2);
+        check(x.clone(), 3);
+        check(x.clone(), 10);
+        check(x.clone(), 100);
     }
 }
 


### PR DESCRIPTION
When a `BigUint` is small enough to fit in a `u64`, we use that to compute roots instead.

Otherwise, we can get a closer approximation of roots via `f64`.  For values that are even too big for that, we can shift them down in multiples of `n` enough that they do fit, and then shift the result back and refine the answer further.

Benchmarked with an i7-7700K on Fedora 29, `rustc 1.32.0-nightly (21f268495 2018-12-02)`.

```
 name             roots-master ns/iter  roots-opt ns/iter  diff ns/iter   diff %   speedup
 big1k_cbrt       18,787                6,934                   -11,853  -63.09%    x 2.71
 big1k_nth_10     20,896                4,595                   -16,301  -78.01%    x 4.55
 big1k_nth_100    53,912                1,326                   -52,586  -97.54%   x 40.66
 big1k_nth_1000   4,175                 5,205                     1,030   24.67%    x 0.80
 big1k_nth_10000  7,634                 23                       -7,611  -99.70%  x 331.91
 big1k_sqrt       19,083                9,804                    -9,279  -48.62%    x 1.95
 big2k_cbrt       46,799                20,917                  -25,882  -55.30%    x 2.24
 big2k_nth_10     27,959                12,296                  -15,663  -56.02%    x 2.27
 big2k_nth_100    77,422                7,430                   -69,992  -90.40%   x 10.42
 big2k_nth_1000   10,851                10,611                     -240   -2.21%    x 1.02
 big2k_nth_10000  7,963                 24                       -7,939  -99.70%  x 331.79
 big2k_sqrt       53,835                20,542                  -33,293  -61.84%    x 2.62
 big4k_cbrt       117,757               45,320                  -72,437  -61.51%    x 2.60
 big4k_nth_10     87,084                32,310                  -54,774  -62.90%    x 2.70
 big4k_nth_100    43,477                22,657                  -20,820  -47.89%    x 1.92
 big4k_nth_1000   101,478               102,153                     675    0.67%    x 0.99
 big4k_nth_10000  8,384                 24                       -8,360  -99.71%  x 349.33
 big4k_sqrt       142,891               48,711                  -94,180  -65.91%    x 2.93
 big64_cbrt       2,417                 59                       -2,358  -97.56%   x 40.97
 big64_nth_10     4,595                 84                       -4,511  -98.17%   x 54.70
 big64_sqrt       1,109                 37                       -1,072  -96.66%   x 29.97
```

Everything is a big win except `nth_1000`, but even the loss there is fast enough that I'm not worried.  I doubt `nth_root(1000)` would realistically be used anyway -- I just wanted challenging cases.