### PR TITLE
Add PartialEq and PartialOrd between built in integer types and BigInt/BigUint

### DIFF
--- a/src/algorithms.rs
+++ b/src/algorithms.rs
@@ -752,7 +752,7 @@ pub fn cmp_zero_padded_slice(a: &[BigDigit], b: &[BigDigit]) -> Ordering {
         }
     }
 
-    let shortest = core::cmp::min(a_len, b_len);
+    let shortest = ::std::cmp::min(a_len, b_len);
     let ashort = &a[0..shortest];
     let bshort = &b[0..shortest];
 

--- a/src/algorithms.rs
+++ b/src/algorithms.rs
@@ -817,8 +817,8 @@ mod algorithm_tests {
 
     #[test]
     fn test_cmp_zero_padded_slice() {
-        use std::cmp::Ordering::*;
         use super::cmp_zero_padded_slice;
+        use std::cmp::Ordering::*;
 
         assert!(cmp_zero_padded_slice(&[1, 0], &[1]) == Equal);
         assert!(cmp_zero_padded_slice(&[1], &[1, 0]) == Equal);
@@ -839,5 +839,4 @@ mod algorithm_tests {
         assert!(cmp_zero_padded_slice(&[0, 0, 0], &[1000, 0]) == Less);
         assert!(cmp_zero_padded_slice(&[0, 1000], &[0, 1000, 0]) == Equal);
     }
-
 }

--- a/src/algorithms.rs
+++ b/src/algorithms.rs
@@ -752,7 +752,7 @@ pub fn cmp_zero_padded_slice(a: &[BigDigit], b: &[BigDigit]) -> Ordering {
         }
     }
 
-    let shortest = std::cmp::min(a_len, b_len);
+    let shortest = core::cmp::min(a_len, b_len);
     let ashort = &a[0..shortest];
     let bshort = &b[0..shortest];
 

--- a/src/bigint.rs
+++ b/src/bigint.rs
@@ -164,7 +164,10 @@ impl PartialOrd for BigInt {
     }
 }
 
-fn sign<T>(num: T) -> Sign where T: Ord + Zero {
+fn sign<T>(num: T) -> Sign
+where
+    T: Ord + Zero,
+{
     if num < T::zero() {
         Sign::Minus
     } else if num > T::zero() {

--- a/src/bigint.rs
+++ b/src/bigint.rs
@@ -714,7 +714,7 @@ impl Num for BigInt {
         } else {
             Plus
         };
-        let bu = try!(BigUint::from_str_radix(s, radix));
+        let bu = BigUint::from_str_radix(s, radix)?;
         Ok(BigInt::from_biguint(sign, bu))
     }
 }

--- a/src/bigint.rs
+++ b/src/bigint.rs
@@ -164,6 +164,23 @@ impl PartialOrd for BigInt {
     }
 }
 
+fn sign<T>(num: T) -> Sign where T: Ord + Zero {
+    if num < T::zero() {
+        Sign::Minus
+    } else if num > T::zero() {
+        Sign::Plus
+    } else {
+        Sign::NoSign
+    }
+}
+
+impl_partialord_partialeq_for_bigint!(i8, u8);
+impl_partialord_partialeq_for_bigint!(i16, u16);
+impl_partialord_partialeq_for_bigint!(i32, u32);
+impl_partialord_partialeq_for_bigint!(i64, u64);
+#[cfg(has_i128)]
+impl_partialord_partialeq_for_bigint!(i128, u128);
+
 impl Ord for BigInt {
     #[inline]
     fn cmp(&self, other: &BigInt) -> Ordering {

--- a/src/biguint.rs
+++ b/src/biguint.rs
@@ -89,9 +89,9 @@ impl Ord for BigUint {
     }
 }
 
-impl_partialord_partialeq_for_biguint_below_digit!(i8, u8);
-impl_partialord_partialeq_for_biguint_below_digit!(i16, u16);
-impl_partialord_partialeq_for_biguint_below_digit!(i32, u32);
+impl_partialord_partialeq_for_biguint_below_digit!(u8);
+impl_partialord_partialeq_for_biguint_below_digit!(u16);
+impl_partialord_partialeq_for_biguint_below_digit!(u32);
 
 impl_scalar_partialeq!(impl PartialEq<u64> for BigUint);
 impl_partialord_rev!(impl PartialOrd<u64> for BigUint);
@@ -100,18 +100,6 @@ impl PartialOrd<u64> for BigUint {
     fn partial_cmp(&self, other: &u64) -> Option<Ordering> {
         let (hi, lo) = big_digit::from_doublebigdigit(*other);
         Some(cmp_zero_padded_slice(&self.data[..], &[lo, hi]))
-    }
-}
-impl_scalar_partialeq!(impl PartialEq<i64> for BigUint);
-impl_partialord_rev!(impl PartialOrd<i64> for BigUint);
-impl PartialOrd<i64> for BigUint {
-    #[inline]
-    fn partial_cmp(&self, other: &i64) -> Option<Ordering> {
-        if *other < 0 {
-            Some(Greater)
-        } else {
-            self.partial_cmp(&(*other as u64))
-        }
     }
 }
 
@@ -125,21 +113,6 @@ impl PartialOrd<u128> for BigUint {
     fn partial_cmp(&self, other: &u128) -> Option<Ordering> {
         let (a, b, c, d) = u32_from_u128(*other);
         Some(cmp_zero_padded_slice(&self.data[..], &[d, c, b, a]))
-    }
-}
-#[cfg(has_i128)]
-impl_scalar_partialeq!(impl PartialEq<i128> for BigUint);
-#[cfg(has_i128)]
-impl_partialord_rev!(impl PartialOrd<i128> for BigUint);
-#[cfg(has_i128)]
-impl PartialOrd<i128> for BigUint {
-    #[inline]
-    fn partial_cmp(&self, other: &i128) -> Option<Ordering> {
-        if *other < 0 {
-            Some(Greater)
-        } else {
-            self.partial_cmp(&(*other as u128))
-        }
     }
 }
 

--- a/src/biguint.rs
+++ b/src/biguint.rs
@@ -33,7 +33,7 @@ mod monty;
 
 use self::algorithms::{__add2, __sub2rev, add2, sub2, sub2rev};
 use self::algorithms::{biguint_shl, biguint_shr};
-use self::algorithms::{cmp_slice, fls, ilog2};
+use self::algorithms::{cmp_slice, cmp_zero_padded_slice, fls, ilog2};
 use self::algorithms::{div_rem, div_rem_digit, div_rem_ref, rem_digit};
 use self::algorithms::{mac_with_carry, mul3, scalar_mul};
 use self::monty::monty_modpow;
@@ -86,6 +86,60 @@ impl Ord for BigUint {
     #[inline]
     fn cmp(&self, other: &BigUint) -> Ordering {
         cmp_slice(&self.data[..], &other.data[..])
+    }
+}
+
+impl_partialord_partialeq_for_biguint_below_digit!(i8, u8);
+impl_partialord_partialeq_for_biguint_below_digit!(i16, u16);
+impl_partialord_partialeq_for_biguint_below_digit!(i32, u32);
+
+impl_scalar_partialeq!(impl PartialEq<u64> for BigUint);
+impl_partialord_rev!(impl PartialOrd<u64> for BigUint);
+impl PartialOrd<u64> for BigUint {
+    #[inline]
+    fn partial_cmp(&self, other: &u64) -> Option<Ordering> {
+        let (hi, lo) = big_digit::from_doublebigdigit(*other);
+        Some(cmp_zero_padded_slice(&self.data[..], &[lo, hi]))
+    }
+}
+impl_scalar_partialeq!(impl PartialEq<i64> for BigUint);
+impl_partialord_rev!(impl PartialOrd<i64> for BigUint);
+impl PartialOrd<i64> for BigUint {
+    #[inline]
+    fn partial_cmp(&self, other: &i64) -> Option<Ordering> {
+        if *other < 0 {
+            Some(Greater)
+        } else {
+            self.partial_cmp(&(*other as u64))
+        }
+    }
+}
+
+#[cfg(has_i128)]
+impl_scalar_partialeq!(impl PartialEq<u128> for BigUint);
+#[cfg(has_i128)]
+impl_partialord_rev!(impl PartialOrd<u128> for BigUint);
+#[cfg(has_i128)]
+impl PartialOrd<u128> for BigUint {
+    #[inline]
+    fn partial_cmp(&self, other: &u128) -> Option<Ordering> {
+        let (a, b, c, d) = u32_from_u128(*other);
+        Some(cmp_zero_padded_slice(&self.data[..], &[d, c, b, a]))
+    }
+}
+#[cfg(has_i128)]
+impl_scalar_partialeq!(impl PartialEq<i128> for BigUint);
+#[cfg(has_i128)]
+impl_partialord_rev!(impl PartialOrd<i128> for BigUint);
+#[cfg(has_i128)]
+impl PartialOrd<i128> for BigUint {
+    #[inline]
+    fn partial_cmp(&self, other: &i128) -> Option<Ordering> {
+        if *other < 0 {
+            Some(Greater)
+        } else {
+            self.partial_cmp(&(*other as u128))
+        }
     }
 }
 

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -469,8 +469,8 @@ macro_rules! impl_scalar_partialeq {
 }
 
 macro_rules! impl_trait_rev {
-    (impl $trait:ident < $scalar:ty > for $res:ty, $method:ident, $ret:ty) => {
-        impl $trait<$res> for $scalar {
+    (impl $trait_name:ident < $scalar:ty > for $res:ty, $method:ident, $ret:ty) => {
+        impl $trait_name<$res> for $scalar {
             #[inline]
             fn $method(&self, other: &$res) -> $ret {
                 other.$method(self)

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -443,3 +443,110 @@ macro_rules! impl_product_iter_type {
         }
     };
 }
+
+/// Implements PartialEq based on PartialOrd
+macro_rules! impl_scalar_partialeq {
+    (impl PartialEq < $scalar:ty > for $res:ty) => {
+        impl PartialEq<$scalar> for $res {
+            #[inline]
+            fn eq(&self, other: &$scalar) -> bool {
+                match self.partial_cmp(other).unwrap() {
+                    Equal => true,
+                    _ => false,
+                }
+            }
+        }
+        impl PartialEq<$res> for $scalar {
+            #[inline]
+            fn eq(&self, other: &$res) -> bool {
+                match self.partial_cmp(other).unwrap() {
+                    Equal => true,
+                    _ => false,
+                }
+            }
+        }
+    };
+}
+
+macro_rules! impl_trait_rev {
+    (impl $trait:ident < $scalar:ty > for $res:ty, $method:ident, $ret:ty) => {
+        impl $trait<$res> for $scalar {
+            #[inline]
+            fn $method(&self, other: &$res) -> $ret {
+                other.$method(self)
+            }
+        }
+    };
+}
+
+macro_rules! impl_partialord_rev {
+    (impl PartialOrd < $scalar:ty > for $typ:ty) => {
+        impl PartialOrd<$typ> for $scalar {
+            #[inline]
+            fn partial_cmp(&self, other: &$typ) -> Option<Ordering> {
+                other.partial_cmp(self).map(|o| o.reverse())
+            }
+        }
+    };
+}
+
+macro_rules! impl_partialord_partialeq_for_biguint_below_digit {
+    ($typ_signed:ty, $typ_unsigned:ty) => {
+        impl_scalar_partialeq!(impl PartialEq<$typ_unsigned> for BigUint);
+        impl_partialord_rev!(impl PartialOrd<$typ_unsigned> for BigUint);
+        impl PartialOrd<$typ_unsigned> for BigUint {
+            #[inline]
+            fn partial_cmp(&self, other: &$typ_unsigned) -> Option<Ordering> {
+                Some(cmp_zero_padded_slice(&self.data[..], &[*other as u32]))
+            }
+        }
+
+        impl_scalar_partialeq!(impl PartialEq<$typ_signed> for BigUint);
+        impl_partialord_rev!(impl PartialOrd<$typ_signed> for BigUint);
+        impl PartialOrd<$typ_signed> for BigUint {
+            #[inline]
+            fn partial_cmp(&self, other: &$typ_signed) -> Option<Ordering> {
+                if *other < 0 {
+                    Some(Greater)
+                } else {
+                    self.partial_cmp(&(*other as u32))
+                }
+            }
+        }
+    };
+}
+
+macro_rules! impl_partialord_partialeq_for_bigint {
+    ($typ_signed:ty, $typ_unsigned:ty) => {
+        impl_scalar_partialeq!(impl PartialEq<$typ_signed> for BigInt);
+        impl_partialord_rev!(impl PartialOrd<$typ_signed> for BigInt);
+        impl PartialOrd<$typ_signed> for BigInt {
+            #[inline]
+            fn partial_cmp(&self, other: &$typ_signed) -> Option<Ordering> {
+                let scmp = self.sign().cmp(&sign(*other));
+                if scmp != Equal {
+                    return Some(scmp);
+                }
+
+                let abs = (*other).abs() as $typ_unsigned;
+                match self.sign {
+                    NoSign => Some(Equal),
+                    Plus => self.data.partial_cmp(&abs),
+                    Minus => abs.partial_cmp(&self.data),
+                }
+            }
+        }
+
+        impl_scalar_partialeq!(impl PartialEq<$typ_unsigned> for BigInt);
+        impl_partialord_rev!(impl PartialOrd<$typ_unsigned> for BigInt);
+        impl PartialOrd<$typ_unsigned> for BigInt {
+            #[inline]
+            fn partial_cmp(&self, other: &$typ_unsigned) -> Option<Ordering> {
+                match self.sign {
+                    Minus => Some(Less),
+                    _ => self.data.partial_cmp(other),
+                }
+            }
+        }
+    };
+}

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -491,26 +491,13 @@ macro_rules! impl_partialord_rev {
 }
 
 macro_rules! impl_partialord_partialeq_for_biguint_below_digit {
-    ($typ_signed:ty, $typ_unsigned:ty) => {
+    ($typ_unsigned:ty) => {
         impl_scalar_partialeq!(impl PartialEq<$typ_unsigned> for BigUint);
         impl_partialord_rev!(impl PartialOrd<$typ_unsigned> for BigUint);
         impl PartialOrd<$typ_unsigned> for BigUint {
             #[inline]
             fn partial_cmp(&self, other: &$typ_unsigned) -> Option<Ordering> {
                 Some(cmp_zero_padded_slice(&self.data[..], &[*other as u32]))
-            }
-        }
-
-        impl_scalar_partialeq!(impl PartialEq<$typ_signed> for BigUint);
-        impl_partialord_rev!(impl PartialOrd<$typ_signed> for BigUint);
-        impl PartialOrd<$typ_signed> for BigUint {
-            #[inline]
-            fn partial_cmp(&self, other: &$typ_signed) -> Option<Ordering> {
-                if *other < 0 {
-                    Some(Greater)
-                } else {
-                    self.partial_cmp(&(*other as u32))
-                }
             }
         }
     };

--- a/tests/bigint.rs
+++ b/tests/bigint.rs
@@ -40,8 +40,10 @@ fn test_from_bytes_be() {
     check("AA", "16705");
     check("AB", "16706");
     check("Hello world!", "22405534230753963835153736737");
-    assert_eq!(BigInt::from_bytes_be(Plus, &[]), Zero::zero());
-    assert_eq!(BigInt::from_bytes_be(Minus, &[]), Zero::zero());
+    assert_eq!(BigInt::from_bytes_be(Plus, &[]), BigInt::zero());
+    assert_eq!(BigInt::from_bytes_be(Plus, &[]), 0);
+    assert_eq!(BigInt::from_bytes_be(Minus, &[]), BigInt::zero());
+    assert_eq!(BigInt::from_bytes_be(Minus, &[]), 0);
 }
 
 #[test]
@@ -75,8 +77,8 @@ fn test_from_bytes_le() {
     check("AA", "16705");
     check("BA", "16706");
     check("!dlrow olleH", "22405534230753963835153736737");
-    assert_eq!(BigInt::from_bytes_le(Plus, &[]), Zero::zero());
-    assert_eq!(BigInt::from_bytes_le(Minus, &[]), Zero::zero());
+    assert_eq!(BigInt::from_bytes_le(Plus, &[]), BigInt::zero());
+    assert_eq!(BigInt::from_bytes_le(Minus, &[]), BigInt::zero());
 }
 
 #[test]
@@ -659,7 +661,7 @@ fn test_add() {
         assert_op!(a + nc == nb);
         assert_op!(b + nc == na);
         assert_op!(na + nb == nc);
-        assert_op!(a + na == Zero::zero());
+        assert_op!(a + na == BigInt::zero());
 
         assert_assign_op!(a += b == c);
         assert_assign_op!(b += a == c);
@@ -668,7 +670,7 @@ fn test_add() {
         assert_assign_op!(a += nc == nb);
         assert_assign_op!(b += nc == na);
         assert_assign_op!(na += nb == nc);
-        assert_assign_op!(a += na == Zero::zero());
+        assert_assign_op!(a += na == BigInt::zero());
     }
 }
 
@@ -688,7 +690,7 @@ fn test_sub() {
         assert_op!(b - na == c);
         assert_op!(a - nb == c);
         assert_op!(nc - na == nb);
-        assert_op!(a - a == Zero::zero());
+        assert_op!(a - a == BigInt::zero());
 
         assert_assign_op!(c -= a == b);
         assert_assign_op!(c -= b == a);
@@ -697,7 +699,7 @@ fn test_sub() {
         assert_assign_op!(b -= na == c);
         assert_assign_op!(a -= nb == c);
         assert_assign_op!(nc -= na == nb);
-        assert_assign_op!(a -= a == Zero::zero());
+        assert_assign_op!(a -= a == BigInt::zero());
     }
 }
 
@@ -859,7 +861,7 @@ fn test_checked_add() {
         assert!(a.checked_add(&(-&c)).unwrap() == (-&b));
         assert!(b.checked_add(&(-&c)).unwrap() == (-&a));
         assert!((-&a).checked_add(&(-&b)).unwrap() == (-&c));
-        assert!(a.checked_add(&(-&a)).unwrap() == Zero::zero());
+        assert!(a.checked_add(&(-&a)).unwrap() == BigInt::zero());
     }
 }
 
@@ -878,7 +880,7 @@ fn test_checked_sub() {
         assert!(b.checked_sub(&(-&a)).unwrap() == c);
         assert!(a.checked_sub(&(-&b)).unwrap() == c);
         assert!((-&c).checked_sub(&(-&a)).unwrap() == (-&b));
-        assert!(a.checked_sub(&a).unwrap() == Zero::zero());
+        assert!(a.checked_sub(&a).unwrap() == BigInt::zero());
     }
 }
 
@@ -1119,8 +1121,8 @@ fn test_iter_sum() {
         FromPrimitive::from_i32(-7).unwrap(),
     ];
 
-    assert_eq!(result, data.iter().sum());
-    assert_eq!(result, data.into_iter().sum());
+    assert_eq!(result, data.iter().sum::<BigInt>());
+    assert_eq!(result, data.into_iter().sum::<BigInt>());
 }
 
 #[test]
@@ -1138,8 +1140,8 @@ fn test_iter_product() {
         * data.get(3).unwrap()
         * data.get(4).unwrap();
 
-    assert_eq!(result, data.iter().product());
-    assert_eq!(result, data.into_iter().product());
+    assert_eq!(result, data.iter().product::<BigInt>());
+    assert_eq!(result, data.into_iter().product::<BigInt>());
 }
 
 #[test]
@@ -1147,8 +1149,8 @@ fn test_iter_sum_generic() {
     let result: BigInt = FromPrimitive::from_isize(-1234567).unwrap();
     let data = vec![-1000000, -200000, -30000, -4000, -500, -60, -7];
 
-    assert_eq!(result, data.iter().sum());
-    assert_eq!(result, data.into_iter().sum());
+    assert_eq!(result, data.iter().sum::<BigInt>());
+    assert_eq!(result, data.into_iter().sum::<BigInt>());
 }
 
 #[test]
@@ -1160,8 +1162,8 @@ fn test_iter_product_generic() {
         * data[3].to_bigint().unwrap()
         * data[4].to_bigint().unwrap();
 
-    assert_eq!(result, data.iter().product());
-    assert_eq!(result, data.into_iter().product());
+    assert_eq!(result, data.iter().product::<BigInt>());
+    assert_eq!(result, data.into_iter().product::<BigInt>());
 }
 
 #[test]

--- a/tests/bigint_scalar.rs
+++ b/tests/bigint_scalar.rs
@@ -5,8 +5,8 @@ use num_bigint::BigInt;
 use num_bigint::Sign::Plus;
 use num_traits::{Signed, ToPrimitive, Zero};
 
-use std::ops::Neg;
 use std::cmp::Ordering;
+use std::ops::Neg;
 
 mod consts;
 use consts::*;

--- a/tests/bigint_scalar.rs
+++ b/tests/bigint_scalar.rs
@@ -145,58 +145,6 @@ fn test_scalar_div_rem() {
     }
 }
 
-macro_rules! bigint_scalar_cmp_asserts {
-    ($big:expr, $scalar:expr) => {
-
-        assert!($big.partial_cmp(&($scalar as i8)) == Some(Ordering::Equal));
-        assert!(($scalar as i8).partial_cmp(&$big) == Some(Ordering::Equal));
-        assert!($big.partial_cmp(&($scalar as i8 - 1)) == Some(Ordering::Greater));
-        assert!(($scalar as i8 + 1).partial_cmp(&$big) == Some(Ordering::Greater));
-        assert!($big.partial_cmp(&($scalar as i8 + 1)) == Some(Ordering::Less));
-        assert!(($scalar as i8 - 1).partial_cmp(&$big) == Some(Ordering::Less));
-
-        assert!($big.partial_cmp(&($scalar as i16)) == Some(Ordering::Equal));
-        assert!(($scalar as i16).partial_cmp(&$big) == Some(Ordering::Equal));
-        assert!($big.partial_cmp(&($scalar as i16 - 1)) == Some(Ordering::Greater));
-        assert!(($scalar as i16 + 1).partial_cmp(&$big) == Some(Ordering::Greater));
-        assert!($big.partial_cmp(&($scalar as i16 + 1)) == Some(Ordering::Less));
-        assert!(($scalar as i16 - 1).partial_cmp(&$big) == Some(Ordering::Less));
-
-        assert!($big.partial_cmp(&($scalar as i32)) == Some(Ordering::Equal));
-        assert!(($scalar as i32).partial_cmp(&$big) == Some(Ordering::Equal));
-        assert!($big.partial_cmp(&($scalar as i32 - 1)) == Some(Ordering::Greater));
-        assert!(($scalar as i32 + 1).partial_cmp(&$big) == Some(Ordering::Greater));
-        assert!($big.partial_cmp(&($scalar as i32 + 1)) == Some(Ordering::Less));
-        assert!(($scalar as i32 - 1).partial_cmp(&$big) == Some(Ordering::Less));
-
-        assert!($big.partial_cmp(&($scalar as i64)) == Some(Ordering::Equal));
-        assert!(($scalar as i64).partial_cmp(&$big) == Some(Ordering::Equal));
-        assert!($big.partial_cmp(&($scalar as i64 - 1)) == Some(Ordering::Greater));
-        assert!(($scalar as i64 + 1).partial_cmp(&$big) == Some(Ordering::Greater));
-        assert!($big.partial_cmp(&($scalar as i64 + 1)) == Some(Ordering::Less));
-        assert!(($scalar as i64 - 1).partial_cmp(&$big) == Some(Ordering::Less));
-
-        assert!(($scalar as i8) == $big);
-        assert!($big == ($scalar as i16));
-        assert!(($scalar as i16) == $big);
-        assert!($big == ($scalar as i32));
-        assert!(($scalar as i32) == $big);
-        assert!($big == ($scalar as i64));
-        assert!(($scalar as i64) == $big);
-
-        if $scalar > 0 {
-            assert!($big == ($scalar as u8));
-            assert!(($scalar as u8) == $big);
-            assert!($big == ($scalar as u16));
-            assert!(($scalar as u16) == $big);
-            assert!($big == ($scalar as u32));
-            assert!(($scalar as u32) == $big);
-            assert!($big == ($scalar as u64));
-            assert!(($scalar as u64) == $big);
-        }
-    };
-}
-
 #[test]
 fn test_bigint_scalar_cmp() {
     let m_five = BigInt::from(-5);

--- a/tests/bigint_scalar.rs
+++ b/tests/bigint_scalar.rs
@@ -6,6 +6,7 @@ use num_bigint::Sign::Plus;
 use num_traits::{Signed, ToPrimitive, Zero};
 
 use std::ops::Neg;
+use std::cmp::Ordering;
 
 mod consts;
 use consts::*;
@@ -93,7 +94,7 @@ fn test_scalar_div_rem() {
         if !r.is_zero() {
             assert_eq!(r.sign(), a.sign());
         }
-        assert!(r.abs() <= From::from(b));
+        assert!(r.abs() <= b);
         assert!(*a == b * &q + &r);
         assert!(q == *ans_q);
         assert!(r == *ans_r);
@@ -142,4 +143,120 @@ fn test_scalar_div_rem() {
             check(&a, b, &c, &d);
         }
     }
+}
+
+macro_rules! bigint_scalar_cmp_asserts {
+    ($big:expr, $scalar:expr) => {
+
+        assert!($big.partial_cmp(&($scalar as i8)) == Some(Ordering::Equal));
+        assert!(($scalar as i8).partial_cmp(&$big) == Some(Ordering::Equal));
+        assert!($big.partial_cmp(&($scalar as i8 - 1)) == Some(Ordering::Greater));
+        assert!(($scalar as i8 + 1).partial_cmp(&$big) == Some(Ordering::Greater));
+        assert!($big.partial_cmp(&($scalar as i8 + 1)) == Some(Ordering::Less));
+        assert!(($scalar as i8 - 1).partial_cmp(&$big) == Some(Ordering::Less));
+
+        assert!($big.partial_cmp(&($scalar as i16)) == Some(Ordering::Equal));
+        assert!(($scalar as i16).partial_cmp(&$big) == Some(Ordering::Equal));
+        assert!($big.partial_cmp(&($scalar as i16 - 1)) == Some(Ordering::Greater));
+        assert!(($scalar as i16 + 1).partial_cmp(&$big) == Some(Ordering::Greater));
+        assert!($big.partial_cmp(&($scalar as i16 + 1)) == Some(Ordering::Less));
+        assert!(($scalar as i16 - 1).partial_cmp(&$big) == Some(Ordering::Less));
+
+        assert!($big.partial_cmp(&($scalar as i32)) == Some(Ordering::Equal));
+        assert!(($scalar as i32).partial_cmp(&$big) == Some(Ordering::Equal));
+        assert!($big.partial_cmp(&($scalar as i32 - 1)) == Some(Ordering::Greater));
+        assert!(($scalar as i32 + 1).partial_cmp(&$big) == Some(Ordering::Greater));
+        assert!($big.partial_cmp(&($scalar as i32 + 1)) == Some(Ordering::Less));
+        assert!(($scalar as i32 - 1).partial_cmp(&$big) == Some(Ordering::Less));
+
+        assert!($big.partial_cmp(&($scalar as i64)) == Some(Ordering::Equal));
+        assert!(($scalar as i64).partial_cmp(&$big) == Some(Ordering::Equal));
+        assert!($big.partial_cmp(&($scalar as i64 - 1)) == Some(Ordering::Greater));
+        assert!(($scalar as i64 + 1).partial_cmp(&$big) == Some(Ordering::Greater));
+        assert!($big.partial_cmp(&($scalar as i64 + 1)) == Some(Ordering::Less));
+        assert!(($scalar as i64 - 1).partial_cmp(&$big) == Some(Ordering::Less));
+
+        assert!(($scalar as i8) == $big);
+        assert!($big == ($scalar as i16));
+        assert!(($scalar as i16) == $big);
+        assert!($big == ($scalar as i32));
+        assert!(($scalar as i32) == $big);
+        assert!($big == ($scalar as i64));
+        assert!(($scalar as i64) == $big);
+
+        if $scalar > 0 {
+            assert!($big == ($scalar as u8));
+            assert!(($scalar as u8) == $big);
+            assert!($big == ($scalar as u16));
+            assert!(($scalar as u16) == $big);
+            assert!($big == ($scalar as u32));
+            assert!(($scalar as u32) == $big);
+            assert!($big == ($scalar as u64));
+            assert!(($scalar as u64) == $big);
+        }
+    };
+}
+
+#[test]
+fn test_bigint_scalar_cmp() {
+    let m_five = BigInt::from(-5);
+    let m_one = BigInt::from(-1);
+    let zero = BigInt::from(0);
+    let one = BigInt::from(1);
+    let five = BigInt::from(5);
+
+    fn cmp_asserts(big: &BigInt, scalar: i32) {
+        assert!(big.partial_cmp(&(scalar as i8)) == Some(Ordering::Equal));
+        assert!((scalar as i8).partial_cmp(big) == Some(Ordering::Equal));
+        assert!(big.partial_cmp(&(scalar as i8 - 1)) == Some(Ordering::Greater));
+        assert!((scalar as i8 + 1).partial_cmp(big) == Some(Ordering::Greater));
+        assert!(big.partial_cmp(&(scalar as i8 + 1)) == Some(Ordering::Less));
+        assert!((scalar as i8 - 1).partial_cmp(big) == Some(Ordering::Less));
+
+        assert!(big.partial_cmp(&(scalar as i16)) == Some(Ordering::Equal));
+        assert!((scalar as i16).partial_cmp(big) == Some(Ordering::Equal));
+        assert!(big.partial_cmp(&(scalar as i16 - 1)) == Some(Ordering::Greater));
+        assert!((scalar as i16 + 1).partial_cmp(big) == Some(Ordering::Greater));
+        assert!(big.partial_cmp(&(scalar as i16 + 1)) == Some(Ordering::Less));
+        assert!((scalar as i16 - 1).partial_cmp(big) == Some(Ordering::Less));
+
+        assert!(big.partial_cmp(&(scalar as i32)) == Some(Ordering::Equal));
+        assert!((scalar as i32).partial_cmp(big) == Some(Ordering::Equal));
+        assert!(big.partial_cmp(&(scalar as i32 - 1)) == Some(Ordering::Greater));
+        assert!((scalar as i32 + 1).partial_cmp(big) == Some(Ordering::Greater));
+        assert!(big.partial_cmp(&(scalar as i32 + 1)) == Some(Ordering::Less));
+        assert!((scalar as i32 - 1).partial_cmp(big) == Some(Ordering::Less));
+
+        assert!(big.partial_cmp(&(scalar as i64)) == Some(Ordering::Equal));
+        assert!((scalar as i64).partial_cmp(big) == Some(Ordering::Equal));
+        assert!(big.partial_cmp(&(scalar as i64 - 1)) == Some(Ordering::Greater));
+        assert!((scalar as i64 + 1).partial_cmp(big) == Some(Ordering::Greater));
+        assert!(big.partial_cmp(&(scalar as i64 + 1)) == Some(Ordering::Less));
+        assert!((scalar as i64 - 1).partial_cmp(big) == Some(Ordering::Less));
+
+        assert!((scalar as i8) == *big);
+        assert!(*big == (scalar as i16));
+        assert!((scalar as i16) == *big);
+        assert!(*big == (scalar as i32));
+        assert!((scalar as i32) == *big);
+        assert!(*big == (scalar as i64));
+        assert!((scalar as i64) == *big);
+
+        if scalar > 0 {
+            assert!(*big == (scalar as u8));
+            assert!((scalar as u8) == *big);
+            assert!(*big == (scalar as u16));
+            assert!((scalar as u16) == *big);
+            assert!(*big == (scalar as u32));
+            assert!((scalar as u32) == *big);
+            assert!(*big == (scalar as u64));
+            assert!((scalar as u64) == *big);
+        }
+    }
+
+    cmp_asserts(&zero, 0i32);
+    cmp_asserts(&one, 1i32);
+    cmp_asserts(&five, 5i32);
+    cmp_asserts(&m_five, -5i32);
+    cmp_asserts(&m_one, -1i32);
 }

--- a/tests/biguint.rs
+++ b/tests/biguint.rs
@@ -41,7 +41,7 @@ fn test_from_bytes_be() {
     check("AA", "16705");
     check("AB", "16706");
     check("Hello world!", "22405534230753963835153736737");
-    assert_eq!(BigUint::from_bytes_be(&[]), Zero::zero());
+    assert_eq!(BigUint::from_bytes_be(&[]), BigUint::zero());
 }
 
 #[test]
@@ -74,7 +74,7 @@ fn test_from_bytes_le() {
     check("AA", "16705");
     check("BA", "16706");
     check("!dlrow olleH", "22405534230753963835153736737");
-    assert_eq!(BigUint::from_bytes_le(&[]), Zero::zero());
+    assert_eq!(BigUint::from_bytes_le(&[]), BigUint::zero());
 }
 
 #[test]
@@ -872,17 +872,17 @@ fn test_div_rem() {
 
         if !a.is_zero() {
             assert_op!(c / a == b);
-            assert_op!(c % a == Zero::zero());
+            assert_op!(c % a == BigUint::zero());
             assert_assign_op!(c /= a == b);
-            assert_assign_op!(c %= a == Zero::zero());
-            assert_eq!(c.div_rem(&a), (b.clone(), Zero::zero()));
+            assert_assign_op!(c %= a == BigUint::zero());
+            assert_eq!(c.div_rem(&a), (b.clone(), BigUint::zero()));
         }
         if !b.is_zero() {
             assert_op!(c / b == a);
-            assert_op!(c % b == Zero::zero());
+            assert_op!(c % b == BigUint::zero());
             assert_assign_op!(c /= b == a);
-            assert_assign_op!(c %= b == Zero::zero());
-            assert_eq!(c.div_rem(&b), (a.clone(), Zero::zero()));
+            assert_assign_op!(c %= b == BigUint::zero());
+            assert_eq!(c.div_rem(&b), (a.clone(), BigUint::zero()));
         }
     }
 
@@ -1638,8 +1638,8 @@ fn test_iter_sum() {
         FromPrimitive::from_u32(7).unwrap(),
     ];
 
-    assert_eq!(result, data.iter().sum());
-    assert_eq!(result, data.into_iter().sum());
+    assert_eq!(result, data.iter().sum::<BigUint>());
+    assert_eq!(result, data.into_iter().sum::<BigUint>());
 }
 
 #[test]
@@ -1657,8 +1657,8 @@ fn test_iter_product() {
         * data.get(3).unwrap()
         * data.get(4).unwrap();
 
-    assert_eq!(result, data.iter().product());
-    assert_eq!(result, data.into_iter().product());
+    assert_eq!(result, data.iter().product::<BigUint>());
+    assert_eq!(result, data.into_iter().product::<BigUint>());
 }
 
 #[test]
@@ -1666,8 +1666,8 @@ fn test_iter_sum_generic() {
     let result: BigUint = FromPrimitive::from_isize(1234567).unwrap();
     let data = vec![1000000_u32, 200000, 30000, 4000, 500, 60, 7];
 
-    assert_eq!(result, data.iter().sum());
-    assert_eq!(result, data.into_iter().sum());
+    assert_eq!(result, data.iter().sum::<BigUint>());
+    assert_eq!(result, data.into_iter().sum::<BigUint>());
 }
 
 #[test]
@@ -1679,8 +1679,8 @@ fn test_iter_product_generic() {
         * data[3].to_biguint().unwrap()
         * data[4].to_biguint().unwrap();
 
-    assert_eq!(result, data.iter().product());
-    assert_eq!(result, data.into_iter().product());
+    assert_eq!(result, data.iter().product::<BigUint>());
+    assert_eq!(result, data.into_iter().product::<BigUint>());
 }
 
 #[test]

--- a/tests/biguint_scalar.rs
+++ b/tests/biguint_scalar.rs
@@ -117,7 +117,6 @@ fn test_biguint_scalar_cmp() {
     let five = BigUint::from(5u32);
 
     fn scalar_cmp_asserts(num: &BigUint, scalar: i32) {
-
         assert!(num.partial_cmp(&(scalar as i8)) == Some(Equal));
         assert!((scalar as i8).partial_cmp(num) == Some(Equal));
         assert!(num.partial_cmp(&(scalar as i8 - 1)) == Some(Greater));
@@ -180,7 +179,6 @@ fn test_biguint_scalar_cmp() {
             assert!((scalar as u128 + 1).partial_cmp(num) == Some(Greater));
             assert!(num.partial_cmp(&(scalar as u128 + 1)) == Some(Less));
         }
-
     }
 
     scalar_cmp_asserts(&zero, 0);
@@ -191,5 +189,4 @@ fn test_biguint_scalar_cmp() {
     assert!(a.partial_cmp(&10000000000u64) == Some(Equal));
     assert!(a.partial_cmp(&1000000000u64) == Some(Greater));
     assert!(a.partial_cmp(&100000000000u64) == Some(Less));
-
 }

--- a/tests/biguint_scalar.rs
+++ b/tests/biguint_scalar.rs
@@ -4,6 +4,8 @@ extern crate num_traits;
 use num_bigint::BigUint;
 use num_traits::{ToPrimitive, Zero};
 
+use std::cmp::Ordering;
+
 mod consts;
 use consts::*;
 
@@ -66,8 +68,8 @@ fn test_scalar_mul() {
 
 #[test]
 fn test_scalar_rem_noncommutative() {
-    assert_eq!(5u8 % BigUint::from(7u8), 5u8.into());
-    assert_eq!(BigUint::from(5u8) % 7u8, 5u8.into());
+    assert_eq!(5u8 % BigUint::from(7u8), 5);
+    assert_eq!(BigUint::from(5u8) % 7u8, 5);
 }
 
 #[test]
@@ -106,4 +108,90 @@ fn test_scalar_div_rem() {
             assert_unsigned_scalar_op!(a % b == d);
         }
     }
+}
+
+#[test]
+fn test_biguint_scalar_cmp() {
+    use std::cmp::Ordering::*;
+
+    let zero = BigUint::from(0u32);
+    let one = BigUint::from(1u32);
+    let five = BigUint::from(5u32);
+
+    fn scalar_cmp_asserts(num: &BigUint, scalar: i32) {
+
+        assert!(num.partial_cmp(&(scalar as i8)) == Some(Equal));
+        assert!((scalar as i8).partial_cmp(num) == Some(Equal));
+        assert!(num.partial_cmp(&(scalar as i8 - 1)) == Some(Greater));
+        assert!((scalar as i8 + 1).partial_cmp(num) == Some(Greater));
+        assert!(num.partial_cmp(&(scalar as i8 + 1)) == Some(Less));
+        assert!((scalar as i8 - 1).partial_cmp(num) == Some(Less));
+
+        assert!(num.partial_cmp(&(scalar as u8)) == Some(Equal));
+        assert!((scalar as u8).partial_cmp(num) == Some(Equal));
+        assert!((scalar as u8 + 1).partial_cmp(num) == Some(Greater));
+        assert!(num.partial_cmp(&(scalar as u8 + 1)) == Some(Less));
+
+        assert!(num.partial_cmp(&(scalar as i16)) == Some(Equal));
+        assert!((scalar as i16).partial_cmp(num) == Some(Equal));
+        assert!(num.partial_cmp(&(scalar as i16 - 1)) == Some(Greater));
+        assert!((scalar as i16 + 1).partial_cmp(num) == Some(Greater));
+        assert!(num.partial_cmp(&(scalar as i16 + 1)) == Some(Less));
+        assert!((scalar as i16 - 1).partial_cmp(num) == Some(Less));
+
+        assert!(num.partial_cmp(&(scalar as u16)) == Some(Equal));
+        assert!((scalar as u16).partial_cmp(num) == Some(Equal));
+        assert!((scalar as u16 + 1).partial_cmp(num) == Some(Greater));
+        assert!(num.partial_cmp(&(scalar as u16 + 1)) == Some(Less));
+
+        assert!(num.partial_cmp(&(scalar as i32)) == Some(Equal));
+        assert!((scalar as i32).partial_cmp(num) == Some(Equal));
+        assert!(num.partial_cmp(&(scalar as i32 - 1)) == Some(Greater));
+        assert!((scalar as i32 + 1).partial_cmp(num) == Some(Greater));
+        assert!(num.partial_cmp(&(scalar as i32 + 1)) == Some(Less));
+        assert!((scalar as i32 - 1).partial_cmp(num) == Some(Less));
+
+        assert!(num.partial_cmp(&(scalar as u32)) == Some(Equal));
+        assert!((scalar as u32).partial_cmp(num) == Some(Equal));
+        assert!((scalar as u32 + 1).partial_cmp(num) == Some(Greater));
+        assert!(num.partial_cmp(&(scalar as u32 + 1)) == Some(Less));
+
+        assert!(num.partial_cmp(&(scalar as i64)) == Some(Equal));
+        assert!((scalar as i64).partial_cmp(num) == Some(Equal));
+        assert!(num.partial_cmp(&(scalar as i64 - 1)) == Some(Greater));
+        assert!((scalar as i64 + 1).partial_cmp(num) == Some(Greater));
+        assert!(num.partial_cmp(&(scalar as i64 + 1)) == Some(Less));
+        assert!((scalar as i64 - 1).partial_cmp(num) == Some(Less));
+
+        assert!(num.partial_cmp(&(scalar as u64)) == Some(Equal));
+        assert!((scalar as u64).partial_cmp(num) == Some(Equal));
+        assert!((scalar as u64 + 1).partial_cmp(num) == Some(Greater));
+        assert!(num.partial_cmp(&(scalar as u64 + 1)) == Some(Less));
+
+        #[cfg(has_i128)]
+        {
+            assert!(num.partial_cmp(&(scalar as i128)) == Some(Equal));
+            assert!((scalar as i128).partial_cmp(num) == Some(Equal));
+            assert!(num.partial_cmp(&(scalar as i128 - 1)) == Some(Greater));
+            assert!((scalar as i128 + 1).partial_cmp(num) == Some(Greater));
+            assert!(num.partial_cmp(&(scalar as i128 + 1)) == Some(Less));
+            assert!((scalar as i128 - 1).partial_cmp(num) == Some(Less));
+
+            assert!(num.partial_cmp(&(scalar as u128)) == Some(Equal));
+            assert!((scalar as u128).partial_cmp(num) == Some(Equal));
+            assert!((scalar as u128 + 1).partial_cmp(num) == Some(Greater));
+            assert!(num.partial_cmp(&(scalar as u128 + 1)) == Some(Less));
+        }
+
+    }
+
+    scalar_cmp_asserts(&zero, 0);
+    scalar_cmp_asserts(&one, 1);
+    scalar_cmp_asserts(&five, 5);
+
+    let a = BigUint::from(10000000000u64);
+    assert!(a.partial_cmp(&10000000000u64) == Some(Equal));
+    assert!(a.partial_cmp(&1000000000u64) == Some(Greater));
+    assert!(a.partial_cmp(&100000000000u64) == Some(Less));
+
 }

--- a/tests/biguint_scalar.rs
+++ b/tests/biguint_scalar.rs
@@ -4,8 +4,6 @@ extern crate num_traits;
 use num_bigint::BigUint;
 use num_traits::{ToPrimitive, Zero};
 
-use std::cmp::Ordering;
-
 mod consts;
 use consts::*;
 

--- a/tests/biguint_scalar.rs
+++ b/tests/biguint_scalar.rs
@@ -66,8 +66,8 @@ fn test_scalar_mul() {
 
 #[test]
 fn test_scalar_rem_noncommutative() {
-    assert_eq!(5u8 % BigUint::from(7u8), 5);
-    assert_eq!(BigUint::from(5u8) % 7u8, 5);
+    assert_eq!(5u8 % BigUint::from(7u8), 5u8);
+    assert_eq!(BigUint::from(5u8) % 7u8, 5u8);
 }
 
 #[test]
@@ -117,48 +117,20 @@ fn test_biguint_scalar_cmp() {
     let five = BigUint::from(5u32);
 
     fn scalar_cmp_asserts(num: &BigUint, scalar: i32) {
-        assert!(num.partial_cmp(&(scalar as i8)) == Some(Equal));
-        assert!((scalar as i8).partial_cmp(num) == Some(Equal));
-        assert!(num.partial_cmp(&(scalar as i8 - 1)) == Some(Greater));
-        assert!((scalar as i8 + 1).partial_cmp(num) == Some(Greater));
-        assert!(num.partial_cmp(&(scalar as i8 + 1)) == Some(Less));
-        assert!((scalar as i8 - 1).partial_cmp(num) == Some(Less));
-
         assert!(num.partial_cmp(&(scalar as u8)) == Some(Equal));
         assert!((scalar as u8).partial_cmp(num) == Some(Equal));
         assert!((scalar as u8 + 1).partial_cmp(num) == Some(Greater));
         assert!(num.partial_cmp(&(scalar as u8 + 1)) == Some(Less));
-
-        assert!(num.partial_cmp(&(scalar as i16)) == Some(Equal));
-        assert!((scalar as i16).partial_cmp(num) == Some(Equal));
-        assert!(num.partial_cmp(&(scalar as i16 - 1)) == Some(Greater));
-        assert!((scalar as i16 + 1).partial_cmp(num) == Some(Greater));
-        assert!(num.partial_cmp(&(scalar as i16 + 1)) == Some(Less));
-        assert!((scalar as i16 - 1).partial_cmp(num) == Some(Less));
 
         assert!(num.partial_cmp(&(scalar as u16)) == Some(Equal));
         assert!((scalar as u16).partial_cmp(num) == Some(Equal));
         assert!((scalar as u16 + 1).partial_cmp(num) == Some(Greater));
         assert!(num.partial_cmp(&(scalar as u16 + 1)) == Some(Less));
 
-        assert!(num.partial_cmp(&(scalar as i32)) == Some(Equal));
-        assert!((scalar as i32).partial_cmp(num) == Some(Equal));
-        assert!(num.partial_cmp(&(scalar as i32 - 1)) == Some(Greater));
-        assert!((scalar as i32 + 1).partial_cmp(num) == Some(Greater));
-        assert!(num.partial_cmp(&(scalar as i32 + 1)) == Some(Less));
-        assert!((scalar as i32 - 1).partial_cmp(num) == Some(Less));
-
         assert!(num.partial_cmp(&(scalar as u32)) == Some(Equal));
         assert!((scalar as u32).partial_cmp(num) == Some(Equal));
         assert!((scalar as u32 + 1).partial_cmp(num) == Some(Greater));
         assert!(num.partial_cmp(&(scalar as u32 + 1)) == Some(Less));
-
-        assert!(num.partial_cmp(&(scalar as i64)) == Some(Equal));
-        assert!((scalar as i64).partial_cmp(num) == Some(Equal));
-        assert!(num.partial_cmp(&(scalar as i64 - 1)) == Some(Greater));
-        assert!((scalar as i64 + 1).partial_cmp(num) == Some(Greater));
-        assert!(num.partial_cmp(&(scalar as i64 + 1)) == Some(Less));
-        assert!((scalar as i64 - 1).partial_cmp(num) == Some(Less));
 
         assert!(num.partial_cmp(&(scalar as u64)) == Some(Equal));
         assert!((scalar as u64).partial_cmp(num) == Some(Equal));
@@ -167,13 +139,6 @@ fn test_biguint_scalar_cmp() {
 
         #[cfg(has_i128)]
         {
-            assert!(num.partial_cmp(&(scalar as i128)) == Some(Equal));
-            assert!((scalar as i128).partial_cmp(num) == Some(Equal));
-            assert!(num.partial_cmp(&(scalar as i128 - 1)) == Some(Greater));
-            assert!((scalar as i128 + 1).partial_cmp(num) == Some(Greater));
-            assert!(num.partial_cmp(&(scalar as i128 + 1)) == Some(Less));
-            assert!((scalar as i128 - 1).partial_cmp(num) == Some(Less));
-
             assert!(num.partial_cmp(&(scalar as u128)) == Some(Equal));
             assert!((scalar as u128).partial_cmp(num) == Some(Equal));
             assert!((scalar as u128 + 1).partial_cmp(num) == Some(Greater));

--- a/tests/quickcheck.rs
+++ b/tests/quickcheck.rs
@@ -315,3 +315,18 @@ fn quicktest_shift() {
     qc.quickcheck(test_shl_unsigned as fn(u32, u8) -> TestResult);
     qc.quickcheck(test_shl_signed as fn(i32, u8) -> TestResult);
 }
+
+#[test]
+fn quickcheck_scalar_cmp() {
+    let gen = StdThreadGen::new(usize::max_value());
+    let mut qc = QuickCheck::with_gen(gen);
+
+    fn test_cmp(lhs: i64, rhs: i64) -> TestResult {
+        let correct = lhs.partial_cmp(&rhs);
+        let big_lhs = BigInt::from(lhs);
+        let res = big_lhs.partial_cmp(&rhs);
+        TestResult::from_bool(correct == res)
+    }
+
+    qc.quickcheck(test_cmp as fn(i64, i64) -> TestResult);
+}


### PR DESCRIPTION
This has been one of the major annoyances for me when using num-bigint compared to something like rug.