### PR TITLE
Document the "rand" feature.

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,19 @@ Implementations for `i128` and `u128` are only available with Rust 1.26 and
 later.  The build script automatically detects this, but you can make it
 mandatory by enabling the `i128` crate feature.
 
+### Random Generation
+
+`num-bigint` supports the generation of random big integers when the `rand`
+feature is enabled. To enable it include rand as
+
+```toml
+rand = "0.5"
+num-bigint = { version = "0.2", features = ["rand"] }
+```
+
+Note that you must use the version of `rand` that `num-bigint` is compatible
+with: `0.5`.
+
 ## Releases
 
 Release notes are available in [RELEASES.md](RELEASES.md).

--- a/src/bigrand.rs
+++ b/src/bigrand.rs
@@ -14,6 +14,9 @@ use bigint::{into_magnitude, magnitude};
 use integer::Integer;
 use traits::Zero;
 
+/// A trait for sampling random big integers.
+///
+/// The `rand` feature must be enabled to use this. See crate-level documentation for details.
 pub trait RandBigInt {
     /// Generate a random `BigUint` of the given bit size.
     fn gen_biguint(&mut self, bit_size: usize) -> BigUint;
@@ -191,6 +194,8 @@ impl SampleUniform for BigInt {
 }
 
 /// A random distribution for `BigUint` and `BigInt` values of a particular bit size.
+///
+/// The `rand` feature must be enabled to use this. See crate-level documentation for details.
 #[derive(Clone, Copy, Debug)]
 pub struct RandomBits {
     bits: usize,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,6 +71,33 @@
 //! # }
 //! ```
 //!
+//! See the "Features" section for instructions for enabling random number generation.
+//!
+//! ## Features
+//!
+//! The `std` crate feature is mandatory and enabled by default.  If you depend on
+//! `num-bigint` with `default-features = false`, you must manually enable the
+//! `std` feature yourself.  In the future, we hope to support `#![no_std]` with
+//! the `alloc` crate when `std` is not enabled.
+//!
+//! Implementations for `i128` and `u128` are only available with Rust 1.26 and
+//! later.  The build script automatically detects this, but you can make it
+//! mandatory by enabling the `i128` crate feature.
+//!
+//! ### Random Generation
+//!
+//! `num-bigint` supports the generation of random big integers when the `rand`
+//! feature is enabled. To enable it include rand as
+//!
+//! ```toml
+//! rand = "0.5"
+//! num-bigint = { version = "0.2", features = ["rand"] }
+//! ```
+//!
+//! Note that you must use the version of `rand` that `num-bigint` is compatible
+//! with: `0.5`.
+//!
+//!
 //! ## Compatibility
 //!
 //! The `num-bigint` crate is tested for rustc 1.15 and greater.


### PR DESCRIPTION
When using this crate I had trouble figuring out why I couldn't use the `RandomBits` structure. Hopefully future users will be less confused!

Doc locations:
   * README
   * `RandomBits` struct
   * `RandBigInt` trait