### PR TITLE
Specialize more of Integer

### DIFF
--- a/src/bigint.rs
+++ b/src/bigint.rs
@@ -2199,7 +2199,7 @@ impl Integer for BigInt {
     #[inline]
     fn div_rem(&self, other: &BigInt) -> (BigInt, BigInt) {
         // r.sign == self.sign
-        let (d_ui, r_ui) = self.data.div_mod_floor(&other.data);
+        let (d_ui, r_ui) = self.data.div_rem(&other.data);
         let d = BigInt::from_biguint(self.sign, d_ui);
         let r = BigInt::from_biguint(self.sign, r_ui);
         if other.is_negative() {
@@ -2211,39 +2211,71 @@ impl Integer for BigInt {
 
     #[inline]
     fn div_floor(&self, other: &BigInt) -> BigInt {
-        let (d, _) = self.div_mod_floor(other);
-        d
+        let (d_ui, m) = self.data.div_mod_floor(&other.data);
+        let d = BigInt::from(d_ui);
+        match (self.sign, other.sign) {
+            (Plus, Plus) | (NoSign, Plus) | (Minus, Minus) => d,
+            (Plus, Minus) | (NoSign, Minus) | (Minus, Plus) => {
+                if m.is_zero() {
+                    -d
+                } else {
+                    -d - 1u32
+                }
+            }
+            (_, NoSign) => unreachable!(),
+        }
     }
 
     #[inline]
     fn mod_floor(&self, other: &BigInt) -> BigInt {
-        let (_, m) = self.div_mod_floor(other);
-        m
+        // m.sign == other.sign
+        let m_ui = self.data.mod_floor(&other.data);
+        let m = BigInt::from_biguint(other.sign, m_ui);
+        match (self.sign, other.sign) {
+            (Plus, Plus) | (NoSign, Plus) | (Minus, Minus) => m,
+            (Plus, Minus) | (NoSign, Minus) | (Minus, Plus) => {
+                if m.is_zero() {
+                    m
+                } else {
+                    other - m
+                }
+            }
+            (_, NoSign) => unreachable!(),
+        }
     }
 
     fn div_mod_floor(&self, other: &BigInt) -> (BigInt, BigInt) {
         // m.sign == other.sign
-        let (d_ui, m_ui) = self.data.div_rem(&other.data);
+        let (d_ui, m_ui) = self.data.div_mod_floor(&other.data);
         let d = BigInt::from(d_ui);
-        let m = BigInt::from(m_ui);
+        let m = BigInt::from_biguint(other.sign, m_ui);
         match (self.sign, other.sign) {
-            (_, NoSign) => panic!(),
-            (Plus, Plus) | (NoSign, Plus) => (d, m),
-            (Plus, Minus) | (NoSign, Minus) => {
+            (Plus, Plus) | (NoSign, Plus) | (Minus, Minus) => (d, m),
+            (Plus, Minus) | (NoSign, Minus) | (Minus, Plus) => {
                 if m.is_zero() {
-                    (-d, Zero::zero())
-                } else {
-                    (-d - 1u32, m + other)
-                }
-            }
-            (Minus, Plus) => {
-                if m.is_zero() {
-                    (-d, Zero::zero())
+                    (-d, m)
                 } else {
                     (-d - 1u32, other - m)
                 }
             }
-            (Minus, Minus) => (d, -m),
+            (_, NoSign) => unreachable!(),
+        }
+    }
+
+    #[inline]
+    fn div_ceil(&self, other: &Self) -> Self {
+        let (d_ui, m) = self.data.div_mod_floor(&other.data);
+        let d = BigInt::from(d_ui);
+        match (self.sign, other.sign) {
+            (Plus, Minus) | (NoSign, Minus) | (Minus, Plus) => -d,
+            (Plus, Plus) | (NoSign, Plus) | (Minus, Minus) => {
+                if m.is_zero() {
+                    d
+                } else {
+                    d + 1u32
+                }
+            }
+            (_, NoSign) => unreachable!(),
         }
     }
 
@@ -2259,6 +2291,26 @@ impl Integer for BigInt {
     #[inline]
     fn lcm(&self, other: &BigInt) -> BigInt {
         BigInt::from(self.data.lcm(&other.data))
+    }
+
+    /// Calculates the Greatest Common Divisor (GCD) and
+    /// Lowest Common Multiple (LCM) together.
+    #[inline]
+    fn gcd_lcm(&self, other: &BigInt) -> (BigInt, BigInt) {
+        let (gcd, lcm) = self.data.gcd_lcm(&other.data);
+        (BigInt::from(gcd), BigInt::from(lcm))
+    }
+
+    /// Greatest common divisor, least common multiple, and Bézout coefficients.
+    #[inline]
+    fn extended_gcd_lcm(&self, other: &BigInt) -> (num_integer::ExtendedGcd<BigInt>, BigInt) {
+        let egcd = self.extended_gcd(other);
+        let lcm = if egcd.gcd.is_zero() {
+            BigInt::zero()
+        } else {
+            BigInt::from(&self.data / &egcd.gcd.data * &other.data)
+        };
+        (egcd, lcm)
     }
 
     /// Deprecated, use `is_multiple_of` instead.
@@ -2283,6 +2335,22 @@ impl Integer for BigInt {
     #[inline]
     fn is_odd(&self) -> bool {
         self.data.is_odd()
+    }
+
+    /// Rounds up to nearest multiple of argument.
+    #[inline]
+    fn next_multiple_of(&self, other: &Self) -> Self {
+        let m = self.mod_floor(other);
+        if m.is_zero() {
+            self.clone()
+        } else {
+            self + (other - m)
+        }
+    }
+    /// Rounds down to nearest multiple of argument.
+    #[inline]
+    fn prev_multiple_of(&self, other: &Self) -> Self {
+        self - self.mod_floor(other)
     }
 }
 

--- a/src/biguint.rs
+++ b/src/biguint.rs
@@ -1536,6 +1536,16 @@ impl Integer for BigUint {
         div_rem_ref(self, other)
     }
 
+    #[inline]
+    fn div_ceil(&self, other: &BigUint) -> BigUint {
+        let (d, m) = div_rem_ref(self, other);
+        if m.is_zero() {
+            d
+        } else {
+            d + 1u32
+        }
+    }
+
     /// Calculates the Greatest Common Divisor (GCD) of the number and `other`.
     ///
     /// The result is always positive.
@@ -1584,6 +1594,19 @@ impl Integer for BigUint {
         }
     }
 
+    /// Calculates the Greatest Common Divisor (GCD) and
+    /// Lowest Common Multiple (LCM) together.
+    #[inline]
+    fn gcd_lcm(&self, other: &Self) -> (Self, Self) {
+        let gcd = self.gcd(other);
+        let lcm = if gcd.is_zero() {
+            Self::zero()
+        } else {
+            self / &gcd * other
+        };
+        (gcd, lcm)
+    }
+
     /// Deprecated, use `is_multiple_of` instead.
     #[inline]
     fn divides(&self, other: &BigUint) -> bool {
@@ -1610,6 +1633,22 @@ impl Integer for BigUint {
     #[inline]
     fn is_odd(&self) -> bool {
         !self.is_even()
+    }
+
+    /// Rounds up to nearest multiple of argument.
+    #[inline]
+    fn next_multiple_of(&self, other: &Self) -> Self {
+        let m = self.mod_floor(other);
+        if m.is_zero() {
+            self.clone()
+        } else {
+            self + (other - m)
+        }
+    }
+    /// Rounds down to nearest multiple of argument.
+    #[inline]
+    fn prev_multiple_of(&self, other: &Self) -> Self {
+        self - self.mod_floor(other)
     }
 }
 

--- a/tests/bigint.rs
+++ b/tests/bigint.rs
@@ -734,6 +734,8 @@ fn test_mul() {
 fn test_div_mod_floor() {
     fn check_sub(a: &BigInt, b: &BigInt, ans_d: &BigInt, ans_m: &BigInt) {
         let (d, m) = a.div_mod_floor(b);
+        assert_eq!(d, a.div_floor(b));
+        assert_eq!(m, a.mod_floor(b));
         if !m.is_zero() {
             assert_eq!(m.sign(), b.sign());
         }
@@ -810,6 +812,53 @@ fn test_div_rem() {
         check_sub(&a.neg(), b, &q.neg(), &r.neg());
         check_sub(&a.neg(), &b.neg(), q, &r.neg());
     }
+    for elm in MUL_TRIPLES.iter() {
+        let (a_vec, b_vec, c_vec) = *elm;
+        let a = BigInt::from_slice(Plus, a_vec);
+        let b = BigInt::from_slice(Plus, b_vec);
+        let c = BigInt::from_slice(Plus, c_vec);
+
+        if !a.is_zero() {
+            check(&c, &a, &b, &Zero::zero());
+        }
+        if !b.is_zero() {
+            check(&c, &b, &a, &Zero::zero());
+        }
+    }
+
+    for elm in DIV_REM_QUADRUPLES.iter() {
+        let (a_vec, b_vec, c_vec, d_vec) = *elm;
+        let a = BigInt::from_slice(Plus, a_vec);
+        let b = BigInt::from_slice(Plus, b_vec);
+        let c = BigInt::from_slice(Plus, c_vec);
+        let d = BigInt::from_slice(Plus, d_vec);
+
+        if !b.is_zero() {
+            check(&a, &b, &c, &d);
+        }
+    }
+}
+
+#[test]
+fn test_div_ceil() {
+    fn check_sub(a: &BigInt, b: &BigInt, ans_d: &BigInt) {
+        assert_eq!(a.div_ceil(b), *ans_d);
+    }
+
+    fn check(a: &BigInt, b: &BigInt, d: &BigInt, m: &BigInt) {
+        if m.is_zero() {
+            check_sub(a, b, d);
+            check_sub(a, &b.neg(), &d.neg());
+            check_sub(&a.neg(), b, &d.neg());
+            check_sub(&a.neg(), &b.neg(), d);
+        } else {
+            check_sub(a, b, &(d + 1));
+            check_sub(a, &b.neg(), &d.neg());
+            check_sub(&a.neg(), b, &d.neg());
+            check_sub(&a.neg(), &b.neg(), &(d + 1));
+        }
+    }
+
     for elm in MUL_TRIPLES.iter() {
         let (a_vec, b_vec, c_vec) = *elm;
         let a = BigInt::from_slice(Plus, a_vec);
@@ -933,6 +982,9 @@ fn test_gcd() {
         let big_c: BigInt = FromPrimitive::from_isize(c).unwrap();
 
         assert_eq!(big_a.gcd(&big_b), big_c);
+        assert_eq!(big_a.extended_gcd(&big_b).gcd, big_c);
+        assert_eq!(big_a.gcd_lcm(&big_b).0, big_c);
+        assert_eq!(big_a.extended_gcd_lcm(&big_b).0.gcd, big_c);
     }
 
     check(10, 2, 2);
@@ -953,6 +1005,8 @@ fn test_lcm() {
         let big_c: BigInt = FromPrimitive::from_isize(c).unwrap();
 
         assert_eq!(big_a.lcm(&big_b), big_c);
+        assert_eq!(big_a.gcd_lcm(&big_b).1, big_c);
+        assert_eq!(big_a.extended_gcd_lcm(&big_b).1, big_c);
     }
 
     check(0, 0, 0);
@@ -964,6 +1018,30 @@ fn test_lcm() {
     check(-1, -1, 1);
     check(8, 9, 72);
     check(11, 5, 55);
+}
+
+#[test]
+fn test_next_multiple_of() {
+    assert_eq!(BigInt::from(16).next_multiple_of(&BigInt::from(8)), 16);
+    assert_eq!(BigInt::from(23).next_multiple_of(&BigInt::from(8)), 24);
+    assert_eq!(BigInt::from(16).next_multiple_of(&BigInt::from(-8)), 16);
+    assert_eq!(BigInt::from(23).next_multiple_of(&BigInt::from(-8)), 16);
+    assert_eq!(BigInt::from(-16).next_multiple_of(&BigInt::from(8)), -16);
+    assert_eq!(BigInt::from(-23).next_multiple_of(&BigInt::from(8)), -16);
+    assert_eq!(BigInt::from(-16).next_multiple_of(&BigInt::from(-8)), -16);
+    assert_eq!(BigInt::from(-23).next_multiple_of(&BigInt::from(-8)), -24);
+}
+
+#[test]
+fn test_prev_multiple_of() {
+    assert_eq!(BigInt::from(16).prev_multiple_of(&BigInt::from(8)), 16);
+    assert_eq!(BigInt::from(23).prev_multiple_of(&BigInt::from(8)), 16);
+    assert_eq!(BigInt::from(16).prev_multiple_of(&BigInt::from(-8)), 16);
+    assert_eq!(BigInt::from(23).prev_multiple_of(&BigInt::from(-8)), 24);
+    assert_eq!(BigInt::from(-16).prev_multiple_of(&BigInt::from(8)), -16);
+    assert_eq!(BigInt::from(-23).prev_multiple_of(&BigInt::from(8)), -24);
+    assert_eq!(BigInt::from(-16).prev_multiple_of(&BigInt::from(-8)), -16);
+    assert_eq!(BigInt::from(-23).prev_multiple_of(&BigInt::from(-8)), -16);
 }
 
 #[test]

--- a/tests/biguint.rs
+++ b/tests/biguint.rs
@@ -892,6 +892,43 @@ fn test_div_rem() {
 }
 
 #[test]
+fn test_div_ceil() {
+    fn check(a: &BigUint, b: &BigUint, d: &BigUint, m: &BigUint) {
+        if m.is_zero() {
+            assert_eq!(a.div_ceil(b), *d);
+        } else {
+            assert_eq!(a.div_ceil(b), d + 1u32);
+        }
+    }
+
+    for elm in MUL_TRIPLES.iter() {
+        let (a_vec, b_vec, c_vec) = *elm;
+        let a = BigUint::from_slice(a_vec);
+        let b = BigUint::from_slice(b_vec);
+        let c = BigUint::from_slice(c_vec);
+
+        if !a.is_zero() {
+            check(&c, &a, &b, &Zero::zero());
+        }
+        if !b.is_zero() {
+            check(&c, &b, &a, &Zero::zero());
+        }
+    }
+
+    for elm in DIV_REM_QUADRUPLES.iter() {
+        let (a_vec, b_vec, c_vec, d_vec) = *elm;
+        let a = BigUint::from_slice(a_vec);
+        let b = BigUint::from_slice(b_vec);
+        let c = BigUint::from_slice(c_vec);
+        let d = BigUint::from_slice(d_vec);
+
+        if !b.is_zero() {
+            check(&a, &b, &c, &d);
+        }
+    }
+}
+
+#[test]
 fn test_checked_add() {
     for elm in SUM_TRIPLES.iter() {
         let (a_vec, b_vec, c_vec) = *elm;
@@ -984,6 +1021,7 @@ fn test_gcd() {
         let big_c: BigUint = FromPrimitive::from_usize(c).unwrap();
 
         assert_eq!(big_a.gcd(&big_b), big_c);
+        assert_eq!(big_a.gcd_lcm(&big_b).0, big_c);
     }
 
     check(10, 2, 2);
@@ -1001,6 +1039,7 @@ fn test_lcm() {
         let big_c: BigUint = FromPrimitive::from_usize(c).unwrap();
 
         assert_eq!(big_a.lcm(&big_b), big_c);
+        assert_eq!(big_a.gcd_lcm(&big_b).1, big_c);
     }
 
     check(0, 0, 0);
@@ -1010,6 +1049,30 @@ fn test_lcm() {
     check(8, 9, 72);
     check(11, 5, 55);
     check(99, 17, 1683);
+}
+
+#[test]
+fn test_next_multiple_of() {
+    assert_eq!(
+        BigUint::from(16u32).next_multiple_of(&BigUint::from(8u32)),
+        16u32
+    );
+    assert_eq!(
+        BigUint::from(23u32).next_multiple_of(&BigUint::from(8u32)),
+        24u32
+    );
+}
+
+#[test]
+fn test_prev_multiple_of() {
+    assert_eq!(
+        BigUint::from(16u32).prev_multiple_of(&BigUint::from(8u32)),
+        16u32
+    );
+    assert_eq!(
+        BigUint::from(23u32).prev_multiple_of(&BigUint::from(8u32)),
+        16u32
+    );
 }
 
 #[test]


### PR DESCRIPTION
None of this is strictly necessary to override, but they should be a
little bit faster in these manual implementations.

That includes `Integer::div_ceil`, so this closes #69.