### PR TITLE
Add a quicker Rem

### DIFF
--- a/src/biguint.rs
+++ b/src/biguint.rs
@@ -1824,13 +1824,25 @@ pub fn to_str_radix_reversed(u: &BigUint, radix: u32) -> Vec<u8> {
 }
 
 impl BigUint {
+    /// quickly computes `self % div`
+    pub fn quick_rem(&self, div: u32) -> u32 {
+        let mut rem = 0u64;
+        for digit in self.data.iter().rev() {
+            rem = (rem << 32) + (*digit) as u64;
+            rem %= div as u64;
+        }
+
+        rem as u32
+    }
+
+
     /// Creates and initializes a `BigUint`.
     ///
     /// The digits are in little-endian base 2<sup>32</sup>.
     #[inline]
     pub fn new(digits: Vec<u32>) -> BigUint {
         BigUint { data: digits }.normalized()
-    }
+}
 
     /// Creates and initializes a `BigUint`.
     ///

--- a/src/biguint.rs
+++ b/src/biguint.rs
@@ -1842,7 +1842,7 @@ impl BigUint {
     #[inline]
     pub fn new(digits: Vec<u32>) -> BigUint {
         BigUint { data: digits }.normalized()
-}
+    }
 
     /// Creates and initializes a `BigUint`.
     ///

--- a/src/biguint.rs
+++ b/src/biguint.rs
@@ -1845,6 +1845,15 @@ impl BigUint {
         total
     }
 
+    pub fn trailing_zeros(&self) -> Option<usize> {
+    self.data
+        .iter()
+        .enumerate()
+        .find(|&(_, &digit)| digit != 0)
+        .map(|(i, digit)| i * big_digit::BITS + digit.trailing_zeros() as usize)
+}
+
+
     /// Creates and initializes a `BigUint`.
     ///
     /// The digits are in little-endian base 2<sup>32</sup>.

--- a/src/biguint.rs
+++ b/src/biguint.rs
@@ -1835,6 +1835,15 @@ impl BigUint {
         rem as u32
     }
 
+    pub fn factorial(&self) -> BigUint {
+        let mut total = BigUint::from(1u8);
+        let mut i = BigUint::from(1u8);
+        while &i < self {
+            i += 1u8;
+            total *= &i;
+        }
+        total
+    }
 
     /// Creates and initializes a `BigUint`.
     ///


### PR DESCRIPTION
Right now all implementations of Rem return a `BigUint` and are somewhat slow.
Due to the fact that `a % b < b` is always true, we might want to change Rem to return a value of type `b` instead of a.

I have implemented a somewhat faster version of Rem and ran [some benchmarks](https://github.com/lcnr/quick-rem):

|xbits | old | new |old (bigger is better)
|---|----|----|--------------------
4 | 51,257 ns/iter (+/- 22,916)| 10,864 ns/iter (+/- 9,191)|4.72
6|67,351 ns/iter (+/- 44,639)| 23,170 ns/iter (+/- 19,247)|2.91
8 |132,859 ns/iter (+/- 54,852)| 75,033 ns/iter (+/- 6,360)|1.77
10 |399,424 ns/iter (+/- 75,839)| 346,401 ns/iter (+/- 2,146)|1.153
14 |5,957,626 ns/iter (+/- 394,632)| 5,986,485 ns/iter (+/- 1,919,245)|1.00
18 |96,009,267 ns/iter (+/- 12,585,847)| 94,161,577 ns/iter (+/- 15,044,440)|1.02

Relevant because of this [test for truncatable primes](https://github.com/lcnr/truncatable/blob/master/src/is_prime.rs) which is three times faster when using `quick_rem`instead of the current implementation.