### PR TITLE
update min rustc for the rug crate

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ table offers a brief comparison to a few alternatives.
 | :--------------- | :------------- | :-------- | :------------- |
 | **`num-bigint`** | MIT/Apache-2.0 | 1.15      | pure rust |
 | [`ramp`]         | Apache-2.0     | nightly   | rust and inline assembly |
-| [`rug`]          | LGPL-3.0+      | 1.18      | bundles [GMP] via [`gmp-mpfr-sys`] |
+| [`rug`]          | LGPL-3.0+      | 1.31      | bundles [GMP] via [`gmp-mpfr-sys`] |
 | [`rust-gmp`]     | MIT            | stable?   | links to [GMP] |
 | [`apint`]        | MIT/Apache-2.0 | 1.26      | pure rust (unfinished) |
 


### PR DESCRIPTION
Rug 1.4.0 now requires rust 1.31.