### PR TITLE
Fix lcm (0,0) panic

### DIFF
--- a/src/bigint.rs
+++ b/src/bigint.rs
@@ -2188,7 +2188,11 @@ impl Integer for BigInt {
     /// Calculates the Lowest Common Multiple (LCM) of the number and `other`.
     #[inline]
     fn lcm(&self, other: &BigInt) -> BigInt {
-        BigInt::from_biguint(Plus, self.data.lcm(&other.data))
+        if self.is_zero() && other.is_zero() {
+            Self::zero()
+        } else {
+            BigInt::from_biguint(Plus, self.data.lcm(&other.data))
+        }
     }
 
     /// Deprecated, use `is_multiple_of` instead.

--- a/src/bigint.rs
+++ b/src/bigint.rs
@@ -2188,11 +2188,7 @@ impl Integer for BigInt {
     /// Calculates the Lowest Common Multiple (LCM) of the number and `other`.
     #[inline]
     fn lcm(&self, other: &BigInt) -> BigInt {
-        if self.is_zero() && other.is_zero() {
-            Self::zero()
-        } else {
-            BigInt::from_biguint(Plus, self.data.lcm(&other.data))
-        }
+        BigInt::from_biguint(Plus, self.data.lcm(&other.data))
     }
 
     /// Deprecated, use `is_multiple_of` instead.

--- a/src/biguint.rs
+++ b/src/biguint.rs
@@ -1320,7 +1320,11 @@ impl Integer for BigUint {
     /// Calculates the Lowest Common Multiple (LCM) of the number and `other`.
     #[inline]
     fn lcm(&self, other: &BigUint) -> BigUint {
-        self / self.gcd(other) * other
+        if self.is_zero() && other.is_zero() {
+            Self::zero()
+        } else {
+            self / self.gcd(other) * other
+        }
     }
 
     /// Deprecated, use `is_multiple_of` instead.

--- a/tests/bigint.rs
+++ b/tests/bigint.rs
@@ -962,6 +962,7 @@ fn test_lcm() {
         assert_eq!(big_a.lcm(&big_b), big_c);
     }
 
+    check(0, 0, 0);
     check(1, 0, 0);
     check(0, 1, 0);
     check(1, 1, 1);

--- a/tests/biguint.rs
+++ b/tests/biguint.rs
@@ -1015,6 +1015,7 @@ fn test_lcm() {
         assert_eq!(big_a.lcm(&big_b), big_c);
     }
 
+    check(0, 0, 0);
     check(1, 0, 0);
     check(0, 1, 0);
     check(1, 1, 1);


### PR DESCRIPTION
Fixes #103 
Added a simple check to the BigInt::lcm() in the case that both arguments are
zero. If this is the case, the method returns BigInt::zero().

Added test case to test/bigint.rs checking that lcm(0, 0) returns 0.