### PR TITLE
Implement `Pow` by value

### DIFF
--- a/benches/bigint.rs
+++ b/benches/bigint.rs
@@ -4,7 +4,7 @@
 extern crate test;
 
 use num_bigint::{BigInt, BigUint, RandBigInt};
-use num_traits::{FromPrimitive, Num, One, Pow, Zero};
+use num_traits::{FromPrimitive, Num, One, Zero};
 use rand::rngs::StdRng;
 use rand::SeedableRng;
 use std::mem::replace;
@@ -327,11 +327,30 @@ fn hash(b: &mut Bencher) {
 #[bench]
 fn pow_bench(b: &mut Bencher) {
     b.iter(|| {
-        let upper = 100_usize;
-        for i in 2..=upper {
+        let upper = 100_u32;
+        let mut i_big = BigUint::from(1u32);
+        for _i in 2..=upper {
+            i_big += 1u32;
             for j in 2..=upper {
-                let i_big = BigUint::from_usize(i).unwrap();
                 i_big.pow(j);
+            }
+        }
+    });
+}
+
+#[bench]
+fn pow_bench_bigexp(b: &mut Bencher) {
+    use num_traits::Pow;
+
+    b.iter(|| {
+        let upper = 100_u32;
+        let mut i_big = BigUint::from(1u32);
+        for _i in 2..=upper {
+            i_big += 1u32;
+            let mut j_big = BigUint::from(1u32);
+            for _j in 2..=upper {
+                j_big += 1u32;
+                Pow::pow(&i_big, &j_big);
             }
         }
     });

--- a/benches/roots.rs
+++ b/benches/roots.rs
@@ -4,7 +4,6 @@
 extern crate test;
 
 use num_bigint::{BigUint, RandBigInt};
-use num_traits::Pow;
 use rand::rngs::StdRng;
 use rand::SeedableRng;
 use test::Bencher;

--- a/ci/big_quickcheck/src/lib.rs
+++ b/ci/big_quickcheck/src/lib.rs
@@ -8,7 +8,7 @@
 
 use num_bigint::{BigInt, BigUint};
 use num_integer::Integer;
-use num_traits::{Num, One, Pow, Signed, Zero};
+use num_traits::{Num, One, Signed, Zero};
 use quickcheck::{QuickCheck, StdThreadGen, TestResult};
 use quickcheck_macros::quickcheck;
 

--- a/ci/big_rand/src/lib.rs
+++ b/ci/big_rand/src/lib.rs
@@ -10,7 +10,7 @@ mod torture;
 
 mod biguint {
     use num_bigint::{BigUint, RandBigInt, RandomBits};
-    use num_traits::{Pow, Zero};
+    use num_traits::Zero;
     use rand::distributions::Uniform;
     use rand::thread_rng;
     use rand::{Rng, SeedableRng};

--- a/tests/bigint.rs
+++ b/tests/bigint.rs
@@ -1148,15 +1148,15 @@ fn test_pow() {
     let minus_two = BigInt::from(-2i32);
     macro_rules! check {
         ($t:ty) => {
-            assert_eq!(two.pow(0 as $t), one);
-            assert_eq!(two.pow(1 as $t), two);
-            assert_eq!(two.pow(2 as $t), four);
-            assert_eq!(two.pow(3 as $t), eight);
-            assert_eq!(two.pow(&(3 as $t)), eight);
-            assert_eq!(minus_two.pow(0 as $t), one, "-2^0");
-            assert_eq!(minus_two.pow(1 as $t), minus_two, "-2^1");
-            assert_eq!(minus_two.pow(2 as $t), four, "-2^2");
-            assert_eq!(minus_two.pow(3 as $t), -&eight, "-2^3");
+            assert_eq!(Pow::pow(&two, 0 as $t), one);
+            assert_eq!(Pow::pow(&two, 1 as $t), two);
+            assert_eq!(Pow::pow(&two, 2 as $t), four);
+            assert_eq!(Pow::pow(&two, 3 as $t), eight);
+            assert_eq!(Pow::pow(&two, &(3 as $t)), eight);
+            assert_eq!(Pow::pow(&minus_two, 0 as $t), one, "-2^0");
+            assert_eq!(Pow::pow(&minus_two, 1 as $t), minus_two, "-2^1");
+            assert_eq!(Pow::pow(&minus_two, 2 as $t), four, "-2^2");
+            assert_eq!(Pow::pow(&minus_two, 3 as $t), -&eight, "-2^3");
         };
     }
     check!(u8);

--- a/tests/biguint.rs
+++ b/tests/biguint.rs
@@ -1676,13 +1676,13 @@ fn test_pow() {
     let twentyfourtyeight = BigUint::from(2048u32);
     macro_rules! check {
         ($t:ty) => {
-            assert_eq!(two.pow(0 as $t), one);
-            assert_eq!(two.pow(1 as $t), two);
-            assert_eq!(two.pow(2 as $t), four);
-            assert_eq!(two.pow(3 as $t), eight);
-            assert_eq!(two.pow(10 as $t), tentwentyfour);
-            assert_eq!(two.pow(11 as $t), twentyfourtyeight);
-            assert_eq!(two.pow(&(11 as $t)), twentyfourtyeight);
+            assert_eq!(Pow::pow(&two, 0 as $t), one);
+            assert_eq!(Pow::pow(&two, 1 as $t), two);
+            assert_eq!(Pow::pow(&two, 2 as $t), four);
+            assert_eq!(Pow::pow(&two, 3 as $t), eight);
+            assert_eq!(Pow::pow(&two, 10 as $t), tentwentyfour);
+            assert_eq!(Pow::pow(&two, 11 as $t), twentyfourtyeight);
+            assert_eq!(Pow::pow(&two, &(11 as $t)), twentyfourtyeight);
         };
     }
     check!(u8);

--- a/tests/roots.rs
+++ b/tests/roots.rs
@@ -1,6 +1,6 @@
 mod biguint {
     use num_bigint::BigUint;
-    use num_traits::{One, Pow, Zero};
+    use num_traits::{One, Zero};
     use std::{i32, u32};
 
     fn check<T: Into<BigUint>>(x: T, n: u32) {
@@ -114,7 +114,7 @@ mod biguint {
 
 mod bigint {
     use num_bigint::BigInt;
-    use num_traits::{Pow, Signed};
+    use num_traits::Signed;
 
     fn check(x: i64, n: u32) {
         let big_x = BigInt::from(x);


### PR DESCRIPTION
We already had `Pow` for references, so the default call doesn't consume
your allocation, but this wasn't sufficient for uses like `BigRational`.
Now we do implement it by value, and have also added a new inherent
method `pow(&self, exp: u32)` that takes precedence. That exponent type
matches the same method on primitive integers, and is likely sufficient
for most use cases.

Fixes #106