### PR TITLE
Add TryFrom impls

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ sudo: false
 rust:
   - 1.31.0 # 2018!
   - 1.32.0 # rand
-  - 1.34.0 # quickcheck
+  - 1.34.0 # quickcheck, has_try_from
   - 1.36.0 # alloc
   - stable
   - beta

--- a/build.rs
+++ b/build.rs
@@ -9,6 +9,8 @@ fn main() {
     if pointer_width.as_ref().map(String::as_str) == Ok("64") {
         autocfg::emit("u64_digit");
     }
+    let ac = autocfg::new();
+    ac.emit_path_cfg("std::convert::TryFrom", "has_try_from");
 
     autocfg::rerun_path("build.rs");
 

--- a/build.rs
+++ b/build.rs
@@ -10,7 +10,9 @@ fn main() {
         autocfg::emit("u64_digit");
     }
     let ac = autocfg::new();
-    ac.emit_path_cfg("std::convert::TryFrom", "has_try_from");
+    if ac.probe_path("std::convert::TryFrom") || ac.probe_path("core::convert::TryFrom") {
+        autocfg::emit("has_try_from");
+    }
 
     autocfg::rerun_path("build.rs");
 

--- a/src/bigint.rs
+++ b/src/bigint.rs
@@ -2715,7 +2715,9 @@ impl TryFrom<&BigInt> for BigUint {
 
     #[inline]
     fn try_from(value: &BigInt) -> Result<BigUint, TryFromBigIntError<()>> {
-        value.to_biguint().ok_or_else(|| TryFromBigIntError::new(()))
+        value
+            .to_biguint()
+            .ok_or_else(|| TryFromBigIntError::new(()))
     }
 }
 

--- a/src/bigint.rs
+++ b/src/bigint.rs
@@ -2457,6 +2457,16 @@ macro_rules! impl_try_from_bigint {
                 $to_ty(value).ok_or(TryFromBigIntError(()))
             }
         }
+
+        #[cfg(has_try_from)]
+        impl TryFrom<BigInt> for $T {
+            type Error = TryFromBigIntError;
+
+            #[inline]
+            fn try_from(value: BigInt) -> Result<$T, TryFromBigIntError> {
+                <$T>::try_from(&value)
+            }
+        }
     };
 }
 
@@ -2706,6 +2716,19 @@ impl TryFrom<&BigInt> for BigUint {
     #[inline]
     fn try_from(value: &BigInt) -> Result<BigUint, TryFromBigIntError> {
         value.to_biguint().ok_or(TryFromBigIntError(()))
+    }
+}
+
+#[cfg(has_try_from)]
+impl TryFrom<BigInt> for BigUint {
+    type Error = TryFromBigIntError;
+
+    #[inline]
+    fn try_from(value: BigInt) -> Result<BigUint, TryFromBigIntError> {
+        match value.into_parts() {
+            (Sign::Minus, _) => Err(TryFromBigIntError(())),
+            (_, biguint) => Ok(biguint),
+        }
     }
 }
 

--- a/src/bigint.rs
+++ b/src/bigint.rs
@@ -2715,9 +2715,7 @@ impl TryFrom<&BigInt> for BigUint {
 
     #[inline]
     fn try_from(value: &BigInt) -> Result<BigUint, TryFromBigIntError<()>> {
-        value
-            .to_biguint()
-            .ok_or_else(|| TryFromBigIntError::new(()))
+        value.to_biguint().ok_or(TryFromBigIntError::new(()))
     }
 }
 
@@ -2730,8 +2728,7 @@ impl TryFrom<BigInt> for BigUint {
         if value.sign() == Sign::Minus {
             Err(TryFromBigIntError::new(value))
         } else {
-            let (_, biguint) = value.into_parts();
-            Ok(biguint)
+            Ok(value.data)
         }
     }
 }

--- a/src/bigint.rs
+++ b/src/bigint.rs
@@ -2465,7 +2465,6 @@ impl_try_from_bigint!(u16, ToPrimitive::to_u16);
 impl_try_from_bigint!(u32, ToPrimitive::to_u32);
 impl_try_from_bigint!(u64, ToPrimitive::to_u64);
 impl_try_from_bigint!(usize, ToPrimitive::to_usize);
-#[cfg(has_i128)]
 impl_try_from_bigint!(u128, ToPrimitive::to_u128);
 
 impl_try_from_bigint!(i8, ToPrimitive::to_i8);
@@ -2473,7 +2472,6 @@ impl_try_from_bigint!(i16, ToPrimitive::to_i16);
 impl_try_from_bigint!(i32, ToPrimitive::to_i32);
 impl_try_from_bigint!(i64, ToPrimitive::to_i64);
 impl_try_from_bigint!(isize, ToPrimitive::to_isize);
-#[cfg(has_i128)]
 impl_try_from_bigint!(i128, ToPrimitive::to_i128);
 
 impl FromPrimitive for BigInt {

--- a/src/biguint.rs
+++ b/src/biguint.rs
@@ -1944,6 +1944,16 @@ macro_rules! impl_try_from_biguint {
                 $to_ty(value).ok_or(TryFromBigIntError(()))
             }
         }
+
+        #[cfg(has_try_from)]
+        impl TryFrom<BigUint> for $T {
+            type Error = TryFromBigIntError;
+
+            #[inline]
+            fn try_from(value: BigUint) -> Result<$T, TryFromBigIntError> {
+                <$T>::try_from(&value)
+            }
+        }
     };
 }
 

--- a/src/biguint.rs
+++ b/src/biguint.rs
@@ -1952,7 +1952,6 @@ impl_try_from_biguint!(u16, ToPrimitive::to_u16);
 impl_try_from_biguint!(u32, ToPrimitive::to_u32);
 impl_try_from_biguint!(u64, ToPrimitive::to_u64);
 impl_try_from_biguint!(usize, ToPrimitive::to_usize);
-#[cfg(has_i128)]
 impl_try_from_biguint!(u128, ToPrimitive::to_u128);
 
 impl_try_from_biguint!(i8, ToPrimitive::to_i8);
@@ -1960,7 +1959,6 @@ impl_try_from_biguint!(i16, ToPrimitive::to_i16);
 impl_try_from_biguint!(i32, ToPrimitive::to_i32);
 impl_try_from_biguint!(i64, ToPrimitive::to_i64);
 impl_try_from_biguint!(isize, ToPrimitive::to_isize);
-#[cfg(has_i128)]
 impl_try_from_biguint!(i128, ToPrimitive::to_i128);
 
 impl FromPrimitive for BigUint {
@@ -2087,7 +2085,6 @@ impl_biguint_try_from_int!(i16, FromPrimitive::from_i16);
 impl_biguint_try_from_int!(i32, FromPrimitive::from_i32);
 impl_biguint_try_from_int!(i64, FromPrimitive::from_i64);
 impl_biguint_try_from_int!(isize, FromPrimitive::from_isize);
-#[cfg(has_i128)]
 impl_biguint_try_from_int!(i128, FromPrimitive::from_i128);
 
 /// A generic trait for converting a value to a `BigUint`.

--- a/src/biguint.rs
+++ b/src/biguint.rs
@@ -1937,21 +1937,21 @@ macro_rules! impl_try_from_biguint {
     ($T:ty, $to_ty:path) => {
         #[cfg(has_try_from)]
         impl TryFrom<&BigUint> for $T {
-            type Error = TryFromBigIntError;
+            type Error = TryFromBigIntError<()>;
 
             #[inline]
-            fn try_from(value: &BigUint) -> Result<$T, TryFromBigIntError> {
-                $to_ty(value).ok_or(TryFromBigIntError(()))
+            fn try_from(value: &BigUint) -> Result<$T, TryFromBigIntError<()>> {
+                $to_ty(value).ok_or(TryFromBigIntError::new(()))
             }
         }
 
         #[cfg(has_try_from)]
         impl TryFrom<BigUint> for $T {
-            type Error = TryFromBigIntError;
+            type Error = TryFromBigIntError<BigUint>;
 
             #[inline]
-            fn try_from(value: BigUint) -> Result<$T, TryFromBigIntError> {
-                <$T>::try_from(&value)
+            fn try_from(value: BigUint) -> Result<$T, TryFromBigIntError<BigUint>> {
+                <$T>::try_from(&value).map_err(|_| TryFromBigIntError::new(value))
             }
         }
     };
@@ -2080,11 +2080,11 @@ macro_rules! impl_biguint_try_from_int {
     ($T:ty, $from_ty:path) => {
         #[cfg(has_try_from)]
         impl TryFrom<$T> for BigUint {
-            type Error = TryFromBigIntError;
+            type Error = TryFromBigIntError<()>;
 
             #[inline]
-            fn try_from(value: $T) -> Result<BigUint, TryFromBigIntError> {
-                $from_ty(value).ok_or(TryFromBigIntError(()))
+            fn try_from(value: $T) -> Result<BigUint, TryFromBigIntError<()>> {
+                $from_ty(value).ok_or(TryFromBigIntError::new(()))
             }
         }
     };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -192,9 +192,7 @@ pub struct TryFromBigIntError<T> {
 #[cfg(has_try_from)]
 impl<T> TryFromBigIntError<T> {
     fn new(original: T) -> Self {
-        TryFromBigIntError {
-            original
-        }
+        TryFromBigIntError { original }
     }
 
     fn __description(&self) -> &str {
@@ -203,7 +201,7 @@ impl<T> TryFromBigIntError<T> {
 
     /// Extract the original value, if available. The value will be available
     /// if the type before conversion was either [`BigInt`] or [`BigUint`].
-    /// 
+    ///
     /// [`BigInt`]: struct.BigInt.html
     /// [`BigUint`]: struct.BigUint.html
     pub fn into_original(self) -> T {
@@ -212,7 +210,10 @@ impl<T> TryFromBigIntError<T> {
 }
 
 #[cfg(all(feature = "std", has_try_from))]
-impl<T> std::error::Error for TryFromBigIntError<T> where T: fmt::Debug {
+impl<T> std::error::Error for TryFromBigIntError<T>
+where
+    T: fmt::Debug,
+{
     fn description(&self) -> &str {
         self.__description()
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -187,16 +187,23 @@ impl Error for ParseBigIntError {
 pub struct TryFromBigIntError(());
 
 #[cfg(has_try_from)]
+impl TryFromBigIntError {
+    fn __description(&self) -> &str {
+        "out of range conversion regarding big integer attempted"
+    }
+}
+
+#[cfg(all(feature = "std", has_try_from))]
 impl std::error::Error for TryFromBigIntError {
     fn description(&self) -> &str {
-        "out of range conversion regarding big integer attempted"
+        self.__description()
     }
 }
 
 #[cfg(has_try_from)]
 impl fmt::Display for TryFromBigIntError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        std::error::Error::description(self).fmt(f)
+        self.__description().fmt(f)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -182,6 +182,24 @@ impl Error for ParseBigIntError {
     }
 }
 
+#[cfg(has_try_from)]
+#[derive(Debug, Copy, Clone, Default, PartialEq, Eq, Hash)]
+pub struct TryFromBigIntError(());
+
+#[cfg(has_try_from)]
+impl std::error::Error for TryFromBigIntError {
+    fn description(&self) -> &str {
+        "out of range conversion regarding big integer attempted"
+    }
+}
+
+#[cfg(has_try_from)]
+impl fmt::Display for TryFromBigIntError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        std::error::Error::description(self).fmt(f)
+    }
+}
+
 pub use crate::biguint::BigUint;
 pub use crate::biguint::ToBigUint;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -182,26 +182,44 @@ impl Error for ParseBigIntError {
     }
 }
 
+/// The error type returned when a checked conversion regarding big integer fails.
 #[cfg(has_try_from)]
-#[derive(Debug, Copy, Clone, Default, PartialEq, Eq, Hash)]
-pub struct TryFromBigIntError(());
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub struct TryFromBigIntError<T> {
+    original: T,
+}
 
 #[cfg(has_try_from)]
-impl TryFromBigIntError {
+impl<T> TryFromBigIntError<T> {
+    fn new(original: T) -> Self {
+        TryFromBigIntError {
+            original
+        }
+    }
+
     fn __description(&self) -> &str {
         "out of range conversion regarding big integer attempted"
+    }
+
+    /// Extract the original value, if available. The value will be available
+    /// if the type before conversion was either [`BigInt`] or [`BigUint`].
+    /// 
+    /// [`BigInt`]: struct.BigInt.html
+    /// [`BigUint`]: struct.BigUint.html
+    pub fn into_original(self) -> T {
+        self.original
     }
 }
 
 #[cfg(all(feature = "std", has_try_from))]
-impl std::error::Error for TryFromBigIntError {
+impl<T> std::error::Error for TryFromBigIntError<T> where T: fmt::Debug {
     fn description(&self) -> &str {
         self.__description()
     }
 }
 
 #[cfg(has_try_from)]
-impl fmt::Display for TryFromBigIntError {
+impl<T> fmt::Display for TryFromBigIntError<T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         self.__description().fmt(f)
     }


### PR DESCRIPTION
Closes #120 

Currently contains:

*  `TryFrom` translations of existing conversion traits.
* A minimal Error type used for all `TryFrom` implementations.

Additional implemetations (e.g. `TryFrom<BigInt> for BigUint` which skips `clone()`) could be beneficial. Also, no new tests have been added since all new impls are basically thin adapters around existing, tested methods. It may be beneficial to add them regardless.