### PR TITLE
Doc: some minor clarifications and formatting nits

### DIFF
--- a/src/bigint.rs
+++ b/src/bigint.rs
@@ -2572,7 +2572,7 @@ impl_to_bigint!(f64, FromPrimitive::from_f64);
 impl BigInt {
     /// Creates and initializes a BigInt.
     ///
-    /// The digits are in little-endian base 2<sup>32</sup>.
+    /// The base 2<sup>32</sup> digits are ordered least significant digit first.
     #[inline]
     pub fn new(sign: Sign, digits: Vec<u32>) -> BigInt {
         BigInt::from_biguint(sign, BigUint::new(digits))
@@ -2580,7 +2580,7 @@ impl BigInt {
 
     /// Creates and initializes a `BigInt`.
     ///
-    /// The digits are in little-endian base 2<sup>32</sup>.
+    /// The base 2<sup>32</sup> digits are ordered least significant digit first.
     #[inline]
     pub fn from_biguint(mut sign: Sign, mut data: BigUint) -> BigInt {
         if sign == NoSign {
@@ -2596,12 +2596,16 @@ impl BigInt {
     }
 
     /// Creates and initializes a `BigInt`.
+    ///
+    /// The base 2<sup>32</sup> digits are ordered least significant digit first.
     #[inline]
     pub fn from_slice(sign: Sign, slice: &[u32]) -> BigInt {
         BigInt::from_biguint(sign, BigUint::from_slice(slice))
     }
 
     /// Reinitializes a `BigInt`.
+    ///
+    /// The base 2<sup>32</sup> digits are ordered least significant digit first.
     #[inline]
     pub fn assign_from_slice(&mut self, sign: Sign, slice: &[u32]) {
         if sign == NoSign {
@@ -2778,7 +2782,8 @@ impl BigInt {
         (self.sign, self.data.to_bytes_le())
     }
 
-    /// Returns the sign and the u32 digits representation of the `BigInt` in little-endian order.
+    /// Returns the sign and the `u32` digits representation of the `BigInt` ordered least
+    /// significant digit first.
     ///
     /// # Examples
     ///
@@ -2796,7 +2801,7 @@ impl BigInt {
         (self.sign, self.data.to_u32_digits())
     }
 
-    /// Returns the two's complement byte representation of the `BigInt` in big-endian byte order.
+    /// Returns the two's-complement byte representation of the `BigInt` in big-endian byte order.
     ///
     /// # Examples
     ///
@@ -2824,7 +2829,7 @@ impl BigInt {
         bytes
     }
 
-    /// Returns the two's complement byte representation of the `BigInt` in little-endian byte order.
+    /// Returns the two's-complement byte representation of the `BigInt` in little-endian byte order.
     ///
     /// # Examples
     ///

--- a/src/biguint.rs
+++ b/src/biguint.rs
@@ -1915,7 +1915,7 @@ pub fn to_str_radix_reversed(u: &BigUint, radix: u32) -> Vec<u8> {
 impl BigUint {
     /// Creates and initializes a `BigUint`.
     ///
-    /// The digits are in little-endian base 2<sup>32</sup>.
+    /// The base 2<sup>32</sup> digits are ordered least significant digit first.
     #[inline]
     pub fn new(digits: Vec<u32>) -> BigUint {
         BigUint { data: digits }.normalized()
@@ -1923,7 +1923,7 @@ impl BigUint {
 
     /// Creates and initializes a `BigUint`.
     ///
-    /// The digits are in little-endian base 2<sup>32</sup>.
+    /// The base 2<sup>32</sup> digits are ordered least significant digit first.
     #[inline]
     pub fn from_slice(slice: &[u32]) -> BigUint {
         BigUint::new(slice.to_vec())
@@ -1931,7 +1931,7 @@ impl BigUint {
 
     /// Assign a value to a `BigUint`.
     ///
-    /// The digits are in little-endian base 2<sup>32</sup>.
+    /// The base 2<sup>32</sup> digits are ordered least significant digit first.
     #[inline]
     pub fn assign_from_slice(&mut self, slice: &[u32]) {
         self.data.resize(slice.len(), 0);
@@ -2125,7 +2125,8 @@ impl BigUint {
         }
     }
 
-    /// Returns the u32 digits representation of the `BigUint` in little-endian order.
+    /// Returns the `u32` digits representation of the `BigUint` ordered least significant digit
+    /// first.
     ///
     /// # Examples
     ///


### PR DESCRIPTION
  * Use "least significant digit first" instead of "little endian" for    32-bit digits.
  * Document ordering of BigInt::from_slice and    BigInt::assign_from_slice.
  * Put a dash in "two's-complement" when used as an adjective.
  * Change "u32" to "`u32`".

Fixes #124.