### PR TITLE
Add by value div_rem

### DIFF
--- a/benches/bigint.rs
+++ b/benches/bigint.rs
@@ -37,6 +37,14 @@ fn divide_bench(b: &mut Bencher, xbits: usize, ybits: usize) {
     b.iter(|| &x / &y);
 }
 
+fn remainder_bench(b: &mut Bencher, xbits: usize, ybits: usize) {
+    let mut rng = get_rng();
+    let x = rng.gen_bigint(xbits);
+    let y = rng.gen_bigint(ybits);
+
+    b.iter(|| &x % &y);
+}
+
 fn factorial(n: usize) -> BigUint {
     let mut f: BigUint = One::one();
     for i in 1..(n + 1) {
@@ -102,6 +110,21 @@ fn divide_1(b: &mut Bencher) {
 #[bench]
 fn divide_2(b: &mut Bencher) {
     divide_bench(b, 1 << 16, 1 << 12);
+}
+
+#[bench]
+fn remainder_0(b: &mut Bencher) {
+    remainder_bench(b, 1 << 8, 1 << 6);
+}
+
+#[bench]
+fn remainder_1(b: &mut Bencher) {
+    remainder_bench(b, 1 << 12, 1 << 8);
+}
+
+#[bench]
+fn remainder_2(b: &mut Bencher) {
+    remainder_bench(b, 1 << 16, 1 << 12);
 }
 
 #[bench]

--- a/src/algorithms.rs
+++ b/src/algorithms.rs
@@ -525,9 +525,7 @@ pub fn div_rem(mut u: BigUint, mut d: BigUint) -> (BigUint, BigUint) {
     match u.cmp(&d) {
         Less => return (Zero::zero(), u),
         Equal => {
-            // TODO: use One::set_one in case it gets added to num_traits
-            u.data.clear();
-            u.data.push(1);
+            u.set_one();
             return (u, Zero::zero());
         }
         Greater => {} // Do nothing


### PR DESCRIPTION
Previously all calls to div/rem were using `algorithms::div_rem(u: &BigUint, d: &BigUint) -> (BigUint, BigUint)`. I renamed this method to `div_rem_ref` and added `algorithms::div_rem(u: BigUint, d: BigUint) -> (BigUint, BigUint)`. I also used this new method in `biguint.rs` when applicable. This reduces the amount of allocations needed.