### PR TITLE
impl PartialEq and PartialOrd with primitives

### DIFF
--- a/ci/big_quickcheck/src/lib.rs
+++ b/ci/big_quickcheck/src/lib.rs
@@ -357,3 +357,18 @@ fn quickcheck_modpow() {
 
     qc.quickcheck(test_modpow as fn(i128, u128, i128) -> TestResult);
 }
+
+#[test]
+fn quickcheck_scalar_cmp() {
+    let gen = StdThreadGen::new(usize::max_value());
+    let mut qc = QuickCheck::with_gen(gen);
+
+    fn test_cmp(lhs: i64, rhs: i64) -> TestResult {
+        let correct = lhs.partial_cmp(&rhs);
+        let big_lhs = BigInt::from(lhs);
+        let res = big_lhs.partial_cmp(&rhs);
+        TestResult::from_bool(correct == res)
+    }
+
+    qc.quickcheck(test_cmp as fn(i64, i64) -> TestResult);
+}

--- a/src/algorithms.rs
+++ b/src/algorithms.rs
@@ -849,8 +849,8 @@ mod algorithm_tests {
 
     #[test]
     fn test_cmp_zero_padded_slice() {
-        use std::cmp::Ordering::*;
         use super::cmp_zero_padded_slice;
+        use std::cmp::Ordering::*;
 
         assert!(cmp_zero_padded_slice(&[1, 0], &[1]) == Equal);
         assert!(cmp_zero_padded_slice(&[1], &[1, 0]) == Equal);
@@ -871,5 +871,4 @@ mod algorithm_tests {
         assert!(cmp_zero_padded_slice(&[0, 0, 0], &[1000, 0]) == Less);
         assert!(cmp_zero_padded_slice(&[0, 1000], &[0, 1000, 0]) == Equal);
     }
-
 }

--- a/src/algorithms.rs
+++ b/src/algorithms.rs
@@ -798,7 +798,7 @@ pub(crate) fn cmp_zero_padded_slice(a: &[BigDigit], b: &[BigDigit]) -> Ordering 
         }
     }
 
-    let shortest = std::cmp::min(a_len, b_len);
+    let shortest = core::cmp::min(a_len, b_len);
     let ashort = &a[0..shortest];
     let bshort = &b[0..shortest];
 

--- a/src/algorithms.rs
+++ b/src/algorithms.rs
@@ -785,32 +785,14 @@ pub(crate) fn biguint_shr(n: Cow<'_, BigUint>, bits: usize) -> BigUint {
     biguint_from_vec(data)
 }
 
-pub(crate) fn cmp_zero_padded_slice(a: &[BigDigit], b: &[BigDigit]) -> Ordering {
-    let (a_len, b_len) = (a.len(), b.len());
-    if a_len < b_len {
-        if b.iter().rev().take(b_len - a_len).any(|v| *v > 0) {
-            return Less;
-        }
+pub(crate) fn cmp_zero_padded_slice(mut a: &[BigDigit], mut b: &[BigDigit]) -> Ordering {
+    while let Some((&0, head)) = a.split_last() {
+        a = head;
     }
-    if a_len > b_len {
-        if a.iter().rev().take(a_len - b_len).any(|v| *v > 0) {
-            return Greater;
-        }
+    while let Some((&0, head)) = b.split_last() {
+        b = head;
     }
-
-    let shortest = ::std::cmp::min(a_len, b_len);
-    let ashort = &a[0..shortest];
-    let bshort = &b[0..shortest];
-
-    for (&ai, &bi) in ashort.iter().rev().zip(bshort.iter().rev()) {
-        if ai < bi {
-            return Less;
-        }
-        if ai > bi {
-            return Greater;
-        }
-    }
-    return Equal;
+    cmp_slice(a, b)
 }
 
 pub(crate) fn cmp_slice(a: &[BigDigit], b: &[BigDigit]) -> Ordering {

--- a/src/algorithms.rs
+++ b/src/algorithms.rs
@@ -798,7 +798,7 @@ pub(crate) fn cmp_zero_padded_slice(a: &[BigDigit], b: &[BigDigit]) -> Ordering 
         }
     }
 
-    let shortest = core::cmp::min(a_len, b_len);
+    let shortest = ::std::cmp::min(a_len, b_len);
     let ashort = &a[0..shortest];
     let bshort = &b[0..shortest];
 

--- a/src/algorithms.rs
+++ b/src/algorithms.rs
@@ -834,23 +834,23 @@ mod algorithm_tests {
         use super::cmp_zero_padded_slice;
         use std::cmp::Ordering::*;
 
-        assert!(cmp_zero_padded_slice(&[1, 0], &[1]) == Equal);
-        assert!(cmp_zero_padded_slice(&[1], &[1, 0]) == Equal);
+        assert_eq!(cmp_zero_padded_slice(&[1, 0], &[1]), Equal);
+        assert_eq!(cmp_zero_padded_slice(&[1], &[1, 0]), Equal);
 
-        assert!(cmp_zero_padded_slice(&[0], &[0]) == Equal);
-        assert!(cmp_zero_padded_slice(&[], &[0]) == Equal);
-        assert!(cmp_zero_padded_slice(&[0], &[]) == Equal);
+        assert_eq!(cmp_zero_padded_slice(&[0], &[0]), Equal);
+        assert_eq!(cmp_zero_padded_slice(&[], &[0]), Equal);
+        assert_eq!(cmp_zero_padded_slice(&[0], &[]), Equal);
 
-        assert!(cmp_zero_padded_slice(&[1], &[0]) == Greater);
-        assert!(cmp_zero_padded_slice(&[1000], &[0]) == Greater);
-        assert!(cmp_zero_padded_slice(&[1000], &[0, 0, 0]) == Greater);
-        assert!(cmp_zero_padded_slice(&[1000, 0], &[0, 0, 0]) == Greater);
-        assert!(cmp_zero_padded_slice(&[0, 1000, 0], &[0, 1000]) == Equal);
+        assert_eq!(cmp_zero_padded_slice(&[1], &[0]), Greater);
+        assert_eq!(cmp_zero_padded_slice(&[1000], &[0]), Greater);
+        assert_eq!(cmp_zero_padded_slice(&[1000], &[0, 0, 0]), Greater);
+        assert_eq!(cmp_zero_padded_slice(&[1000, 0], &[0, 0, 0]), Greater);
+        assert_eq!(cmp_zero_padded_slice(&[0, 1000, 0], &[0, 1000]), Equal);
 
-        assert!(cmp_zero_padded_slice(&[0], &[1]) == Less);
-        assert!(cmp_zero_padded_slice(&[0], &[1000]) == Less);
-        assert!(cmp_zero_padded_slice(&[0, 0, 0], &[1000]) == Less);
-        assert!(cmp_zero_padded_slice(&[0, 0, 0], &[1000, 0]) == Less);
-        assert!(cmp_zero_padded_slice(&[0, 1000], &[0, 1000, 0]) == Equal);
+        assert_eq!(cmp_zero_padded_slice(&[0], &[1]), Less);
+        assert_eq!(cmp_zero_padded_slice(&[0], &[1000]), Less);
+        assert_eq!(cmp_zero_padded_slice(&[0, 0, 0], &[1000]), Less);
+        assert_eq!(cmp_zero_padded_slice(&[0, 0, 0], &[1000, 0]), Less);
+        assert_eq!(cmp_zero_padded_slice(&[0, 1000], &[0, 1000, 0]), Equal);
     }
 }

--- a/src/algorithms.rs
+++ b/src/algorithms.rs
@@ -832,7 +832,7 @@ mod algorithm_tests {
     #[test]
     fn test_cmp_zero_padded_slice() {
         use super::cmp_zero_padded_slice;
-        use std::cmp::Ordering::*;
+        use core::cmp::Ordering::*;
 
         assert_eq!(cmp_zero_padded_slice(&[1, 0], &[1]), Equal);
         assert_eq!(cmp_zero_padded_slice(&[1], &[1, 0]), Equal);

--- a/src/algorithms.rs
+++ b/src/algorithms.rs
@@ -785,6 +785,34 @@ pub(crate) fn biguint_shr(n: Cow<'_, BigUint>, bits: usize) -> BigUint {
     biguint_from_vec(data)
 }
 
+pub(crate) fn cmp_zero_padded_slice(a: &[BigDigit], b: &[BigDigit]) -> Ordering {
+    let (a_len, b_len) = (a.len(), b.len());
+    if a_len < b_len {
+        if b.iter().rev().take(b_len - a_len).any(|v| *v > 0) {
+            return Less;
+        }
+    }
+    if a_len > b_len {
+        if a.iter().rev().take(a_len - b_len).any(|v| *v > 0) {
+            return Greater;
+        }
+    }
+
+    let shortest = std::cmp::min(a_len, b_len);
+    let ashort = &a[0..shortest];
+    let bshort = &b[0..shortest];
+
+    for (&ai, &bi) in ashort.iter().rev().zip(bshort.iter().rev()) {
+        if ai < bi {
+            return Less;
+        }
+        if ai > bi {
+            return Greater;
+        }
+    }
+    return Equal;
+}
+
 pub(crate) fn cmp_slice(a: &[BigDigit], b: &[BigDigit]) -> Ordering {
     debug_assert!(a.last() != Some(&0));
     debug_assert!(b.last() != Some(&0));
@@ -818,4 +846,30 @@ mod algorithm_tests {
         assert_eq!(sub_sign_i(&a.data[..], &b.data[..]), &a_i - &b_i);
         assert_eq!(sub_sign_i(&b.data[..], &a.data[..]), &b_i - &a_i);
     }
+
+    #[test]
+    fn test_cmp_zero_padded_slice() {
+        use std::cmp::Ordering::*;
+        use super::cmp_zero_padded_slice;
+
+        assert!(cmp_zero_padded_slice(&[1, 0], &[1]) == Equal);
+        assert!(cmp_zero_padded_slice(&[1], &[1, 0]) == Equal);
+
+        assert!(cmp_zero_padded_slice(&[0], &[0]) == Equal);
+        assert!(cmp_zero_padded_slice(&[], &[0]) == Equal);
+        assert!(cmp_zero_padded_slice(&[0], &[]) == Equal);
+
+        assert!(cmp_zero_padded_slice(&[1], &[0]) == Greater);
+        assert!(cmp_zero_padded_slice(&[1000], &[0]) == Greater);
+        assert!(cmp_zero_padded_slice(&[1000], &[0, 0, 0]) == Greater);
+        assert!(cmp_zero_padded_slice(&[1000, 0], &[0, 0, 0]) == Greater);
+        assert!(cmp_zero_padded_slice(&[0, 1000, 0], &[0, 1000]) == Equal);
+
+        assert!(cmp_zero_padded_slice(&[0], &[1]) == Less);
+        assert!(cmp_zero_padded_slice(&[0], &[1000]) == Less);
+        assert!(cmp_zero_padded_slice(&[0, 0, 0], &[1000]) == Less);
+        assert!(cmp_zero_padded_slice(&[0, 0, 0], &[1000, 0]) == Less);
+        assert!(cmp_zero_padded_slice(&[0, 1000], &[0, 1000, 0]) == Equal);
+    }
+
 }

--- a/src/bigint.rs
+++ b/src/bigint.rs
@@ -195,6 +195,23 @@ impl PartialOrd for BigInt {
     }
 }
 
+fn sign<T>(num: T) -> Sign where T: Ord + Zero {
+    if num < T::zero() {
+        Sign::Minus
+    } else if num > T::zero() {
+        Sign::Plus
+    } else {
+        Sign::NoSign
+    }
+}
+
+impl_partialord_partialeq_for_bigint!(i8, u8);
+impl_partialord_partialeq_for_bigint!(i16, u16);
+impl_partialord_partialeq_for_bigint!(i32, u32);
+impl_partialord_partialeq_for_bigint!(i64, u64);
+#[cfg(has_i128)]
+impl_partialord_partialeq_for_bigint!(i128, u128);
+
 impl Ord for BigInt {
     #[inline]
     fn cmp(&self, other: &BigInt) -> Ordering {

--- a/src/bigint.rs
+++ b/src/bigint.rs
@@ -965,35 +965,30 @@ pow_impl!(usize);
 pow_impl!(u128);
 pow_impl!(BigUint);
 
-// A convenience method for getting the absolute value of an i32 in a u32.
-#[inline]
-fn i32_abs_as_u32(a: i32) -> u32 {
-    if a == i32::min_value() {
-        a as u32
-    } else {
-        a.abs() as u32
-    }
+trait UnsignedAbs {
+    type Unsigned;
+    /// A convenience method for getting the absolute value of a signed primitive as unsigned
+    fn unsigned_abs(self) -> Self::Unsigned;
 }
 
-// A convenience method for getting the absolute value of an i64 in a u64.
-#[inline]
-fn i64_abs_as_u64(a: i64) -> u64 {
-    if a == i64::min_value() {
-        a as u64
-    } else {
-        a.abs() as u64
-    }
-}
+macro_rules! impl_unsigned_abs {
+    ($Signed:ty, $Unsigned:ty) => {
+        impl UnsignedAbs for $Signed {
+            type Unsigned = $Unsigned;
 
-// A convenience method for getting the absolute value of an i128 in a u128.
-#[inline]
-fn i128_abs_as_u128(a: i128) -> u128 {
-    if a == i128::min_value() {
-        a as u128
-    } else {
-        a.abs() as u128
-    }
+            #[inline]
+            fn unsigned_abs(self) -> $Unsigned {
+                self.wrapping_abs() as $Unsigned
+            }
+        }
+    };
 }
+impl_unsigned_abs!(i8, u8);
+impl_unsigned_abs!(i16, u16);
+impl_unsigned_abs!(i32, u32);
+impl_unsigned_abs!(i64, u64);
+impl_unsigned_abs!(i128, u128);
+impl_unsigned_abs!(isize, usize);
 
 // We want to forward to BigUint::add, but it's not clear how that will go until
 // we compare both sign and magnitude.  So we duplicate this body for every
@@ -1159,7 +1154,7 @@ impl Add<i32> for BigInt {
         if other >= 0 {
             self + other as u32
         } else {
-            self - i32_abs_as_u32(other)
+            self - other.unsigned_abs()
         }
     }
 }
@@ -1169,7 +1164,7 @@ impl AddAssign<i32> for BigInt {
         if other >= 0 {
             *self += other as u32;
         } else {
-            *self -= i32_abs_as_u32(other);
+            *self -= other.unsigned_abs();
         }
     }
 }
@@ -1182,7 +1177,7 @@ impl Add<i64> for BigInt {
         if other >= 0 {
             self + other as u64
         } else {
-            self - i64_abs_as_u64(other)
+            self - other.unsigned_abs()
         }
     }
 }
@@ -1192,7 +1187,7 @@ impl AddAssign<i64> for BigInt {
         if other >= 0 {
             *self += other as u64;
         } else {
-            *self -= i64_abs_as_u64(other);
+            *self -= other.unsigned_abs();
         }
     }
 }
@@ -1205,7 +1200,7 @@ impl Add<i128> for BigInt {
         if other >= 0 {
             self + other as u128
         } else {
-            self - i128_abs_as_u128(other)
+            self - other.unsigned_abs()
         }
     }
 }
@@ -1215,7 +1210,7 @@ impl AddAssign<i128> for BigInt {
         if other >= 0 {
             *self += other as u128;
         } else {
-            *self -= i128_abs_as_u128(other);
+            *self -= other.unsigned_abs();
         }
     }
 }
@@ -1411,7 +1406,7 @@ impl Sub<i32> for BigInt {
         if other >= 0 {
             self - other as u32
         } else {
-            self + i32_abs_as_u32(other)
+            self + other.unsigned_abs()
         }
     }
 }
@@ -1421,7 +1416,7 @@ impl SubAssign<i32> for BigInt {
         if other >= 0 {
             *self -= other as u32;
         } else {
-            *self += i32_abs_as_u32(other);
+            *self += other.unsigned_abs();
         }
     }
 }
@@ -1434,7 +1429,7 @@ impl Sub<BigInt> for i32 {
         if self >= 0 {
             self as u32 - other
         } else {
-            -other - i32_abs_as_u32(self)
+            -other - self.unsigned_abs()
         }
     }
 }
@@ -1447,7 +1442,7 @@ impl Sub<i64> for BigInt {
         if other >= 0 {
             self - other as u64
         } else {
-            self + i64_abs_as_u64(other)
+            self + other.unsigned_abs()
         }
     }
 }
@@ -1457,7 +1452,7 @@ impl SubAssign<i64> for BigInt {
         if other >= 0 {
             *self -= other as u64;
         } else {
-            *self += i64_abs_as_u64(other);
+            *self += other.unsigned_abs();
         }
     }
 }
@@ -1470,7 +1465,7 @@ impl Sub<BigInt> for i64 {
         if self >= 0 {
             self as u64 - other
         } else {
-            -other - i64_abs_as_u64(self)
+            -other - self.unsigned_abs()
         }
     }
 }
@@ -1483,7 +1478,7 @@ impl Sub<i128> for BigInt {
         if other >= 0 {
             self - other as u128
         } else {
-            self + i128_abs_as_u128(other)
+            self + other.unsigned_abs()
         }
     }
 }
@@ -1494,7 +1489,7 @@ impl SubAssign<i128> for BigInt {
         if other >= 0 {
             *self -= other as u128;
         } else {
-            *self += i128_abs_as_u128(other);
+            *self += other.unsigned_abs();
         }
     }
 }
@@ -1507,7 +1502,7 @@ impl Sub<BigInt> for i128 {
         if self >= 0 {
             self as u128 - other
         } else {
-            -other - i128_abs_as_u128(self)
+            -other - self.unsigned_abs()
         }
     }
 }
@@ -1606,7 +1601,7 @@ impl Mul<i32> for BigInt {
         if other >= 0 {
             self * other as u32
         } else {
-            -(self * i32_abs_as_u32(other))
+            -(self * other.unsigned_abs())
         }
     }
 }
@@ -1618,7 +1613,7 @@ impl MulAssign<i32> for BigInt {
             *self *= other as u32;
         } else {
             self.sign = -self.sign;
-            *self *= i32_abs_as_u32(other);
+            *self *= other.unsigned_abs();
         }
     }
 }
@@ -1631,7 +1626,7 @@ impl Mul<i64> for BigInt {
         if other >= 0 {
             self * other as u64
         } else {
-            -(self * i64_abs_as_u64(other))
+            -(self * other.unsigned_abs())
         }
     }
 }
@@ -1643,7 +1638,7 @@ impl MulAssign<i64> for BigInt {
             *self *= other as u64;
         } else {
             self.sign = -self.sign;
-            *self *= i64_abs_as_u64(other);
+            *self *= other.unsigned_abs();
         }
     }
 }
@@ -1656,7 +1651,7 @@ impl Mul<i128> for BigInt {
         if other >= 0 {
             self * other as u128
         } else {
-            -(self * i128_abs_as_u128(other))
+            -(self * other.unsigned_abs())
         }
     }
 }
@@ -1668,7 +1663,7 @@ impl MulAssign<i128> for BigInt {
             *self *= other as u128;
         } else {
             self.sign = -self.sign;
-            *self *= i128_abs_as_u128(other);
+            *self *= other.unsigned_abs();
         }
     }
 }
@@ -1795,7 +1790,7 @@ impl Div<i32> for BigInt {
         if other >= 0 {
             self / other as u32
         } else {
-            -(self / i32_abs_as_u32(other))
+            -(self / other.unsigned_abs())
         }
     }
 }
@@ -1807,7 +1802,7 @@ impl DivAssign<i32> for BigInt {
             *self /= other as u32;
         } else {
             self.sign = -self.sign;
-            *self /= i32_abs_as_u32(other);
+            *self /= other.unsigned_abs();
         }
     }
 }
@@ -1820,7 +1815,7 @@ impl Div<BigInt> for i32 {
         if self >= 0 {
             self as u32 / other
         } else {
-            -(i32_abs_as_u32(self) / other)
+            -(self.unsigned_abs() / other)
         }
     }
 }
@@ -1833,7 +1828,7 @@ impl Div<i64> for BigInt {
         if other >= 0 {
             self / other as u64
         } else {
-            -(self / i64_abs_as_u64(other))
+            -(self / other.unsigned_abs())
         }
     }
 }
@@ -1845,7 +1840,7 @@ impl DivAssign<i64> for BigInt {
             *self /= other as u64;
         } else {
             self.sign = -self.sign;
-            *self /= i64_abs_as_u64(other);
+            *self /= other.unsigned_abs();
         }
     }
 }
@@ -1858,7 +1853,7 @@ impl Div<BigInt> for i64 {
         if self >= 0 {
             self as u64 / other
         } else {
-            -(i64_abs_as_u64(self) / other)
+            -(self.unsigned_abs() / other)
         }
     }
 }
@@ -1871,7 +1866,7 @@ impl Div<i128> for BigInt {
         if other >= 0 {
             self / other as u128
         } else {
-            -(self / i128_abs_as_u128(other))
+            -(self / other.unsigned_abs())
         }
     }
 }
@@ -1883,7 +1878,7 @@ impl DivAssign<i128> for BigInt {
             *self /= other as u128;
         } else {
             self.sign = -self.sign;
-            *self /= i128_abs_as_u128(other);
+            *self /= other.unsigned_abs();
         }
     }
 }
@@ -1896,7 +1891,7 @@ impl Div<BigInt> for i128 {
         if self >= 0 {
             self as u128 / other
         } else {
-            -(i128_abs_as_u128(self) / other)
+            -(self.unsigned_abs() / other)
         }
     }
 }
@@ -2029,7 +2024,7 @@ impl Rem<i32> for BigInt {
         if other >= 0 {
             self % other as u32
         } else {
-            self % i32_abs_as_u32(other)
+            self % other.unsigned_abs()
         }
     }
 }
@@ -2040,7 +2035,7 @@ impl RemAssign<i32> for BigInt {
         if other >= 0 {
             *self %= other as u32;
         } else {
-            *self %= i32_abs_as_u32(other);
+            *self %= other.unsigned_abs();
         }
     }
 }
@@ -2053,7 +2048,7 @@ impl Rem<BigInt> for i32 {
         if self >= 0 {
             self as u32 % other
         } else {
-            -(i32_abs_as_u32(self) % other)
+            -(self.unsigned_abs() % other)
         }
     }
 }
@@ -2066,7 +2061,7 @@ impl Rem<i64> for BigInt {
         if other >= 0 {
             self % other as u64
         } else {
-            self % i64_abs_as_u64(other)
+            self % other.unsigned_abs()
         }
     }
 }
@@ -2077,7 +2072,7 @@ impl RemAssign<i64> for BigInt {
         if other >= 0 {
             *self %= other as u64;
         } else {
-            *self %= i64_abs_as_u64(other);
+            *self %= other.unsigned_abs();
         }
     }
 }
@@ -2090,7 +2085,7 @@ impl Rem<BigInt> for i64 {
         if self >= 0 {
             self as u64 % other
         } else {
-            -(i64_abs_as_u64(self) % other)
+            -(self.unsigned_abs() % other)
         }
     }
 }
@@ -2103,7 +2098,7 @@ impl Rem<i128> for BigInt {
         if other >= 0 {
             self % other as u128
         } else {
-            self % i128_abs_as_u128(other)
+            self % other.unsigned_abs()
         }
     }
 }
@@ -2114,7 +2109,7 @@ impl RemAssign<i128> for BigInt {
         if other >= 0 {
             *self %= other as u128;
         } else {
-            *self %= i128_abs_as_u128(other);
+            *self %= other.unsigned_abs();
         }
     }
 }
@@ -2127,7 +2122,7 @@ impl Rem<BigInt> for i128 {
         if self >= 0 {
             self as u128 % other
         } else {
-            -(i128_abs_as_u128(self) % other)
+            -(self.unsigned_abs() % other)
         }
     }
 }

--- a/src/bigint.rs
+++ b/src/bigint.rs
@@ -213,6 +213,7 @@ impl_partialord_partialeq_for_bigint!(i16, u16);
 impl_partialord_partialeq_for_bigint!(i32, u32);
 impl_partialord_partialeq_for_bigint!(i64, u64);
 impl_partialord_partialeq_for_bigint!(i128, u128);
+impl_partialord_partialeq_for_bigint!(isize, usize);
 
 impl Ord for BigInt {
     #[inline]

--- a/src/bigint.rs
+++ b/src/bigint.rs
@@ -195,7 +195,10 @@ impl PartialOrd for BigInt {
     }
 }
 
-fn sign<T>(num: T) -> Sign where T: Ord + Zero {
+fn sign<T>(num: T) -> Sign
+where
+    T: Ord + Zero,
+{
     if num < T::zero() {
         Sign::Minus
     } else if num > T::zero() {

--- a/src/bigint.rs
+++ b/src/bigint.rs
@@ -212,7 +212,6 @@ impl_partialord_partialeq_for_bigint!(i8, u8);
 impl_partialord_partialeq_for_bigint!(i16, u16);
 impl_partialord_partialeq_for_bigint!(i32, u32);
 impl_partialord_partialeq_for_bigint!(i64, u64);
-#[cfg(has_i128)]
 impl_partialord_partialeq_for_bigint!(i128, u128);
 
 impl Ord for BigInt {

--- a/src/biguint.rs
+++ b/src/biguint.rs
@@ -153,6 +153,15 @@ impl PartialOrd<u128> for BigUint {
     }
 }
 
+impl_scalar_partialeq!(impl PartialEq<usize> for BigUint);
+impl_partialord_rev!(impl PartialOrd<usize> for BigUint);
+impl PartialOrd<usize> for BigUint {
+    #[inline]
+    fn partial_cmp(&self, other: &usize) -> Option<Ordering> {
+        self.partial_cmp(&(*other as UsizePromotion))
+    }
+}
+
 impl Default for BigUint {
     #[inline]
     fn default() -> BigUint {

--- a/src/biguint.rs
+++ b/src/biguint.rs
@@ -114,9 +114,9 @@ impl Ord for BigUint {
     }
 }
 
-impl_partialord_partialeq_for_biguint_below_digit!(i8, u8);
-impl_partialord_partialeq_for_biguint_below_digit!(i16, u16);
-impl_partialord_partialeq_for_biguint_below_digit!(i32, u32);
+impl_partialord_partialeq_for_biguint_below_digit!(u8);
+impl_partialord_partialeq_for_biguint_below_digit!(u16);
+impl_partialord_partialeq_for_biguint_below_digit!(u32);
 
 impl_scalar_partialeq!(impl PartialEq<u64> for BigUint);
 impl_partialord_rev!(impl PartialOrd<u64> for BigUint);
@@ -125,18 +125,6 @@ impl PartialOrd<u64> for BigUint {
     fn partial_cmp(&self, other: &u64) -> Option<Ordering> {
         let (hi, lo) = big_digit::from_doublebigdigit(*other);
         Some(cmp_zero_padded_slice(&self.data[..], &[lo, hi]))
-    }
-}
-impl_scalar_partialeq!(impl PartialEq<i64> for BigUint);
-impl_partialord_rev!(impl PartialOrd<i64> for BigUint);
-impl PartialOrd<i64> for BigUint {
-    #[inline]
-    fn partial_cmp(&self, other: &i64) -> Option<Ordering> {
-        if *other < 0 {
-            Some(Greater)
-        } else {
-            self.partial_cmp(&(*other as u64))
-        }
     }
 }
 
@@ -150,21 +138,6 @@ impl PartialOrd<u128> for BigUint {
     fn partial_cmp(&self, other: &u128) -> Option<Ordering> {
         let (a, b, c, d) = u32_from_u128(*other);
         Some(cmp_zero_padded_slice(&self.data[..], &[d, c, b, a]))
-    }
-}
-#[cfg(has_i128)]
-impl_scalar_partialeq!(impl PartialEq<i128> for BigUint);
-#[cfg(has_i128)]
-impl_partialord_rev!(impl PartialOrd<i128> for BigUint);
-#[cfg(has_i128)]
-impl PartialOrd<i128> for BigUint {
-    #[inline]
-    fn partial_cmp(&self, other: &i128) -> Option<Ordering> {
-        if *other < 0 {
-            Some(Greater)
-        } else {
-            self.partial_cmp(&(*other as u128))
-        }
     }
 }
 

--- a/src/biguint.rs
+++ b/src/biguint.rs
@@ -121,6 +121,13 @@ impl_partialord_partialeq_for_biguint_below_digit!(u32);
 impl_scalar_partialeq!(impl PartialEq<u64> for BigUint);
 impl_partialord_rev!(impl PartialOrd<u64> for BigUint);
 impl PartialOrd<u64> for BigUint {
+    #[cfg(u64_digit)]
+    #[inline]
+    fn partial_cmp(&self, other: &u64) -> Option<Ordering> {
+        Some(cmp_zero_padded_slice(&self.data[..], &[*other]))
+    }
+
+    #[cfg(not(u64_digit))]
     #[inline]
     fn partial_cmp(&self, other: &u64) -> Option<Ordering> {
         let (hi, lo) = big_digit::from_doublebigdigit(*other);
@@ -128,12 +135,17 @@ impl PartialOrd<u64> for BigUint {
     }
 }
 
-#[cfg(has_i128)]
 impl_scalar_partialeq!(impl PartialEq<u128> for BigUint);
-#[cfg(has_i128)]
 impl_partialord_rev!(impl PartialOrd<u128> for BigUint);
-#[cfg(has_i128)]
 impl PartialOrd<u128> for BigUint {
+    #[cfg(u64_digit)]
+    #[inline]
+    fn partial_cmp(&self, other: &u128) -> Option<Ordering> {
+        let (hi, lo) = big_digit::from_doublebigdigit(*other);
+        Some(cmp_zero_padded_slice(&self.data[..], &[lo, hi]))
+    }
+
+    #[cfg(not(u64_digit))]
     #[inline]
     fn partial_cmp(&self, other: &u128) -> Option<Ordering> {
         let (a, b, c, d) = u32_from_u128(*other);

--- a/src/biguint.rs
+++ b/src/biguint.rs
@@ -35,7 +35,7 @@ mod monty;
 
 use self::algorithms::{__add2, __sub2rev, add2, sub2, sub2rev};
 use self::algorithms::{biguint_shl, biguint_shr};
-use self::algorithms::{cmp_slice, fls, ilog2};
+use self::algorithms::{cmp_slice, cmp_zero_padded_slice, fls, ilog2};
 use self::algorithms::{div_rem, div_rem_digit, div_rem_ref, rem_digit};
 use self::algorithms::{mac_with_carry, mul3, scalar_mul};
 use self::monty::monty_modpow;
@@ -111,6 +111,60 @@ impl Ord for BigUint {
     #[inline]
     fn cmp(&self, other: &BigUint) -> Ordering {
         cmp_slice(&self.data[..], &other.data[..])
+    }
+}
+
+impl_partialord_partialeq_for_biguint_below_digit!(i8, u8);
+impl_partialord_partialeq_for_biguint_below_digit!(i16, u16);
+impl_partialord_partialeq_for_biguint_below_digit!(i32, u32);
+
+impl_scalar_partialeq!(impl PartialEq<u64> for BigUint);
+impl_partialord_rev!(impl PartialOrd<u64> for BigUint);
+impl PartialOrd<u64> for BigUint {
+    #[inline]
+    fn partial_cmp(&self, other: &u64) -> Option<Ordering> {
+        let (hi, lo) = big_digit::from_doublebigdigit(*other);
+        Some(cmp_zero_padded_slice(&self.data[..], &[lo, hi]))
+    }
+}
+impl_scalar_partialeq!(impl PartialEq<i64> for BigUint);
+impl_partialord_rev!(impl PartialOrd<i64> for BigUint);
+impl PartialOrd<i64> for BigUint {
+    #[inline]
+    fn partial_cmp(&self, other: &i64) -> Option<Ordering> {
+        if *other < 0 {
+            Some(Greater)
+        } else {
+            self.partial_cmp(&(*other as u64))
+        }
+    }
+}
+
+#[cfg(has_i128)]
+impl_scalar_partialeq!(impl PartialEq<u128> for BigUint);
+#[cfg(has_i128)]
+impl_partialord_rev!(impl PartialOrd<u128> for BigUint);
+#[cfg(has_i128)]
+impl PartialOrd<u128> for BigUint {
+    #[inline]
+    fn partial_cmp(&self, other: &u128) -> Option<Ordering> {
+        let (a, b, c, d) = u32_from_u128(*other);
+        Some(cmp_zero_padded_slice(&self.data[..], &[d, c, b, a]))
+    }
+}
+#[cfg(has_i128)]
+impl_scalar_partialeq!(impl PartialEq<i128> for BigUint);
+#[cfg(has_i128)]
+impl_partialord_rev!(impl PartialOrd<i128> for BigUint);
+#[cfg(has_i128)]
+impl PartialOrd<i128> for BigUint {
+    #[inline]
+    fn partial_cmp(&self, other: &i128) -> Option<Ordering> {
+        if *other < 0 {
+            Some(Greater)
+        } else {
+            self.partial_cmp(&(*other as u128))
+        }
     }
 }
 

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -487,26 +487,13 @@ macro_rules! impl_partialord_rev {
 }
 
 macro_rules! impl_partialord_partialeq_for_biguint_below_digit {
-    ($typ_signed:ty, $typ_unsigned:ty) => {
+    ($typ_unsigned:ty) => {
         impl_scalar_partialeq!(impl PartialEq<$typ_unsigned> for BigUint);
         impl_partialord_rev!(impl PartialOrd<$typ_unsigned> for BigUint);
         impl PartialOrd<$typ_unsigned> for BigUint {
             #[inline]
             fn partial_cmp(&self, other: &$typ_unsigned) -> Option<Ordering> {
                 Some(cmp_zero_padded_slice(&self.data[..], &[*other as u32]))
-            }
-        }
-
-        impl_scalar_partialeq!(impl PartialEq<$typ_signed> for BigUint);
-        impl_partialord_rev!(impl PartialOrd<$typ_signed> for BigUint);
-        impl PartialOrd<$typ_signed> for BigUint {
-            #[inline]
-            fn partial_cmp(&self, other: &$typ_signed) -> Option<Ordering> {
-                if *other < 0 {
-                    Some(Greater)
-                } else {
-                    self.partial_cmp(&(*other as u32))
-                }
             }
         }
     };

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -500,7 +500,7 @@ macro_rules! impl_partialord_partialeq_for_bigint {
                     return Some(scmp);
                 }
 
-                let abs = (*other).abs() as $typ_unsigned;
+                let abs: $typ_unsigned = other.unsigned_abs();
                 match self.sign {
                     NoSign => Some(Equal),
                     Plus => self.data.partial_cmp(&abs),

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -493,7 +493,7 @@ macro_rules! impl_partialord_partialeq_for_biguint_below_digit {
         impl PartialOrd<$typ_unsigned> for BigUint {
             #[inline]
             fn partial_cmp(&self, other: &$typ_unsigned) -> Option<Ordering> {
-                Some(cmp_zero_padded_slice(&self.data[..], &[*other as u32]))
+                Some(cmp_zero_padded_slice(&self.data[..], &[BigDigit::from(*other)]))
             }
         }
     };

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -480,7 +480,7 @@ macro_rules! impl_partialord_rev {
         impl PartialOrd<$typ> for $scalar {
             #[inline]
             fn partial_cmp(&self, other: &$typ) -> Option<Ordering> {
-                other.partial_cmp(self).map(|o| o.reverse())
+                other.partial_cmp(self).map(Ordering::reverse)
             }
         }
     };

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -465,8 +465,8 @@ macro_rules! impl_scalar_partialeq {
 }
 
 macro_rules! impl_trait_rev {
-    (impl $trait:ident < $scalar:ty > for $res:ty, $method:ident, $ret:ty) => {
-        impl $trait<$res> for $scalar {
+    (impl $trait_name:ident < $scalar:ty > for $res:ty, $method:ident, $ret:ty) => {
+        impl $trait_name<$res> for $scalar {
             #[inline]
             fn $method(&self, other: &$res) -> $ret {
                 other.$method(self)

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -464,17 +464,6 @@ macro_rules! impl_scalar_partialeq {
     };
 }
 
-macro_rules! impl_trait_rev {
-    (impl $trait_name:ident < $scalar:ty > for $res:ty, $method:ident, $ret:ty) => {
-        impl $trait_name<$res> for $scalar {
-            #[inline]
-            fn $method(&self, other: &$res) -> $ret {
-                other.$method(self)
-            }
-        }
-    };
-}
-
 macro_rules! impl_partialord_rev {
     (impl PartialOrd < $scalar:ty > for $typ:ty) => {
         impl PartialOrd<$typ> for $scalar {

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -446,8 +446,8 @@ macro_rules! impl_scalar_partialeq {
         impl PartialEq<$scalar> for $res {
             #[inline]
             fn eq(&self, other: &$scalar) -> bool {
-                match self.partial_cmp(other).unwrap() {
-                    Equal => true,
+                match self.partial_cmp(other) {
+                    Some(Equal) => true,
                     _ => false,
                 }
             }
@@ -455,8 +455,8 @@ macro_rules! impl_scalar_partialeq {
         impl PartialEq<$res> for $scalar {
             #[inline]
             fn eq(&self, other: &$res) -> bool {
-                match self.partial_cmp(other).unwrap() {
-                    Equal => true,
+                match self.partial_cmp(other) {
+                    Some(Equal) => true,
                     _ => false,
                 }
             }

--- a/tests/bigint.rs
+++ b/tests/bigint.rs
@@ -33,8 +33,10 @@ fn test_from_bytes_be() {
     check("AA", "16705");
     check("AB", "16706");
     check("Hello world!", "22405534230753963835153736737");
-    assert_eq!(BigInt::from_bytes_be(Plus, &[]), Zero::zero());
-    assert_eq!(BigInt::from_bytes_be(Minus, &[]), Zero::zero());
+    assert_eq!(BigInt::from_bytes_be(Plus, &[]), BigInt::zero());
+    assert_eq!(BigInt::from_bytes_be(Plus, &[]), 0);
+    assert_eq!(BigInt::from_bytes_be(Minus, &[]), BigInt::zero());
+    assert_eq!(BigInt::from_bytes_be(Minus, &[]), 0);
 }
 
 #[test]
@@ -68,8 +70,8 @@ fn test_from_bytes_le() {
     check("AA", "16705");
     check("BA", "16706");
     check("!dlrow olleH", "22405534230753963835153736737");
-    assert_eq!(BigInt::from_bytes_le(Plus, &[]), Zero::zero());
-    assert_eq!(BigInt::from_bytes_le(Minus, &[]), Zero::zero());
+    assert_eq!(BigInt::from_bytes_le(Plus, &[]), BigInt::zero());
+    assert_eq!(BigInt::from_bytes_le(Minus, &[]), BigInt::zero());
 }
 
 #[test]
@@ -650,7 +652,7 @@ fn test_add() {
         assert_op!(a + nc == nb);
         assert_op!(b + nc == na);
         assert_op!(na + nb == nc);
-        assert_op!(a + na == Zero::zero());
+        assert_op!(a + na == BigInt::zero());
 
         assert_assign_op!(a += b == c);
         assert_assign_op!(b += a == c);
@@ -659,7 +661,7 @@ fn test_add() {
         assert_assign_op!(a += nc == nb);
         assert_assign_op!(b += nc == na);
         assert_assign_op!(na += nb == nc);
-        assert_assign_op!(a += na == Zero::zero());
+        assert_assign_op!(a += na == BigInt::zero());
     }
 }
 
@@ -679,7 +681,7 @@ fn test_sub() {
         assert_op!(b - na == c);
         assert_op!(a - nb == c);
         assert_op!(nc - na == nb);
-        assert_op!(a - a == Zero::zero());
+        assert_op!(a - a == BigInt::zero());
 
         assert_assign_op!(c -= a == b);
         assert_assign_op!(c -= b == a);
@@ -688,7 +690,7 @@ fn test_sub() {
         assert_assign_op!(b -= na == c);
         assert_assign_op!(a -= nb == c);
         assert_assign_op!(nc -= na == nb);
-        assert_assign_op!(a -= a == Zero::zero());
+        assert_assign_op!(a -= a == BigInt::zero());
     }
 }
 
@@ -850,7 +852,7 @@ fn test_checked_add() {
         assert!(a.checked_add(&(-&c)).unwrap() == (-&b));
         assert!(b.checked_add(&(-&c)).unwrap() == (-&a));
         assert!((-&a).checked_add(&(-&b)).unwrap() == (-&c));
-        assert!(a.checked_add(&(-&a)).unwrap() == Zero::zero());
+        assert!(a.checked_add(&(-&a)).unwrap() == BigInt::zero());
     }
 }
 
@@ -869,7 +871,7 @@ fn test_checked_sub() {
         assert!(b.checked_sub(&(-&a)).unwrap() == c);
         assert!(a.checked_sub(&(-&b)).unwrap() == c);
         assert!((-&c).checked_sub(&(-&a)).unwrap() == (-&b));
-        assert!(a.checked_sub(&a).unwrap() == Zero::zero());
+        assert!(a.checked_sub(&a).unwrap() == BigInt::zero());
     }
 }
 
@@ -1092,8 +1094,8 @@ fn test_iter_sum() {
         FromPrimitive::from_i32(-7).unwrap(),
     ];
 
-    assert_eq!(result, data.iter().sum());
-    assert_eq!(result, data.into_iter().sum());
+    assert_eq!(result, data.iter().sum::<BigInt>());
+    assert_eq!(result, data.into_iter().sum::<BigInt>());
 }
 
 #[test]
@@ -1111,8 +1113,8 @@ fn test_iter_product() {
         * data.get(3).unwrap()
         * data.get(4).unwrap();
 
-    assert_eq!(result, data.iter().product());
-    assert_eq!(result, data.into_iter().product());
+    assert_eq!(result, data.iter().product::<BigInt>());
+    assert_eq!(result, data.into_iter().product::<BigInt>());
 }
 
 #[test]
@@ -1120,8 +1122,8 @@ fn test_iter_sum_generic() {
     let result: BigInt = FromPrimitive::from_isize(-1234567).unwrap();
     let data = vec![-1000000, -200000, -30000, -4000, -500, -60, -7];
 
-    assert_eq!(result, data.iter().sum());
-    assert_eq!(result, data.into_iter().sum());
+    assert_eq!(result, data.iter().sum::<BigInt>());
+    assert_eq!(result, data.into_iter().sum::<BigInt>());
 }
 
 #[test]
@@ -1133,8 +1135,8 @@ fn test_iter_product_generic() {
         * data[3].to_bigint().unwrap()
         * data[4].to_bigint().unwrap();
 
-    assert_eq!(result, data.iter().product());
-    assert_eq!(result, data.into_iter().product());
+    assert_eq!(result, data.iter().product::<BigInt>());
+    assert_eq!(result, data.into_iter().product::<BigInt>());
 }
 
 #[test]

--- a/tests/bigint_scalar.rs
+++ b/tests/bigint_scalar.rs
@@ -159,44 +159,80 @@ fn test_bigint_scalar_cmp() {
     fn cmp_asserts(big: &BigInt, scalar: i32) {
         assert_eq!(big.partial_cmp(&(scalar as i8)), Some(Ordering::Equal));
         assert_eq!((scalar as i8).partial_cmp(big), Some(Ordering::Equal));
-        assert_eq!(big.partial_cmp(&(scalar as i8 - 1)), Some(Ordering::Greater));
+        assert_eq!(
+            big.partial_cmp(&(scalar as i8 - 1)),
+            Some(Ordering::Greater)
+        );
         assert_eq!((scalar as i8 + 1).partial_cmp(big), Some(Ordering::Greater));
         assert_eq!(big.partial_cmp(&(scalar as i8 + 1)), Some(Ordering::Less));
         assert_eq!((scalar as i8 - 1).partial_cmp(big), Some(Ordering::Less));
 
         assert_eq!(big.partial_cmp(&(scalar as i16)), Some(Ordering::Equal));
         assert_eq!((scalar as i16).partial_cmp(big), Some(Ordering::Equal));
-        assert_eq!(big.partial_cmp(&(scalar as i16 - 1)), Some(Ordering::Greater));
-        assert_eq!((scalar as i16 + 1).partial_cmp(big), Some(Ordering::Greater));
+        assert_eq!(
+            big.partial_cmp(&(scalar as i16 - 1)),
+            Some(Ordering::Greater)
+        );
+        assert_eq!(
+            (scalar as i16 + 1).partial_cmp(big),
+            Some(Ordering::Greater)
+        );
         assert_eq!(big.partial_cmp(&(scalar as i16 + 1)), Some(Ordering::Less));
         assert_eq!((scalar as i16 - 1).partial_cmp(big), Some(Ordering::Less));
 
         assert_eq!(big.partial_cmp(&(scalar as i32)), Some(Ordering::Equal));
         assert_eq!((scalar as i32).partial_cmp(big), Some(Ordering::Equal));
-        assert_eq!(big.partial_cmp(&(scalar as i32 - 1)), Some(Ordering::Greater));
-        assert_eq!((scalar as i32 + 1).partial_cmp(big), Some(Ordering::Greater));
+        assert_eq!(
+            big.partial_cmp(&(scalar as i32 - 1)),
+            Some(Ordering::Greater)
+        );
+        assert_eq!(
+            (scalar as i32 + 1).partial_cmp(big),
+            Some(Ordering::Greater)
+        );
         assert_eq!(big.partial_cmp(&(scalar as i32 + 1)), Some(Ordering::Less));
         assert_eq!((scalar as i32 - 1).partial_cmp(big), Some(Ordering::Less));
 
         assert_eq!(big.partial_cmp(&(scalar as i64)), Some(Ordering::Equal));
         assert_eq!((scalar as i64).partial_cmp(big), Some(Ordering::Equal));
-        assert_eq!(big.partial_cmp(&(scalar as i64 - 1)), Some(Ordering::Greater));
-        assert_eq!((scalar as i64 + 1).partial_cmp(big), Some(Ordering::Greater));
+        assert_eq!(
+            big.partial_cmp(&(scalar as i64 - 1)),
+            Some(Ordering::Greater)
+        );
+        assert_eq!(
+            (scalar as i64 + 1).partial_cmp(big),
+            Some(Ordering::Greater)
+        );
         assert_eq!(big.partial_cmp(&(scalar as i64 + 1)), Some(Ordering::Less));
         assert_eq!((scalar as i64 - 1).partial_cmp(big), Some(Ordering::Less));
 
         assert_eq!(big.partial_cmp(&(scalar as i128)), Some(Ordering::Equal));
         assert_eq!((scalar as i128).partial_cmp(big), Some(Ordering::Equal));
-        assert_eq!(big.partial_cmp(&(scalar as i128 - 1)), Some(Ordering::Greater));
-        assert_eq!((scalar as i128 + 1).partial_cmp(big), Some(Ordering::Greater));
+        assert_eq!(
+            big.partial_cmp(&(scalar as i128 - 1)),
+            Some(Ordering::Greater)
+        );
+        assert_eq!(
+            (scalar as i128 + 1).partial_cmp(big),
+            Some(Ordering::Greater)
+        );
         assert_eq!(big.partial_cmp(&(scalar as i128 + 1)), Some(Ordering::Less));
         assert_eq!((scalar as i128 - 1).partial_cmp(big), Some(Ordering::Less));
 
         assert_eq!(big.partial_cmp(&(scalar as isize)), Some(Ordering::Equal));
         assert_eq!((scalar as isize).partial_cmp(big), Some(Ordering::Equal));
-        assert_eq!(big.partial_cmp(&(scalar as isize - 1)), Some(Ordering::Greater));
-        assert_eq!((scalar as isize + 1).partial_cmp(big), Some(Ordering::Greater));
-        assert_eq!(big.partial_cmp(&(scalar as isize + 1)), Some(Ordering::Less));
+        assert_eq!(
+            big.partial_cmp(&(scalar as isize - 1)),
+            Some(Ordering::Greater)
+        );
+        assert_eq!(
+            (scalar as isize + 1).partial_cmp(big),
+            Some(Ordering::Greater)
+        );
+        assert_eq!(
+            big.partial_cmp(&(scalar as isize + 1)),
+            Some(Ordering::Less)
+        );
         assert_eq!((scalar as isize - 1).partial_cmp(big), Some(Ordering::Less));
 
         assert_eq!((scalar as i8), *big);

--- a/tests/bigint_scalar.rs
+++ b/tests/bigint_scalar.rs
@@ -2,8 +2,8 @@ use num_bigint::BigInt;
 use num_bigint::Sign::Plus;
 use num_traits::{Signed, ToPrimitive, Zero};
 
-use std::ops::Neg;
 use std::cmp::Ordering;
+use std::ops::Neg;
 
 mod consts;
 use crate::consts::*;

--- a/tests/bigint_scalar.rs
+++ b/tests/bigint_scalar.rs
@@ -148,58 +148,6 @@ fn test_scalar_div_rem() {
     }
 }
 
-macro_rules! bigint_scalar_cmp_asserts {
-    ($big:expr, $scalar:expr) => {
-
-        assert!($big.partial_cmp(&($scalar as i8)) == Some(Ordering::Equal));
-        assert!(($scalar as i8).partial_cmp(&$big) == Some(Ordering::Equal));
-        assert!($big.partial_cmp(&($scalar as i8 - 1)) == Some(Ordering::Greater));
-        assert!(($scalar as i8 + 1).partial_cmp(&$big) == Some(Ordering::Greater));
-        assert!($big.partial_cmp(&($scalar as i8 + 1)) == Some(Ordering::Less));
-        assert!(($scalar as i8 - 1).partial_cmp(&$big) == Some(Ordering::Less));
-
-        assert!($big.partial_cmp(&($scalar as i16)) == Some(Ordering::Equal));
-        assert!(($scalar as i16).partial_cmp(&$big) == Some(Ordering::Equal));
-        assert!($big.partial_cmp(&($scalar as i16 - 1)) == Some(Ordering::Greater));
-        assert!(($scalar as i16 + 1).partial_cmp(&$big) == Some(Ordering::Greater));
-        assert!($big.partial_cmp(&($scalar as i16 + 1)) == Some(Ordering::Less));
-        assert!(($scalar as i16 - 1).partial_cmp(&$big) == Some(Ordering::Less));
-
-        assert!($big.partial_cmp(&($scalar as i32)) == Some(Ordering::Equal));
-        assert!(($scalar as i32).partial_cmp(&$big) == Some(Ordering::Equal));
-        assert!($big.partial_cmp(&($scalar as i32 - 1)) == Some(Ordering::Greater));
-        assert!(($scalar as i32 + 1).partial_cmp(&$big) == Some(Ordering::Greater));
-        assert!($big.partial_cmp(&($scalar as i32 + 1)) == Some(Ordering::Less));
-        assert!(($scalar as i32 - 1).partial_cmp(&$big) == Some(Ordering::Less));
-
-        assert!($big.partial_cmp(&($scalar as i64)) == Some(Ordering::Equal));
-        assert!(($scalar as i64).partial_cmp(&$big) == Some(Ordering::Equal));
-        assert!($big.partial_cmp(&($scalar as i64 - 1)) == Some(Ordering::Greater));
-        assert!(($scalar as i64 + 1).partial_cmp(&$big) == Some(Ordering::Greater));
-        assert!($big.partial_cmp(&($scalar as i64 + 1)) == Some(Ordering::Less));
-        assert!(($scalar as i64 - 1).partial_cmp(&$big) == Some(Ordering::Less));
-
-        assert!(($scalar as i8) == $big);
-        assert!($big == ($scalar as i16));
-        assert!(($scalar as i16) == $big);
-        assert!($big == ($scalar as i32));
-        assert!(($scalar as i32) == $big);
-        assert!($big == ($scalar as i64));
-        assert!(($scalar as i64) == $big);
-
-        if $scalar > 0 {
-            assert!($big == ($scalar as u8));
-            assert!(($scalar as u8) == $big);
-            assert!($big == ($scalar as u16));
-            assert!(($scalar as u16) == $big);
-            assert!($big == ($scalar as u32));
-            assert!(($scalar as u32) == $big);
-            assert!($big == ($scalar as u64));
-            assert!(($scalar as u64) == $big);
-        }
-    };
-}
-
 #[test]
 fn test_bigint_scalar_cmp() {
     let m_five = BigInt::from(-5);

--- a/tests/bigint_scalar.rs
+++ b/tests/bigint_scalar.rs
@@ -3,6 +3,7 @@ use num_bigint::Sign::Plus;
 use num_traits::{Signed, ToPrimitive, Zero};
 
 use std::ops::Neg;
+use std::cmp::Ordering;
 
 mod consts;
 use crate::consts::*;
@@ -93,7 +94,7 @@ fn test_scalar_div_rem() {
         if !r.is_zero() {
             assert_eq!(r.sign(), a.sign());
         }
-        assert!(r.abs() <= From::from(b));
+        assert!(r.abs() <= b);
         assert!(*a == b * &q + &r);
         assert!(q == *ans_q);
         assert!(r == *ans_r);
@@ -145,4 +146,120 @@ fn test_scalar_div_rem() {
             check(&a, b, &c, &d);
         }
     }
+}
+
+macro_rules! bigint_scalar_cmp_asserts {
+    ($big:expr, $scalar:expr) => {
+
+        assert!($big.partial_cmp(&($scalar as i8)) == Some(Ordering::Equal));
+        assert!(($scalar as i8).partial_cmp(&$big) == Some(Ordering::Equal));
+        assert!($big.partial_cmp(&($scalar as i8 - 1)) == Some(Ordering::Greater));
+        assert!(($scalar as i8 + 1).partial_cmp(&$big) == Some(Ordering::Greater));
+        assert!($big.partial_cmp(&($scalar as i8 + 1)) == Some(Ordering::Less));
+        assert!(($scalar as i8 - 1).partial_cmp(&$big) == Some(Ordering::Less));
+
+        assert!($big.partial_cmp(&($scalar as i16)) == Some(Ordering::Equal));
+        assert!(($scalar as i16).partial_cmp(&$big) == Some(Ordering::Equal));
+        assert!($big.partial_cmp(&($scalar as i16 - 1)) == Some(Ordering::Greater));
+        assert!(($scalar as i16 + 1).partial_cmp(&$big) == Some(Ordering::Greater));
+        assert!($big.partial_cmp(&($scalar as i16 + 1)) == Some(Ordering::Less));
+        assert!(($scalar as i16 - 1).partial_cmp(&$big) == Some(Ordering::Less));
+
+        assert!($big.partial_cmp(&($scalar as i32)) == Some(Ordering::Equal));
+        assert!(($scalar as i32).partial_cmp(&$big) == Some(Ordering::Equal));
+        assert!($big.partial_cmp(&($scalar as i32 - 1)) == Some(Ordering::Greater));
+        assert!(($scalar as i32 + 1).partial_cmp(&$big) == Some(Ordering::Greater));
+        assert!($big.partial_cmp(&($scalar as i32 + 1)) == Some(Ordering::Less));
+        assert!(($scalar as i32 - 1).partial_cmp(&$big) == Some(Ordering::Less));
+
+        assert!($big.partial_cmp(&($scalar as i64)) == Some(Ordering::Equal));
+        assert!(($scalar as i64).partial_cmp(&$big) == Some(Ordering::Equal));
+        assert!($big.partial_cmp(&($scalar as i64 - 1)) == Some(Ordering::Greater));
+        assert!(($scalar as i64 + 1).partial_cmp(&$big) == Some(Ordering::Greater));
+        assert!($big.partial_cmp(&($scalar as i64 + 1)) == Some(Ordering::Less));
+        assert!(($scalar as i64 - 1).partial_cmp(&$big) == Some(Ordering::Less));
+
+        assert!(($scalar as i8) == $big);
+        assert!($big == ($scalar as i16));
+        assert!(($scalar as i16) == $big);
+        assert!($big == ($scalar as i32));
+        assert!(($scalar as i32) == $big);
+        assert!($big == ($scalar as i64));
+        assert!(($scalar as i64) == $big);
+
+        if $scalar > 0 {
+            assert!($big == ($scalar as u8));
+            assert!(($scalar as u8) == $big);
+            assert!($big == ($scalar as u16));
+            assert!(($scalar as u16) == $big);
+            assert!($big == ($scalar as u32));
+            assert!(($scalar as u32) == $big);
+            assert!($big == ($scalar as u64));
+            assert!(($scalar as u64) == $big);
+        }
+    };
+}
+
+#[test]
+fn test_bigint_scalar_cmp() {
+    let m_five = BigInt::from(-5);
+    let m_one = BigInt::from(-1);
+    let zero = BigInt::from(0);
+    let one = BigInt::from(1);
+    let five = BigInt::from(5);
+
+    fn cmp_asserts(big: &BigInt, scalar: i32) {
+        assert!(big.partial_cmp(&(scalar as i8)) == Some(Ordering::Equal));
+        assert!((scalar as i8).partial_cmp(big) == Some(Ordering::Equal));
+        assert!(big.partial_cmp(&(scalar as i8 - 1)) == Some(Ordering::Greater));
+        assert!((scalar as i8 + 1).partial_cmp(big) == Some(Ordering::Greater));
+        assert!(big.partial_cmp(&(scalar as i8 + 1)) == Some(Ordering::Less));
+        assert!((scalar as i8 - 1).partial_cmp(big) == Some(Ordering::Less));
+
+        assert!(big.partial_cmp(&(scalar as i16)) == Some(Ordering::Equal));
+        assert!((scalar as i16).partial_cmp(big) == Some(Ordering::Equal));
+        assert!(big.partial_cmp(&(scalar as i16 - 1)) == Some(Ordering::Greater));
+        assert!((scalar as i16 + 1).partial_cmp(big) == Some(Ordering::Greater));
+        assert!(big.partial_cmp(&(scalar as i16 + 1)) == Some(Ordering::Less));
+        assert!((scalar as i16 - 1).partial_cmp(big) == Some(Ordering::Less));
+
+        assert!(big.partial_cmp(&(scalar as i32)) == Some(Ordering::Equal));
+        assert!((scalar as i32).partial_cmp(big) == Some(Ordering::Equal));
+        assert!(big.partial_cmp(&(scalar as i32 - 1)) == Some(Ordering::Greater));
+        assert!((scalar as i32 + 1).partial_cmp(big) == Some(Ordering::Greater));
+        assert!(big.partial_cmp(&(scalar as i32 + 1)) == Some(Ordering::Less));
+        assert!((scalar as i32 - 1).partial_cmp(big) == Some(Ordering::Less));
+
+        assert!(big.partial_cmp(&(scalar as i64)) == Some(Ordering::Equal));
+        assert!((scalar as i64).partial_cmp(big) == Some(Ordering::Equal));
+        assert!(big.partial_cmp(&(scalar as i64 - 1)) == Some(Ordering::Greater));
+        assert!((scalar as i64 + 1).partial_cmp(big) == Some(Ordering::Greater));
+        assert!(big.partial_cmp(&(scalar as i64 + 1)) == Some(Ordering::Less));
+        assert!((scalar as i64 - 1).partial_cmp(big) == Some(Ordering::Less));
+
+        assert!((scalar as i8) == *big);
+        assert!(*big == (scalar as i16));
+        assert!((scalar as i16) == *big);
+        assert!(*big == (scalar as i32));
+        assert!((scalar as i32) == *big);
+        assert!(*big == (scalar as i64));
+        assert!((scalar as i64) == *big);
+
+        if scalar > 0 {
+            assert!(*big == (scalar as u8));
+            assert!((scalar as u8) == *big);
+            assert!(*big == (scalar as u16));
+            assert!((scalar as u16) == *big);
+            assert!(*big == (scalar as u32));
+            assert!((scalar as u32) == *big);
+            assert!(*big == (scalar as u64));
+            assert!((scalar as u64) == *big);
+        }
+    }
+
+    cmp_asserts(&zero, 0i32);
+    cmp_asserts(&one, 1i32);
+    cmp_asserts(&five, 5i32);
+    cmp_asserts(&m_five, -5i32);
+    cmp_asserts(&m_one, -1i32);
 }

--- a/tests/bigint_scalar.rs
+++ b/tests/bigint_scalar.rs
@@ -1,6 +1,6 @@
 use num_bigint::BigInt;
 use num_bigint::Sign::Plus;
-use num_traits::{Signed, ToPrimitive, Zero};
+use num_traits::{Bounded, Signed, ToPrimitive, Zero};
 
 use std::cmp::Ordering;
 use std::ops::Neg;
@@ -232,4 +232,39 @@ fn test_bigint_scalar_cmp() {
     cmp_asserts(&five, 5i32);
     cmp_asserts(&m_five, -5i32);
     cmp_asserts(&m_one, -1i32);
+}
+
+#[test]
+fn test_bigint_scalar_cmp_limits() {
+    fn check<T>()
+    where
+        T: Copy + Bounded,
+        BigInt: From<T> + PartialOrd<T>,
+    {
+        let min = T::min_value();
+        let big_min = BigInt::from(min);
+        assert_eq!(big_min.partial_cmp(&min), Some(Ordering::Equal));
+        assert_eq!((&big_min - 1u32).partial_cmp(&min), Some(Ordering::Less));
+        assert_eq!((&big_min + 1u32).partial_cmp(&min), Some(Ordering::Greater));
+
+        let max = T::max_value();
+        let big_max = BigInt::from(max);
+        assert_eq!(big_max.partial_cmp(&max), Some(Ordering::Equal));
+        assert_eq!((&big_max - 1u32).partial_cmp(&max), Some(Ordering::Less));
+        assert_eq!((&big_max + 1u32).partial_cmp(&max), Some(Ordering::Greater));
+    }
+
+    check::<i8>();
+    check::<i16>();
+    check::<i32>();
+    check::<i64>();
+    check::<i128>();
+    check::<isize>();
+
+    check::<u8>();
+    check::<u16>();
+    check::<u32>();
+    check::<u64>();
+    check::<u128>();
+    check::<usize>();
 }

--- a/tests/bigint_scalar.rs
+++ b/tests/bigint_scalar.rs
@@ -157,73 +157,73 @@ fn test_bigint_scalar_cmp() {
     let five = BigInt::from(5);
 
     fn cmp_asserts(big: &BigInt, scalar: i32) {
-        assert!(big.partial_cmp(&(scalar as i8)) == Some(Ordering::Equal));
-        assert!((scalar as i8).partial_cmp(big) == Some(Ordering::Equal));
-        assert!(big.partial_cmp(&(scalar as i8 - 1)) == Some(Ordering::Greater));
-        assert!((scalar as i8 + 1).partial_cmp(big) == Some(Ordering::Greater));
-        assert!(big.partial_cmp(&(scalar as i8 + 1)) == Some(Ordering::Less));
-        assert!((scalar as i8 - 1).partial_cmp(big) == Some(Ordering::Less));
+        assert_eq!(big.partial_cmp(&(scalar as i8)), Some(Ordering::Equal));
+        assert_eq!((scalar as i8).partial_cmp(big), Some(Ordering::Equal));
+        assert_eq!(big.partial_cmp(&(scalar as i8 - 1)), Some(Ordering::Greater));
+        assert_eq!((scalar as i8 + 1).partial_cmp(big), Some(Ordering::Greater));
+        assert_eq!(big.partial_cmp(&(scalar as i8 + 1)), Some(Ordering::Less));
+        assert_eq!((scalar as i8 - 1).partial_cmp(big), Some(Ordering::Less));
 
-        assert!(big.partial_cmp(&(scalar as i16)) == Some(Ordering::Equal));
-        assert!((scalar as i16).partial_cmp(big) == Some(Ordering::Equal));
-        assert!(big.partial_cmp(&(scalar as i16 - 1)) == Some(Ordering::Greater));
-        assert!((scalar as i16 + 1).partial_cmp(big) == Some(Ordering::Greater));
-        assert!(big.partial_cmp(&(scalar as i16 + 1)) == Some(Ordering::Less));
-        assert!((scalar as i16 - 1).partial_cmp(big) == Some(Ordering::Less));
+        assert_eq!(big.partial_cmp(&(scalar as i16)), Some(Ordering::Equal));
+        assert_eq!((scalar as i16).partial_cmp(big), Some(Ordering::Equal));
+        assert_eq!(big.partial_cmp(&(scalar as i16 - 1)), Some(Ordering::Greater));
+        assert_eq!((scalar as i16 + 1).partial_cmp(big), Some(Ordering::Greater));
+        assert_eq!(big.partial_cmp(&(scalar as i16 + 1)), Some(Ordering::Less));
+        assert_eq!((scalar as i16 - 1).partial_cmp(big), Some(Ordering::Less));
 
-        assert!(big.partial_cmp(&(scalar as i32)) == Some(Ordering::Equal));
-        assert!((scalar as i32).partial_cmp(big) == Some(Ordering::Equal));
-        assert!(big.partial_cmp(&(scalar as i32 - 1)) == Some(Ordering::Greater));
-        assert!((scalar as i32 + 1).partial_cmp(big) == Some(Ordering::Greater));
-        assert!(big.partial_cmp(&(scalar as i32 + 1)) == Some(Ordering::Less));
-        assert!((scalar as i32 - 1).partial_cmp(big) == Some(Ordering::Less));
+        assert_eq!(big.partial_cmp(&(scalar as i32)), Some(Ordering::Equal));
+        assert_eq!((scalar as i32).partial_cmp(big), Some(Ordering::Equal));
+        assert_eq!(big.partial_cmp(&(scalar as i32 - 1)), Some(Ordering::Greater));
+        assert_eq!((scalar as i32 + 1).partial_cmp(big), Some(Ordering::Greater));
+        assert_eq!(big.partial_cmp(&(scalar as i32 + 1)), Some(Ordering::Less));
+        assert_eq!((scalar as i32 - 1).partial_cmp(big), Some(Ordering::Less));
 
-        assert!(big.partial_cmp(&(scalar as i64)) == Some(Ordering::Equal));
-        assert!((scalar as i64).partial_cmp(big) == Some(Ordering::Equal));
-        assert!(big.partial_cmp(&(scalar as i64 - 1)) == Some(Ordering::Greater));
-        assert!((scalar as i64 + 1).partial_cmp(big) == Some(Ordering::Greater));
-        assert!(big.partial_cmp(&(scalar as i64 + 1)) == Some(Ordering::Less));
-        assert!((scalar as i64 - 1).partial_cmp(big) == Some(Ordering::Less));
+        assert_eq!(big.partial_cmp(&(scalar as i64)), Some(Ordering::Equal));
+        assert_eq!((scalar as i64).partial_cmp(big), Some(Ordering::Equal));
+        assert_eq!(big.partial_cmp(&(scalar as i64 - 1)), Some(Ordering::Greater));
+        assert_eq!((scalar as i64 + 1).partial_cmp(big), Some(Ordering::Greater));
+        assert_eq!(big.partial_cmp(&(scalar as i64 + 1)), Some(Ordering::Less));
+        assert_eq!((scalar as i64 - 1).partial_cmp(big), Some(Ordering::Less));
 
-        assert!(big.partial_cmp(&(scalar as i128)) == Some(Ordering::Equal));
-        assert!((scalar as i128).partial_cmp(big) == Some(Ordering::Equal));
-        assert!(big.partial_cmp(&(scalar as i128 - 1)) == Some(Ordering::Greater));
-        assert!((scalar as i128 + 1).partial_cmp(big) == Some(Ordering::Greater));
-        assert!(big.partial_cmp(&(scalar as i128 + 1)) == Some(Ordering::Less));
-        assert!((scalar as i128 - 1).partial_cmp(big) == Some(Ordering::Less));
+        assert_eq!(big.partial_cmp(&(scalar as i128)), Some(Ordering::Equal));
+        assert_eq!((scalar as i128).partial_cmp(big), Some(Ordering::Equal));
+        assert_eq!(big.partial_cmp(&(scalar as i128 - 1)), Some(Ordering::Greater));
+        assert_eq!((scalar as i128 + 1).partial_cmp(big), Some(Ordering::Greater));
+        assert_eq!(big.partial_cmp(&(scalar as i128 + 1)), Some(Ordering::Less));
+        assert_eq!((scalar as i128 - 1).partial_cmp(big), Some(Ordering::Less));
 
-        assert!(big.partial_cmp(&(scalar as isize)) == Some(Ordering::Equal));
-        assert!((scalar as isize).partial_cmp(big) == Some(Ordering::Equal));
-        assert!(big.partial_cmp(&(scalar as isize - 1)) == Some(Ordering::Greater));
-        assert!((scalar as isize + 1).partial_cmp(big) == Some(Ordering::Greater));
-        assert!(big.partial_cmp(&(scalar as isize + 1)) == Some(Ordering::Less));
-        assert!((scalar as isize - 1).partial_cmp(big) == Some(Ordering::Less));
+        assert_eq!(big.partial_cmp(&(scalar as isize)), Some(Ordering::Equal));
+        assert_eq!((scalar as isize).partial_cmp(big), Some(Ordering::Equal));
+        assert_eq!(big.partial_cmp(&(scalar as isize - 1)), Some(Ordering::Greater));
+        assert_eq!((scalar as isize + 1).partial_cmp(big), Some(Ordering::Greater));
+        assert_eq!(big.partial_cmp(&(scalar as isize + 1)), Some(Ordering::Less));
+        assert_eq!((scalar as isize - 1).partial_cmp(big), Some(Ordering::Less));
 
-        assert!((scalar as i8) == *big);
-        assert!(*big == (scalar as i16));
-        assert!((scalar as i16) == *big);
-        assert!(*big == (scalar as i32));
-        assert!((scalar as i32) == *big);
-        assert!(*big == (scalar as i64));
-        assert!((scalar as i64) == *big);
-        assert!(*big == (scalar as i128));
-        assert!((scalar as i128) == *big);
-        assert!(*big == (scalar as isize));
-        assert!((scalar as isize) == *big);
+        assert_eq!((scalar as i8), *big);
+        assert_eq!(*big, (scalar as i16));
+        assert_eq!((scalar as i16), *big);
+        assert_eq!(*big, (scalar as i32));
+        assert_eq!((scalar as i32), *big);
+        assert_eq!(*big, (scalar as i64));
+        assert_eq!((scalar as i64), *big);
+        assert_eq!(*big, (scalar as i128));
+        assert_eq!((scalar as i128), *big);
+        assert_eq!(*big, (scalar as isize));
+        assert_eq!((scalar as isize), *big);
 
         if scalar > 0 {
-            assert!(*big == (scalar as u8));
-            assert!((scalar as u8) == *big);
-            assert!(*big == (scalar as u16));
-            assert!((scalar as u16) == *big);
-            assert!(*big == (scalar as u32));
-            assert!((scalar as u32) == *big);
-            assert!(*big == (scalar as u64));
-            assert!((scalar as u64) == *big);
-            assert!(*big == (scalar as u128));
-            assert!((scalar as u128) == *big);
-            assert!(*big == (scalar as usize));
-            assert!((scalar as usize) == *big);
+            assert_eq!(*big, (scalar as u8));
+            assert_eq!((scalar as u8), *big);
+            assert_eq!(*big, (scalar as u16));
+            assert_eq!((scalar as u16), *big);
+            assert_eq!(*big, (scalar as u32));
+            assert_eq!((scalar as u32), *big);
+            assert_eq!(*big, (scalar as u64));
+            assert_eq!((scalar as u64), *big);
+            assert_eq!(*big, (scalar as u128));
+            assert_eq!((scalar as u128), *big);
+            assert_eq!(*big, (scalar as usize));
+            assert_eq!((scalar as usize), *big);
         }
     }
 

--- a/tests/bigint_scalar.rs
+++ b/tests/bigint_scalar.rs
@@ -185,6 +185,20 @@ fn test_bigint_scalar_cmp() {
         assert!(big.partial_cmp(&(scalar as i64 + 1)) == Some(Ordering::Less));
         assert!((scalar as i64 - 1).partial_cmp(big) == Some(Ordering::Less));
 
+        assert!(big.partial_cmp(&(scalar as i128)) == Some(Ordering::Equal));
+        assert!((scalar as i128).partial_cmp(big) == Some(Ordering::Equal));
+        assert!(big.partial_cmp(&(scalar as i128 - 1)) == Some(Ordering::Greater));
+        assert!((scalar as i128 + 1).partial_cmp(big) == Some(Ordering::Greater));
+        assert!(big.partial_cmp(&(scalar as i128 + 1)) == Some(Ordering::Less));
+        assert!((scalar as i128 - 1).partial_cmp(big) == Some(Ordering::Less));
+
+        assert!(big.partial_cmp(&(scalar as isize)) == Some(Ordering::Equal));
+        assert!((scalar as isize).partial_cmp(big) == Some(Ordering::Equal));
+        assert!(big.partial_cmp(&(scalar as isize - 1)) == Some(Ordering::Greater));
+        assert!((scalar as isize + 1).partial_cmp(big) == Some(Ordering::Greater));
+        assert!(big.partial_cmp(&(scalar as isize + 1)) == Some(Ordering::Less));
+        assert!((scalar as isize - 1).partial_cmp(big) == Some(Ordering::Less));
+
         assert!((scalar as i8) == *big);
         assert!(*big == (scalar as i16));
         assert!((scalar as i16) == *big);
@@ -192,6 +206,10 @@ fn test_bigint_scalar_cmp() {
         assert!((scalar as i32) == *big);
         assert!(*big == (scalar as i64));
         assert!((scalar as i64) == *big);
+        assert!(*big == (scalar as i128));
+        assert!((scalar as i128) == *big);
+        assert!(*big == (scalar as isize));
+        assert!((scalar as isize) == *big);
 
         if scalar > 0 {
             assert!(*big == (scalar as u8));
@@ -202,6 +220,10 @@ fn test_bigint_scalar_cmp() {
             assert!((scalar as u32) == *big);
             assert!(*big == (scalar as u64));
             assert!((scalar as u64) == *big);
+            assert!(*big == (scalar as u128));
+            assert!((scalar as u128) == *big);
+            assert!(*big == (scalar as usize));
+            assert!((scalar as usize) == *big);
         }
     }
 

--- a/tests/biguint.rs
+++ b/tests/biguint.rs
@@ -36,7 +36,7 @@ fn test_from_bytes_be() {
     check("AA", "16705");
     check("AB", "16706");
     check("Hello world!", "22405534230753963835153736737");
-    assert_eq!(BigUint::from_bytes_be(&[]), Zero::zero());
+    assert_eq!(BigUint::from_bytes_be(&[]), BigUint::zero());
 }
 
 #[test]
@@ -69,7 +69,7 @@ fn test_from_bytes_le() {
     check("AA", "16705");
     check("BA", "16706");
     check("!dlrow olleH", "22405534230753963835153736737");
-    assert_eq!(BigUint::from_bytes_le(&[]), Zero::zero());
+    assert_eq!(BigUint::from_bytes_le(&[]), BigUint::zero());
 }
 
 #[test]
@@ -860,17 +860,17 @@ fn test_div_rem() {
 
         if !a.is_zero() {
             assert_op!(c / a == b);
-            assert_op!(c % a == Zero::zero());
+            assert_op!(c % a == BigUint::zero());
             assert_assign_op!(c /= a == b);
-            assert_assign_op!(c %= a == Zero::zero());
-            assert_eq!(c.div_rem(&a), (b.clone(), Zero::zero()));
+            assert_assign_op!(c %= a == BigUint::zero());
+            assert_eq!(c.div_rem(&a), (b.clone(), BigUint::zero()));
         }
         if !b.is_zero() {
             assert_op!(c / b == a);
-            assert_op!(c % b == Zero::zero());
+            assert_op!(c % b == BigUint::zero());
             assert_assign_op!(c /= b == a);
-            assert_assign_op!(c %= b == Zero::zero());
-            assert_eq!(c.div_rem(&b), (a.clone(), Zero::zero()));
+            assert_assign_op!(c %= b == BigUint::zero());
+            assert_eq!(c.div_rem(&b), (a.clone(), BigUint::zero()));
         }
     }
 
@@ -1621,8 +1621,8 @@ fn test_iter_sum() {
         FromPrimitive::from_u32(7).unwrap(),
     ];
 
-    assert_eq!(result, data.iter().sum());
-    assert_eq!(result, data.into_iter().sum());
+    assert_eq!(result, data.iter().sum::<BigUint>());
+    assert_eq!(result, data.into_iter().sum::<BigUint>());
 }
 
 #[test]
@@ -1640,8 +1640,8 @@ fn test_iter_product() {
         * data.get(3).unwrap()
         * data.get(4).unwrap();
 
-    assert_eq!(result, data.iter().product());
-    assert_eq!(result, data.into_iter().product());
+    assert_eq!(result, data.iter().product::<BigUint>());
+    assert_eq!(result, data.into_iter().product::<BigUint>());
 }
 
 #[test]
@@ -1649,8 +1649,8 @@ fn test_iter_sum_generic() {
     let result: BigUint = FromPrimitive::from_isize(1234567).unwrap();
     let data = vec![1000000_u32, 200000, 30000, 4000, 500, 60, 7];
 
-    assert_eq!(result, data.iter().sum());
-    assert_eq!(result, data.into_iter().sum());
+    assert_eq!(result, data.iter().sum::<BigUint>());
+    assert_eq!(result, data.into_iter().sum::<BigUint>());
 }
 
 #[test]
@@ -1662,8 +1662,8 @@ fn test_iter_product_generic() {
         * data[3].to_biguint().unwrap()
         * data[4].to_biguint().unwrap();
 
-    assert_eq!(result, data.iter().product());
-    assert_eq!(result, data.into_iter().product());
+    assert_eq!(result, data.iter().product::<BigUint>());
+    assert_eq!(result, data.into_iter().product::<BigUint>());
 }
 
 #[test]

--- a/tests/biguint_scalar.rs
+++ b/tests/biguint_scalar.rs
@@ -141,13 +141,10 @@ fn test_biguint_scalar_cmp() {
         assert!((scalar as u64 + 1).partial_cmp(num) == Some(Greater));
         assert!(num.partial_cmp(&(scalar as u64 + 1)) == Some(Less));
 
-        #[cfg(has_i128)]
-        {
-            assert!(num.partial_cmp(&(scalar as u128)) == Some(Equal));
-            assert!((scalar as u128).partial_cmp(num) == Some(Equal));
-            assert!((scalar as u128 + 1).partial_cmp(num) == Some(Greater));
-            assert!(num.partial_cmp(&(scalar as u128 + 1)) == Some(Less));
-        }
+        assert!(num.partial_cmp(&(scalar as u128)) == Some(Equal));
+        assert!((scalar as u128).partial_cmp(num) == Some(Equal));
+        assert!((scalar as u128 + 1).partial_cmp(num) == Some(Greater));
+        assert!(num.partial_cmp(&(scalar as u128 + 1)) == Some(Less));
     }
 
     scalar_cmp_asserts(&zero, 0);

--- a/tests/biguint_scalar.rs
+++ b/tests/biguint_scalar.rs
@@ -1,6 +1,8 @@
 use num_bigint::BigUint;
 use num_traits::{ToPrimitive, Zero};
 
+use std::cmp::Ordering;
+
 mod consts;
 use crate::consts::*;
 
@@ -66,8 +68,8 @@ fn test_scalar_mul() {
 
 #[test]
 fn test_scalar_rem_noncommutative() {
-    assert_eq!(5u8 % BigUint::from(7u8), 5u8.into());
-    assert_eq!(BigUint::from(5u8) % 7u8, 5u8.into());
+    assert_eq!(5u8 % BigUint::from(7u8), 5);
+    assert_eq!(BigUint::from(5u8) % 7u8, 5);
 }
 
 #[test]
@@ -110,4 +112,90 @@ fn test_scalar_div_rem() {
             assert_unsigned_scalar_assign_op!(a %= b == d);
         }
     }
+}
+
+#[test]
+fn test_biguint_scalar_cmp() {
+    use std::cmp::Ordering::*;
+
+    let zero = BigUint::from(0u32);
+    let one = BigUint::from(1u32);
+    let five = BigUint::from(5u32);
+
+    fn scalar_cmp_asserts(num: &BigUint, scalar: i32) {
+
+        assert!(num.partial_cmp(&(scalar as i8)) == Some(Equal));
+        assert!((scalar as i8).partial_cmp(num) == Some(Equal));
+        assert!(num.partial_cmp(&(scalar as i8 - 1)) == Some(Greater));
+        assert!((scalar as i8 + 1).partial_cmp(num) == Some(Greater));
+        assert!(num.partial_cmp(&(scalar as i8 + 1)) == Some(Less));
+        assert!((scalar as i8 - 1).partial_cmp(num) == Some(Less));
+
+        assert!(num.partial_cmp(&(scalar as u8)) == Some(Equal));
+        assert!((scalar as u8).partial_cmp(num) == Some(Equal));
+        assert!((scalar as u8 + 1).partial_cmp(num) == Some(Greater));
+        assert!(num.partial_cmp(&(scalar as u8 + 1)) == Some(Less));
+
+        assert!(num.partial_cmp(&(scalar as i16)) == Some(Equal));
+        assert!((scalar as i16).partial_cmp(num) == Some(Equal));
+        assert!(num.partial_cmp(&(scalar as i16 - 1)) == Some(Greater));
+        assert!((scalar as i16 + 1).partial_cmp(num) == Some(Greater));
+        assert!(num.partial_cmp(&(scalar as i16 + 1)) == Some(Less));
+        assert!((scalar as i16 - 1).partial_cmp(num) == Some(Less));
+
+        assert!(num.partial_cmp(&(scalar as u16)) == Some(Equal));
+        assert!((scalar as u16).partial_cmp(num) == Some(Equal));
+        assert!((scalar as u16 + 1).partial_cmp(num) == Some(Greater));
+        assert!(num.partial_cmp(&(scalar as u16 + 1)) == Some(Less));
+
+        assert!(num.partial_cmp(&(scalar as i32)) == Some(Equal));
+        assert!((scalar as i32).partial_cmp(num) == Some(Equal));
+        assert!(num.partial_cmp(&(scalar as i32 - 1)) == Some(Greater));
+        assert!((scalar as i32 + 1).partial_cmp(num) == Some(Greater));
+        assert!(num.partial_cmp(&(scalar as i32 + 1)) == Some(Less));
+        assert!((scalar as i32 - 1).partial_cmp(num) == Some(Less));
+
+        assert!(num.partial_cmp(&(scalar as u32)) == Some(Equal));
+        assert!((scalar as u32).partial_cmp(num) == Some(Equal));
+        assert!((scalar as u32 + 1).partial_cmp(num) == Some(Greater));
+        assert!(num.partial_cmp(&(scalar as u32 + 1)) == Some(Less));
+
+        assert!(num.partial_cmp(&(scalar as i64)) == Some(Equal));
+        assert!((scalar as i64).partial_cmp(num) == Some(Equal));
+        assert!(num.partial_cmp(&(scalar as i64 - 1)) == Some(Greater));
+        assert!((scalar as i64 + 1).partial_cmp(num) == Some(Greater));
+        assert!(num.partial_cmp(&(scalar as i64 + 1)) == Some(Less));
+        assert!((scalar as i64 - 1).partial_cmp(num) == Some(Less));
+
+        assert!(num.partial_cmp(&(scalar as u64)) == Some(Equal));
+        assert!((scalar as u64).partial_cmp(num) == Some(Equal));
+        assert!((scalar as u64 + 1).partial_cmp(num) == Some(Greater));
+        assert!(num.partial_cmp(&(scalar as u64 + 1)) == Some(Less));
+
+        #[cfg(has_i128)]
+        {
+            assert!(num.partial_cmp(&(scalar as i128)) == Some(Equal));
+            assert!((scalar as i128).partial_cmp(num) == Some(Equal));
+            assert!(num.partial_cmp(&(scalar as i128 - 1)) == Some(Greater));
+            assert!((scalar as i128 + 1).partial_cmp(num) == Some(Greater));
+            assert!(num.partial_cmp(&(scalar as i128 + 1)) == Some(Less));
+            assert!((scalar as i128 - 1).partial_cmp(num) == Some(Less));
+
+            assert!(num.partial_cmp(&(scalar as u128)) == Some(Equal));
+            assert!((scalar as u128).partial_cmp(num) == Some(Equal));
+            assert!((scalar as u128 + 1).partial_cmp(num) == Some(Greater));
+            assert!(num.partial_cmp(&(scalar as u128 + 1)) == Some(Less));
+        }
+
+    }
+
+    scalar_cmp_asserts(&zero, 0);
+    scalar_cmp_asserts(&one, 1);
+    scalar_cmp_asserts(&five, 5);
+
+    let a = BigUint::from(10000000000u64);
+    assert!(a.partial_cmp(&10000000000u64) == Some(Equal));
+    assert!(a.partial_cmp(&1000000000u64) == Some(Greater));
+    assert!(a.partial_cmp(&100000000000u64) == Some(Less));
+
 }

--- a/tests/biguint_scalar.rs
+++ b/tests/biguint_scalar.rs
@@ -121,35 +121,35 @@ fn test_biguint_scalar_cmp() {
     let five = BigUint::from(5u32);
 
     fn scalar_cmp_asserts(num: &BigUint, scalar: i32) {
-        assert!(num.partial_cmp(&(scalar as u8)) == Some(Equal));
-        assert!((scalar as u8).partial_cmp(num) == Some(Equal));
-        assert!((scalar as u8 + 1).partial_cmp(num) == Some(Greater));
-        assert!(num.partial_cmp(&(scalar as u8 + 1)) == Some(Less));
+        assert_eq!(num.partial_cmp(&(scalar as u8)), Some(Equal));
+        assert_eq!((scalar as u8).partial_cmp(num), Some(Equal));
+        assert_eq!((scalar as u8 + 1).partial_cmp(num), Some(Greater));
+        assert_eq!(num.partial_cmp(&(scalar as u8 + 1)), Some(Less));
 
-        assert!(num.partial_cmp(&(scalar as u16)) == Some(Equal));
-        assert!((scalar as u16).partial_cmp(num) == Some(Equal));
-        assert!((scalar as u16 + 1).partial_cmp(num) == Some(Greater));
-        assert!(num.partial_cmp(&(scalar as u16 + 1)) == Some(Less));
+        assert_eq!(num.partial_cmp(&(scalar as u16)), Some(Equal));
+        assert_eq!((scalar as u16).partial_cmp(num), Some(Equal));
+        assert_eq!((scalar as u16 + 1).partial_cmp(num), Some(Greater));
+        assert_eq!(num.partial_cmp(&(scalar as u16 + 1)), Some(Less));
 
-        assert!(num.partial_cmp(&(scalar as u32)) == Some(Equal));
-        assert!((scalar as u32).partial_cmp(num) == Some(Equal));
-        assert!((scalar as u32 + 1).partial_cmp(num) == Some(Greater));
-        assert!(num.partial_cmp(&(scalar as u32 + 1)) == Some(Less));
+        assert_eq!(num.partial_cmp(&(scalar as u32)), Some(Equal));
+        assert_eq!((scalar as u32).partial_cmp(num), Some(Equal));
+        assert_eq!((scalar as u32 + 1).partial_cmp(num), Some(Greater));
+        assert_eq!(num.partial_cmp(&(scalar as u32 + 1)), Some(Less));
 
-        assert!(num.partial_cmp(&(scalar as u64)) == Some(Equal));
-        assert!((scalar as u64).partial_cmp(num) == Some(Equal));
-        assert!((scalar as u64 + 1).partial_cmp(num) == Some(Greater));
-        assert!(num.partial_cmp(&(scalar as u64 + 1)) == Some(Less));
+        assert_eq!(num.partial_cmp(&(scalar as u64)), Some(Equal));
+        assert_eq!((scalar as u64).partial_cmp(num), Some(Equal));
+        assert_eq!((scalar as u64 + 1).partial_cmp(num), Some(Greater));
+        assert_eq!(num.partial_cmp(&(scalar as u64 + 1)), Some(Less));
 
-        assert!(num.partial_cmp(&(scalar as u128)) == Some(Equal));
-        assert!((scalar as u128).partial_cmp(num) == Some(Equal));
-        assert!((scalar as u128 + 1).partial_cmp(num) == Some(Greater));
-        assert!(num.partial_cmp(&(scalar as u128 + 1)) == Some(Less));
+        assert_eq!(num.partial_cmp(&(scalar as u128)), Some(Equal));
+        assert_eq!((scalar as u128).partial_cmp(num), Some(Equal));
+        assert_eq!((scalar as u128 + 1).partial_cmp(num), Some(Greater));
+        assert_eq!(num.partial_cmp(&(scalar as u128 + 1)), Some(Less));
 
-        assert!(num.partial_cmp(&(scalar as usize)) == Some(Equal));
-        assert!((scalar as usize).partial_cmp(num) == Some(Equal));
-        assert!((scalar as usize + 1).partial_cmp(num) == Some(Greater));
-        assert!(num.partial_cmp(&(scalar as usize + 1)) == Some(Less));
+        assert_eq!(num.partial_cmp(&(scalar as usize)), Some(Equal));
+        assert_eq!((scalar as usize).partial_cmp(num), Some(Equal));
+        assert_eq!((scalar as usize + 1).partial_cmp(num), Some(Greater));
+        assert_eq!(num.partial_cmp(&(scalar as usize + 1)), Some(Less));
     }
 
     scalar_cmp_asserts(&zero, 0);
@@ -157,7 +157,7 @@ fn test_biguint_scalar_cmp() {
     scalar_cmp_asserts(&five, 5);
 
     let a = BigUint::from(10000000000u64);
-    assert!(a.partial_cmp(&10000000000u64) == Some(Equal));
-    assert!(a.partial_cmp(&1000000000u64) == Some(Greater));
-    assert!(a.partial_cmp(&100000000000u64) == Some(Less));
+    assert_eq!(a.partial_cmp(&10000000000u64), Some(Equal));
+    assert_eq!(a.partial_cmp(&1000000000u64), Some(Greater));
+    assert_eq!(a.partial_cmp(&100000000000u64), Some(Less));
 }

--- a/tests/biguint_scalar.rs
+++ b/tests/biguint_scalar.rs
@@ -121,7 +121,6 @@ fn test_biguint_scalar_cmp() {
     let five = BigUint::from(5u32);
 
     fn scalar_cmp_asserts(num: &BigUint, scalar: i32) {
-
         assert!(num.partial_cmp(&(scalar as i8)) == Some(Equal));
         assert!((scalar as i8).partial_cmp(num) == Some(Equal));
         assert!(num.partial_cmp(&(scalar as i8 - 1)) == Some(Greater));
@@ -184,7 +183,6 @@ fn test_biguint_scalar_cmp() {
             assert!((scalar as u128 + 1).partial_cmp(num) == Some(Greater));
             assert!(num.partial_cmp(&(scalar as u128 + 1)) == Some(Less));
         }
-
     }
 
     scalar_cmp_asserts(&zero, 0);
@@ -195,5 +193,4 @@ fn test_biguint_scalar_cmp() {
     assert!(a.partial_cmp(&10000000000u64) == Some(Equal));
     assert!(a.partial_cmp(&1000000000u64) == Some(Greater));
     assert!(a.partial_cmp(&100000000000u64) == Some(Less));
-
 }

--- a/tests/biguint_scalar.rs
+++ b/tests/biguint_scalar.rs
@@ -145,6 +145,11 @@ fn test_biguint_scalar_cmp() {
         assert!((scalar as u128).partial_cmp(num) == Some(Equal));
         assert!((scalar as u128 + 1).partial_cmp(num) == Some(Greater));
         assert!(num.partial_cmp(&(scalar as u128 + 1)) == Some(Less));
+
+        assert!(num.partial_cmp(&(scalar as usize)) == Some(Equal));
+        assert!((scalar as usize).partial_cmp(num) == Some(Equal));
+        assert!((scalar as usize + 1).partial_cmp(num) == Some(Greater));
+        assert!(num.partial_cmp(&(scalar as usize + 1)) == Some(Less));
     }
 
     scalar_cmp_asserts(&zero, 0);

--- a/tests/biguint_scalar.rs
+++ b/tests/biguint_scalar.rs
@@ -66,8 +66,8 @@ fn test_scalar_mul() {
 
 #[test]
 fn test_scalar_rem_noncommutative() {
-    assert_eq!(5u8 % BigUint::from(7u8), 5);
-    assert_eq!(BigUint::from(5u8) % 7u8, 5);
+    assert_eq!(5u8 % BigUint::from(7u8), 5u8);
+    assert_eq!(BigUint::from(5u8) % 7u8, 5u8);
 }
 
 #[test]
@@ -121,48 +121,20 @@ fn test_biguint_scalar_cmp() {
     let five = BigUint::from(5u32);
 
     fn scalar_cmp_asserts(num: &BigUint, scalar: i32) {
-        assert!(num.partial_cmp(&(scalar as i8)) == Some(Equal));
-        assert!((scalar as i8).partial_cmp(num) == Some(Equal));
-        assert!(num.partial_cmp(&(scalar as i8 - 1)) == Some(Greater));
-        assert!((scalar as i8 + 1).partial_cmp(num) == Some(Greater));
-        assert!(num.partial_cmp(&(scalar as i8 + 1)) == Some(Less));
-        assert!((scalar as i8 - 1).partial_cmp(num) == Some(Less));
-
         assert!(num.partial_cmp(&(scalar as u8)) == Some(Equal));
         assert!((scalar as u8).partial_cmp(num) == Some(Equal));
         assert!((scalar as u8 + 1).partial_cmp(num) == Some(Greater));
         assert!(num.partial_cmp(&(scalar as u8 + 1)) == Some(Less));
-
-        assert!(num.partial_cmp(&(scalar as i16)) == Some(Equal));
-        assert!((scalar as i16).partial_cmp(num) == Some(Equal));
-        assert!(num.partial_cmp(&(scalar as i16 - 1)) == Some(Greater));
-        assert!((scalar as i16 + 1).partial_cmp(num) == Some(Greater));
-        assert!(num.partial_cmp(&(scalar as i16 + 1)) == Some(Less));
-        assert!((scalar as i16 - 1).partial_cmp(num) == Some(Less));
 
         assert!(num.partial_cmp(&(scalar as u16)) == Some(Equal));
         assert!((scalar as u16).partial_cmp(num) == Some(Equal));
         assert!((scalar as u16 + 1).partial_cmp(num) == Some(Greater));
         assert!(num.partial_cmp(&(scalar as u16 + 1)) == Some(Less));
 
-        assert!(num.partial_cmp(&(scalar as i32)) == Some(Equal));
-        assert!((scalar as i32).partial_cmp(num) == Some(Equal));
-        assert!(num.partial_cmp(&(scalar as i32 - 1)) == Some(Greater));
-        assert!((scalar as i32 + 1).partial_cmp(num) == Some(Greater));
-        assert!(num.partial_cmp(&(scalar as i32 + 1)) == Some(Less));
-        assert!((scalar as i32 - 1).partial_cmp(num) == Some(Less));
-
         assert!(num.partial_cmp(&(scalar as u32)) == Some(Equal));
         assert!((scalar as u32).partial_cmp(num) == Some(Equal));
         assert!((scalar as u32 + 1).partial_cmp(num) == Some(Greater));
         assert!(num.partial_cmp(&(scalar as u32 + 1)) == Some(Less));
-
-        assert!(num.partial_cmp(&(scalar as i64)) == Some(Equal));
-        assert!((scalar as i64).partial_cmp(num) == Some(Equal));
-        assert!(num.partial_cmp(&(scalar as i64 - 1)) == Some(Greater));
-        assert!((scalar as i64 + 1).partial_cmp(num) == Some(Greater));
-        assert!(num.partial_cmp(&(scalar as i64 + 1)) == Some(Less));
-        assert!((scalar as i64 - 1).partial_cmp(num) == Some(Less));
 
         assert!(num.partial_cmp(&(scalar as u64)) == Some(Equal));
         assert!((scalar as u64).partial_cmp(num) == Some(Equal));
@@ -171,13 +143,6 @@ fn test_biguint_scalar_cmp() {
 
         #[cfg(has_i128)]
         {
-            assert!(num.partial_cmp(&(scalar as i128)) == Some(Equal));
-            assert!((scalar as i128).partial_cmp(num) == Some(Equal));
-            assert!(num.partial_cmp(&(scalar as i128 - 1)) == Some(Greater));
-            assert!((scalar as i128 + 1).partial_cmp(num) == Some(Greater));
-            assert!(num.partial_cmp(&(scalar as i128 + 1)) == Some(Less));
-            assert!((scalar as i128 - 1).partial_cmp(num) == Some(Less));
-
             assert!(num.partial_cmp(&(scalar as u128)) == Some(Equal));
             assert!((scalar as u128).partial_cmp(num) == Some(Equal));
             assert!((scalar as u128 + 1).partial_cmp(num) == Some(Greater));

--- a/tests/biguint_scalar.rs
+++ b/tests/biguint_scalar.rs
@@ -1,8 +1,6 @@
 use num_bigint::BigUint;
 use num_traits::{ToPrimitive, Zero};
 
-use std::cmp::Ordering;
-
 mod consts;
 use crate::consts::*;
 


### PR DESCRIPTION
This rebases and extends #105 (cc @hansihe). As noted before, it may hurt type inference where callers use comparison operators that relied on only one possible `impl` before. We're on the way to 0.3 though, so even a relatively minor break like that is perfectly allowable.