### PR TITLE
Fix `to_signed_bytes_*` for positive number with leading `0x80`

### DIFF
--- a/src/bigint.rs
+++ b/src/bigint.rs
@@ -710,9 +710,10 @@ impl ShlAssign<usize> for BigInt {
 // Negative values need a rounding adjustment if there are any ones in the
 // bits that are getting shifted out.
 fn shr_round_down(i: &BigInt, rhs: usize) -> bool {
-    i.is_negative() && biguint::trailing_zeros(&i.data)
-        .map(|n| n < rhs)
-        .unwrap_or(false)
+    i.is_negative()
+        && biguint::trailing_zeros(&i.data)
+            .map(|n| n < rhs)
+            .unwrap_or(false)
 }
 
 impl Shr<usize> for BigInt {
@@ -1126,15 +1127,13 @@ macro_rules! bigint_sub {
             (_, NoSign) => $a_owned,
             (NoSign, _) => -$b_owned,
             // opposite signs => keep the sign of the left with the sum of magnitudes
-            (Plus, Minus) | (Minus, Plus) =>
-                BigInt::from_biguint($a.sign, $a_data + $b_data),
+            (Plus, Minus) | (Minus, Plus) => BigInt::from_biguint($a.sign, $a_data + $b_data),
             // same sign => keep or toggle the sign of the left with the difference of magnitudes
-            (Plus, Plus) | (Minus, Minus) =>
-                match $a.data.cmp(&$b.data) {
-                    Less => BigInt::from_biguint(-$a.sign, $b_data - $a_data),
-                    Greater => BigInt::from_biguint($a.sign, $a_data - $b_data),
-                    Equal => Zero::zero(),
-                },
+            (Plus, Plus) | (Minus, Minus) => match $a.data.cmp(&$b.data) {
+                Less => BigInt::from_biguint(-$a.sign, $b_data - $a_data),
+                Greater => BigInt::from_biguint($a.sign, $a_data - $b_data),
+                Equal => Zero::zero(),
+            },
         }
     };
 }
@@ -2759,7 +2758,11 @@ impl BigInt {
     pub fn to_signed_bytes_be(&self) -> Vec<u8> {
         let mut bytes = self.data.to_bytes_be();
         let first_byte = bytes.first().map(|v| *v).unwrap_or(0);
-        if first_byte > 0x7f && !(first_byte == 0x80 && bytes.iter().skip(1).all(Zero::is_zero) && self.sign == Sign::Minus) {
+        if first_byte > 0x7f
+            && !(first_byte == 0x80
+                && bytes.iter().skip(1).all(Zero::is_zero)
+                && self.sign == Sign::Minus)
+        {
             // msb used by magnitude, extend by 1 byte
             bytes.insert(0, 0);
         }
@@ -2783,7 +2786,10 @@ impl BigInt {
     pub fn to_signed_bytes_le(&self) -> Vec<u8> {
         let mut bytes = self.data.to_bytes_le();
         let last_byte = bytes.last().map(|v| *v).unwrap_or(0);
-        if last_byte > 0x7f && !(last_byte == 0x80 && bytes.iter().rev().skip(1).all(Zero::is_zero) && self.sign == Sign::Minus)
+        if last_byte > 0x7f
+            && !(last_byte == 0x80
+                && bytes.iter().rev().skip(1).all(Zero::is_zero)
+                && self.sign == Sign::Minus)
         {
             // msb used by magnitude, extend by 1 byte
             bytes.push(0);

--- a/src/bigint.rs
+++ b/src/bigint.rs
@@ -2759,7 +2759,7 @@ impl BigInt {
     pub fn to_signed_bytes_be(&self) -> Vec<u8> {
         let mut bytes = self.data.to_bytes_be();
         let first_byte = bytes.first().map(|v| *v).unwrap_or(0);
-        if first_byte > 0x7f && !(first_byte == 0x80 && bytes.iter().skip(1).all(Zero::is_zero)) {
+        if first_byte > 0x7f && !(first_byte == 0x80 && bytes.iter().skip(1).all(Zero::is_zero) && self.sign == Sign::Minus) {
             // msb used by magnitude, extend by 1 byte
             bytes.insert(0, 0);
         }
@@ -2783,7 +2783,7 @@ impl BigInt {
     pub fn to_signed_bytes_le(&self) -> Vec<u8> {
         let mut bytes = self.data.to_bytes_le();
         let last_byte = bytes.last().map(|v| *v).unwrap_or(0);
-        if last_byte > 0x7f && !(last_byte == 0x80 && bytes.iter().rev().skip(1).all(Zero::is_zero))
+        if last_byte > 0x7f && !(last_byte == 0x80 && bytes.iter().rev().skip(1).all(Zero::is_zero) && self.sign == Sign::Minus)
         {
             // msb used by magnitude, extend by 1 byte
             bytes.push(0);

--- a/src/biguint.rs
+++ b/src/biguint.rs
@@ -135,7 +135,8 @@ fn from_bitwise_digits_le(v: &[u8], bits: usize) -> BigUint {
                 .iter()
                 .rev()
                 .fold(0, |acc, &c| (acc << bits) | c as BigDigit)
-        }).collect();
+        })
+        .collect();
 
     BigUint::new(data)
 }

--- a/tests/bigint.rs
+++ b/tests/bigint.rs
@@ -183,6 +183,22 @@ fn test_from_signed_bytes_be() {
 }
 
 #[test]
+fn test_signed_bytes_be_round_trip() {
+    for i in -0x1FFFF..0x20000 {
+        let n = BigInt::from(i);
+        assert_eq!(n, BigInt::from_signed_bytes_be(&n.to_signed_bytes_be()));
+    }
+}
+
+#[test]
+fn test_signed_bytes_le_round_trip() {
+    for i in -0x1FFFF..0x20000 {
+        let n = BigInt::from(i);
+        assert_eq!(n, BigInt::from_signed_bytes_le(&n.to_signed_bytes_le()));
+    }
+}
+
+#[test]
 fn test_cmp() {
     let vs: [&[u32]; 4] = [&[2 as u32], &[1, 1], &[2, 1], &[1, 1, 1]];
     let mut nums = Vec::new();

--- a/tests/bigint.rs
+++ b/tests/bigint.rs
@@ -116,6 +116,7 @@ fn test_to_signed_bytes_le() {
     check("-100", vec![156]);
     check("-8388608", vec![0, 0, 0x80]);
     check("-192", vec![0x40, 0xff]);
+    check("128", vec![0x80, 0])
 }
 
 #[test]
@@ -157,6 +158,7 @@ fn test_to_signed_bytes_be() {
     check("-100", vec![156]);
     check("-8388608", vec![128, 0, 0]);
     check("-192", vec![0xff, 0x40]);
+    check("128", vec![0, 0x80]);
 }
 
 #[test]


### PR DESCRIPTION
The trick for saving a byte on `0x800000..` only works for negative numbers. This caused +128 to be serialized as `0x80` which is -128. So pretty bad bug.