### PR TITLE
Add to_u32_digits to both BigInt and BigUint

### DIFF
--- a/src/bigint.rs
+++ b/src/bigint.rs
@@ -2777,6 +2777,24 @@ impl BigInt {
         (self.sign, self.data.to_bytes_le())
     }
 
+    /// Returns the sign and the u32 digits representation of the `BigInt` in little-endian order.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use num_bigint::{BigInt, Sign};
+    ///
+    /// assert_eq!(BigInt::from(-1125).to_u32_digits(), (Sign::Minus, vec![1125]));
+    /// assert_eq!(BigInt::from(4294967295u32).to_u32_digits(), (Sign::Plus, vec![4294967295]));
+    /// assert_eq!(BigInt::from(4294967296u64).to_u32_digits(), (Sign::Plus, vec![0, 1]));
+    /// assert_eq!(BigInt::from(-112500000000i64).to_u32_digits(), (Sign::Minus, vec![830850304, 26]));
+    /// assert_eq!(BigInt::from(112500000000i64).to_u32_digits(), (Sign::Plus, vec![830850304, 26]));
+    /// ```
+    #[inline]
+    pub fn to_u32_digits(&self) -> (Sign, Vec<u32>) {
+        (self.sign, self.data.to_u32_digits())
+    }
+
     /// Returns the two's complement byte representation of the `BigInt` in big-endian byte order.
     ///
     /// # Examples

--- a/src/biguint.rs
+++ b/src/biguint.rs
@@ -2120,6 +2120,23 @@ impl BigUint {
         }
     }
 
+    /// Returns the u32 digits representation of the `BigUint` in little-endian order.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use num_bigint::BigUint;
+    ///
+    /// assert_eq!(BigUint::from(1125u32).to_u32_digits(), vec![1125]);
+    /// assert_eq!(BigUint::from(4294967295u32).to_u32_digits(), vec![4294967295]);
+    /// assert_eq!(BigUint::from(4294967296u64).to_u32_digits(), vec![0, 1]);
+    /// assert_eq!(BigUint::from(112500000000u64).to_u32_digits(), vec![830850304, 26]);
+    /// ```
+    #[inline]
+    pub fn to_u32_digits(&self) -> Vec<u32> {
+        self.data.clone()
+    }
+
     /// Returns the integer formatted as a string in the given radix.
     /// `radix` must be in the range `2...36`.
     ///


### PR DESCRIPTION
This add access to the u32 internal representation but because it returns a Vec of u32, doesn't force you to commit to this internal representation.