### PR TITLE
Use from() for lossless numerical type conversion

### DIFF
--- a/src/algorithms.rs
+++ b/src/algorithms.rs
@@ -19,8 +19,8 @@ use big_digit::{self, BigDigit, DoubleBigDigit, SignedDoubleBigDigit};
 // Add with carry:
 #[inline]
 fn adc(a: BigDigit, b: BigDigit, acc: &mut DoubleBigDigit) -> BigDigit {
-    *acc += a as DoubleBigDigit;
-    *acc += b as DoubleBigDigit;
+    *acc += DoubleBigDigit::from(a);
+    *acc += DoubleBigDigit::from(b);
     let lo = *acc as BigDigit;
     *acc >>= big_digit::BITS;
     lo
@@ -29,8 +29,8 @@ fn adc(a: BigDigit, b: BigDigit, acc: &mut DoubleBigDigit) -> BigDigit {
 // Subtract with borrow:
 #[inline]
 fn sbb(a: BigDigit, b: BigDigit, acc: &mut SignedDoubleBigDigit) -> BigDigit {
-    *acc += a as SignedDoubleBigDigit;
-    *acc -= b as SignedDoubleBigDigit;
+    *acc += SignedDoubleBigDigit::from(a);
+    *acc -= SignedDoubleBigDigit::from(b);
     let lo = *acc as BigDigit;
     *acc >>= big_digit::BITS;
     lo
@@ -38,8 +38,8 @@ fn sbb(a: BigDigit, b: BigDigit, acc: &mut SignedDoubleBigDigit) -> BigDigit {
 
 #[inline]
 pub fn mac_with_carry(a: BigDigit, b: BigDigit, c: BigDigit, acc: &mut DoubleBigDigit) -> BigDigit {
-    *acc += a as DoubleBigDigit;
-    *acc += (b as DoubleBigDigit) * (c as DoubleBigDigit);
+    *acc += DoubleBigDigit::from(a);
+    *acc += DoubleBigDigit::from(b) * DoubleBigDigit::from(c);
     let lo = *acc as BigDigit;
     *acc >>= big_digit::BITS;
     lo
@@ -47,7 +47,7 @@ pub fn mac_with_carry(a: BigDigit, b: BigDigit, c: BigDigit, acc: &mut DoubleBig
 
 #[inline]
 pub fn mul_with_carry(a: BigDigit, b: BigDigit, acc: &mut DoubleBigDigit) -> BigDigit {
-    *acc += (a as DoubleBigDigit) * (b as DoubleBigDigit);
+    *acc += DoubleBigDigit::from(a) * DoubleBigDigit::from(b);
     let lo = *acc as BigDigit;
     *acc >>= big_digit::BITS;
     lo
@@ -64,7 +64,7 @@ fn div_wide(hi: BigDigit, lo: BigDigit, divisor: BigDigit) -> (BigDigit, BigDigi
     debug_assert!(hi < divisor);
 
     let lhs = big_digit::to_doublebigdigit(hi, lo);
-    let rhs = divisor as DoubleBigDigit;
+    let rhs = DoubleBigDigit::from(divisor);
     ((lhs / rhs) as BigDigit, (lhs % rhs) as BigDigit)
 }
 

--- a/src/bigint.rs
+++ b/src/bigint.rs
@@ -219,7 +219,7 @@ impl fmt::UpperHex for BigInt {
 // ff ff -> ...f 00 01
 #[inline]
 fn negate_carry(a: BigDigit, acc: &mut DoubleBigDigit) -> BigDigit {
-    *acc += (!a) as DoubleBigDigit;
+    *acc += DoubleBigDigit::from(!a);
     let lo = *acc as BigDigit;
     *acc >>= big_digit::BITS;
     lo

--- a/src/biguint.rs
+++ b/src/biguint.rs
@@ -193,7 +193,9 @@ fn from_radix_digits_be(v: &[u8], radix: u32) -> BigUint {
     let i = if r == 0 { power } else { r };
     let (head, tail) = v.split_at(i);
 
-    let first = head.iter().fold(0, |acc, &d| acc * radix + BigDigit::from(d));
+    let first = head
+        .iter()
+        .fold(0, |acc, &d| acc * radix + BigDigit::from(d));
     data.push(first);
 
     debug_assert!(tail.len() % power == 0);
@@ -208,7 +210,9 @@ fn from_radix_digits_be(v: &[u8], radix: u32) -> BigUint {
         }
         debug_assert!(carry == 0);
 
-        let n = chunk.iter().fold(0, |acc, &d| acc * radix + BigDigit::from(d));
+        let n = chunk
+            .iter()
+            .fold(0, |acc, &d| acc * radix + BigDigit::from(d));
         add2(&mut data, &[n]);
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -199,6 +199,6 @@ mod big_digit {
     /// Join two `BigDigit`s into one `DoubleBigDigit`
     #[inline]
     pub fn to_doublebigdigit(hi: BigDigit, lo: BigDigit) -> DoubleBigDigit {
-        (lo as DoubleBigDigit) | ((hi as DoubleBigDigit) << BITS)
+        DoubleBigDigit::from(lo) | (DoubleBigDigit::from(hi) << BITS)
     }
 }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -215,6 +215,8 @@ macro_rules! promote_scalars {
             impl $imp<$scalar> for $res {
                 type Output = $res;
 
+                #[cfg_attr(feature = "cargo-clippy", allow(renamed_and_removed_lints))]
+                #[cfg_attr(feature = "cargo-clippy", allow(cast_lossless))]
                 #[inline]
                 fn $method(self, other: $scalar) -> $res {
                     $imp::$method(self, other as $promo)
@@ -224,6 +226,8 @@ macro_rules! promote_scalars {
             impl $imp<$res> for $scalar {
                 type Output = $res;
 
+                #[cfg_attr(feature = "cargo-clippy", allow(renamed_and_removed_lints))]
+                #[cfg_attr(feature = "cargo-clippy", allow(cast_lossless))]
                 #[inline]
                 fn $method(self, other: $res) -> $res {
                     $imp::$method(self as $promo, other)
@@ -236,6 +240,8 @@ macro_rules! promote_scalars_assign {
     (impl $imp:ident<$promo:ty> for $res:ty, $method:ident, $( $scalar:ty ),*) => {
         $(
             impl $imp<$scalar> for $res {
+                #[cfg_attr(feature = "cargo-clippy", allow(renamed_and_removed_lints))]
+                #[cfg_attr(feature = "cargo-clippy", allow(cast_lossless))]
                 #[inline]
                 fn $method(&mut self, other: $scalar) {
                     self.$method(other as $promo);

--- a/src/monty.rs
+++ b/src/monty.rs
@@ -16,8 +16,8 @@ fn inv_mod_u32(num: u32) -> u32 {
     // num needs to be relatively prime to 2**32 -- i.e. it must be odd.
     assert!(num % 2 != 0);
 
-    let mut a: i64 = num as i64;
-    let mut b: i64 = (u32::max_value() as i64) + 1;
+    let mut a: i64 = i64::from(num);
+    let mut b: i64 = i64::from(u32::max_value()) + 1;
 
     // ExtendedGcd
     // Input: positive integers a and b


### PR DESCRIPTION
Resolves #66

### Note about clippy

As suggested in the issue, I used `cargo clippy` to find instances of casting using `as`. Running clippy reports a ton of warnings and some errors, so I used the following command to allow `clippy::all` but warn on `clippy::cast_lossless`, and output to file:

```
cargo clippy -- -A clippy::all -W clippy::cast_lossless > /path/to/output.txt 2>&1
```

### Unhandled cases

There were two cases reported by clippy which I did **not** handle. The first case is casting that involves macro invocation and the warning looks like the following:

```
warning: casting u8 to u32 may become silently lossy if types change
   --> src/macros.rs:220:41
    |
220 |                       $imp::$method(self, other as $promo)
    |  _________________________________________^
221 | |                 }
222 | |             }
223 | |
...   |
249 | |     (impl $imp:ident for $res:ty, $method:ident) => {
250 | |         promote_scalars!(impl $imp<u32> for $res, $method, u8, u16);
    | |______________________________________^ help: try: `u32::from(other)`
    | 
   ::: src/bigint.rs:964:1
    |
964 |   promote_all_scalars!(impl Add for BigInt, add);
    |   ----------------------------------------------- in this macro invocation
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#cast_lossless
```

The second case was when clippy recommends `i64::from(n)` for example, but making the change causes a compilation error:

```
2351 |                 BigInt::from(i64::from(n))
     |                              ^^^^^^^^^ the trait `std::convert::From<isize>` is not implemented for `i64`
```

### Undetected

I also noticed that there are some instances of casting using `as` that are not reported by clippy. I'm not sure if this is a bug in clippy, or if there's a reason clippy didn't report them. For now, I also ignored these undetected instances.

### How the changes were made

For standard types, I simply followed clippy's suggestion, e.g. `u32::from(c)`.

For internal types such as `DoubleBigDigit`, clippy would suggest to use `u64::from()`, but I used `DoubleBigDigit::from()` instead.

To avoid any potential changes in behavior, I kept all parenthesis I encountered. In the following example, it looks safe to remove them, but I kept them all for consistency:

```
# previously:
*acc += (b as DoubleBigDigit) * (c as DoubleBigDigit);

# replaced with:
*acc += (DoubleBigDigit::from(b)) * (DoubleBigDigit::from(c));
```

Should I remove the parenthesis when it's clearly safe, but keep them when I'm not sure? Or maybe I should remove all of them, and let the tests catch any potential issue?

Please advise if I should try to fix the undetected instances. Also, I didn't review casting with `as` in the comments/documentation. Should I look into the comments too?

If I make these additional changes, let me know if I should squash all changes into one commit.
