### PR TITLE
Implement shift with broad RHS types

### DIFF
--- a/benches/bigint.rs
+++ b/benches/bigint.rs
@@ -293,7 +293,7 @@ fn rand_131072(b: &mut Bencher) {
 
 #[bench]
 fn shl(b: &mut Bencher) {
-    let n = BigUint::one() << 1000;
+    let n = BigUint::one() << 1000u32;
     b.iter(|| {
         let mut m = n.clone();
         for i in 0..50 {
@@ -304,7 +304,7 @@ fn shl(b: &mut Bencher) {
 
 #[bench]
 fn shr(b: &mut Bencher) {
-    let n = BigUint::one() << 2000;
+    let n = BigUint::one() << 2000u32;
     b.iter(|| {
         let mut m = n.clone();
         for i in 0..50 {

--- a/benches/bigint.rs
+++ b/benches/bigint.rs
@@ -294,8 +294,9 @@ fn rand_131072(b: &mut Bencher) {
 #[bench]
 fn shl(b: &mut Bencher) {
     let n = BigUint::one() << 1000u32;
+    let mut m = n.clone();
     b.iter(|| {
-        let mut m = n.clone();
+        m.clone_from(&n);
         for i in 0..50 {
             m <<= i;
         }
@@ -305,8 +306,9 @@ fn shl(b: &mut Bencher) {
 #[bench]
 fn shr(b: &mut Bencher) {
     let n = BigUint::one() << 2000u32;
+    let mut m = n.clone();
     b.iter(|| {
-        let mut m = n.clone();
+        m.clone_from(&n);
         for i in 0..50 {
             m >>= i;
         }

--- a/src/bigint.rs
+++ b/src/bigint.rs
@@ -25,7 +25,7 @@ use serde;
 
 use num_integer::{Integer, Roots};
 use num_traits::{
-    CheckedAdd, CheckedDiv, CheckedMul, CheckedSub, FromPrimitive, Num, One, Pow, Signed,
+    CheckedAdd, CheckedDiv, CheckedMul, CheckedSub, FromPrimitive, Num, One, Pow, PrimInt, Signed,
     ToPrimitive, Zero,
 };
 
@@ -779,69 +779,105 @@ impl Num for BigInt {
     }
 }
 
-impl Shl<usize> for BigInt {
-    type Output = BigInt;
+macro_rules! impl_shift {
+    (@ref $Shx:ident :: $shx:ident, $ShxAssign:ident :: $shx_assign:ident, $rhs:ty) => {
+        impl<'b> $Shx<&'b $rhs> for BigInt {
+            type Output = BigInt;
 
-    #[inline]
-    fn shl(mut self, rhs: usize) -> BigInt {
-        self <<= rhs;
-        self
-    }
+            #[inline]
+            fn $shx(self, rhs: &'b $rhs) -> BigInt {
+                $Shx::$shx(self, *rhs)
+            }
+        }
+        impl<'a, 'b> $Shx<&'b $rhs> for &'a BigInt {
+            type Output = BigInt;
+
+            #[inline]
+            fn $shx(self, rhs: &'b $rhs) -> BigInt {
+                $Shx::$shx(self, *rhs)
+            }
+        }
+        impl<'b> $ShxAssign<&'b $rhs> for BigInt {
+            #[inline]
+            fn $shx_assign(&mut self, rhs: &'b $rhs) {
+                $ShxAssign::$shx_assign(self, *rhs);
+            }
+        }
+    };
+    ($($rhs:ty),+) => {$(
+        impl Shl<$rhs> for BigInt {
+            type Output = BigInt;
+
+            #[inline]
+            fn shl(self, rhs: $rhs) -> BigInt {
+                BigInt::from_biguint(self.sign, self.data << rhs)
+            }
+        }
+        impl<'a> Shl<$rhs> for &'a BigInt {
+            type Output = BigInt;
+
+            #[inline]
+            fn shl(self, rhs: $rhs) -> BigInt {
+                BigInt::from_biguint(self.sign, &self.data << rhs)
+            }
+        }
+        impl ShlAssign<$rhs> for BigInt {
+            #[inline]
+            fn shl_assign(&mut self, rhs: $rhs) {
+                self.data <<= rhs
+            }
+        }
+        impl_shift! { @ref Shl::shl, ShlAssign::shl_assign, $rhs }
+
+        impl Shr<$rhs> for BigInt {
+            type Output = BigInt;
+
+            #[inline]
+            fn shr(self, rhs: $rhs) -> BigInt {
+                let round_down = shr_round_down(&self, rhs);
+                let data = self.data >> rhs;
+                let data = if round_down { data + 1u8 } else { data };
+                BigInt::from_biguint(self.sign, data)
+            }
+        }
+        impl<'a> Shr<$rhs> for &'a BigInt {
+            type Output = BigInt;
+
+            #[inline]
+            fn shr(self, rhs: $rhs) -> BigInt {
+                let round_down = shr_round_down(self, rhs);
+                let data = &self.data >> rhs;
+                let data = if round_down { data + 1u8 } else { data };
+                BigInt::from_biguint(self.sign, data)
+            }
+        }
+        impl ShrAssign<$rhs> for BigInt {
+            #[inline]
+            fn shr_assign(&mut self, rhs: $rhs) {
+                let round_down = shr_round_down(self, rhs);
+                self.data >>= rhs;
+                if round_down {
+                    self.data += 1u8;
+                } else if self.data.is_zero() {
+                    self.sign = NoSign;
+                }
+            }
+        }
+        impl_shift! { @ref Shr::shr, ShrAssign::shr_assign, $rhs }
+    )*};
 }
 
-impl<'a> Shl<usize> for &'a BigInt {
-    type Output = BigInt;
-
-    #[inline]
-    fn shl(self, rhs: usize) -> BigInt {
-        BigInt::from_biguint(self.sign, &self.data << rhs)
-    }
-}
-
-impl ShlAssign<usize> for BigInt {
-    #[inline]
-    fn shl_assign(&mut self, rhs: usize) {
-        self.data <<= rhs;
-    }
-}
+impl_shift! { u8, u16, u32, u64, u128, usize }
+impl_shift! { i8, i16, i32, i64, i128, isize }
 
 // Negative values need a rounding adjustment if there are any ones in the
 // bits that are getting shifted out.
-fn shr_round_down(i: &BigInt, rhs: usize) -> bool {
-    i.is_negative() && i.trailing_zeros().map(|n| n < rhs).unwrap_or(false)
-}
-
-impl Shr<usize> for BigInt {
-    type Output = BigInt;
-
-    #[inline]
-    fn shr(mut self, rhs: usize) -> BigInt {
-        self >>= rhs;
-        self
-    }
-}
-
-impl<'a> Shr<usize> for &'a BigInt {
-    type Output = BigInt;
-
-    #[inline]
-    fn shr(self, rhs: usize) -> BigInt {
-        let round_down = shr_round_down(self, rhs);
-        let data = &self.data >> rhs;
-        BigInt::from_biguint(self.sign, if round_down { data + 1u8 } else { data })
-    }
-}
-
-impl ShrAssign<usize> for BigInt {
-    #[inline]
-    fn shr_assign(&mut self, rhs: usize) {
-        let round_down = shr_round_down(self, rhs);
-        self.data >>= rhs;
-        if round_down {
-            self.data += 1u8;
-        } else if self.data.is_zero() {
-            self.sign = NoSign;
-        }
+fn shr_round_down<T: PrimInt>(i: &BigInt, shift: T) -> bool {
+    if i.is_negative() {
+        let zeros = i.trailing_zeros().expect("negative values are non-zero");
+        shift > T::zero() && shift.to_usize().map(|shift| zeros < shift).unwrap_or(true)
+    } else {
+        false
     }
 }
 

--- a/src/biguint.rs
+++ b/src/biguint.rs
@@ -464,55 +464,86 @@ impl<'a> BitXorAssign<&'a BigUint> for BigUint {
     }
 }
 
-impl Shl<usize> for BigUint {
-    type Output = BigUint;
+macro_rules! impl_shift {
+    (@ref $Shx:ident :: $shx:ident, $ShxAssign:ident :: $shx_assign:ident, $rhs:ty) => {
+        impl<'b> $Shx<&'b $rhs> for BigUint {
+            type Output = BigUint;
 
-    #[inline]
-    fn shl(self, rhs: usize) -> BigUint {
-        biguint_shl(Cow::Owned(self), rhs)
-    }
+            #[inline]
+            fn $shx(self, rhs: &'b $rhs) -> BigUint {
+                $Shx::$shx(self, *rhs)
+            }
+        }
+        impl<'a, 'b> $Shx<&'b $rhs> for &'a BigUint {
+            type Output = BigUint;
+
+            #[inline]
+            fn $shx(self, rhs: &'b $rhs) -> BigUint {
+                $Shx::$shx(self, *rhs)
+            }
+        }
+        impl<'b> $ShxAssign<&'b $rhs> for BigUint {
+            #[inline]
+            fn $shx_assign(&mut self, rhs: &'b $rhs) {
+                $ShxAssign::$shx_assign(self, *rhs);
+            }
+        }
+    };
+    ($($rhs:ty),+) => {$(
+        impl Shl<$rhs> for BigUint {
+            type Output = BigUint;
+
+            #[inline]
+            fn shl(self, rhs: $rhs) -> BigUint {
+                biguint_shl(Cow::Owned(self), rhs)
+            }
+        }
+        impl<'a> Shl<$rhs> for &'a BigUint {
+            type Output = BigUint;
+
+            #[inline]
+            fn shl(self, rhs: $rhs) -> BigUint {
+                biguint_shl(Cow::Borrowed(self), rhs)
+            }
+        }
+        impl ShlAssign<$rhs> for BigUint {
+            #[inline]
+            fn shl_assign(&mut self, rhs: $rhs) {
+                let n = mem::replace(self, BigUint::zero());
+                *self = n << rhs;
+            }
+        }
+        impl_shift! { @ref Shl::shl, ShlAssign::shl_assign, $rhs }
+
+        impl Shr<$rhs> for BigUint {
+            type Output = BigUint;
+
+            #[inline]
+            fn shr(self, rhs: $rhs) -> BigUint {
+                biguint_shr(Cow::Owned(self), rhs)
+            }
+        }
+        impl<'a> Shr<$rhs> for &'a BigUint {
+            type Output = BigUint;
+
+            #[inline]
+            fn shr(self, rhs: $rhs) -> BigUint {
+                biguint_shr(Cow::Borrowed(self), rhs)
+            }
+        }
+        impl ShrAssign<$rhs> for BigUint {
+            #[inline]
+            fn shr_assign(&mut self, rhs: $rhs) {
+                let n = mem::replace(self, BigUint::zero());
+                *self = n >> rhs;
+            }
+        }
+        impl_shift! { @ref Shr::shr, ShrAssign::shr_assign, $rhs }
+    )*};
 }
-impl<'a> Shl<usize> for &'a BigUint {
-    type Output = BigUint;
 
-    #[inline]
-    fn shl(self, rhs: usize) -> BigUint {
-        biguint_shl(Cow::Borrowed(self), rhs)
-    }
-}
-
-impl ShlAssign<usize> for BigUint {
-    #[inline]
-    fn shl_assign(&mut self, rhs: usize) {
-        let n = mem::replace(self, BigUint::zero());
-        *self = n << rhs;
-    }
-}
-
-impl Shr<usize> for BigUint {
-    type Output = BigUint;
-
-    #[inline]
-    fn shr(self, rhs: usize) -> BigUint {
-        biguint_shr(Cow::Owned(self), rhs)
-    }
-}
-impl<'a> Shr<usize> for &'a BigUint {
-    type Output = BigUint;
-
-    #[inline]
-    fn shr(self, rhs: usize) -> BigUint {
-        biguint_shr(Cow::Borrowed(self), rhs)
-    }
-}
-
-impl ShrAssign<usize> for BigUint {
-    #[inline]
-    fn shr_assign(&mut self, rhs: usize) {
-        let n = mem::replace(self, BigUint::zero());
-        *self = n >> rhs;
-    }
-}
+impl_shift! { u8, u16, u32, u64, u128, usize }
+impl_shift! { i8, i16, i32, i64, i128, isize }
 
 impl Zero for BigUint {
     #[inline]

--- a/tests/bigint.rs
+++ b/tests/bigint.rs
@@ -448,16 +448,16 @@ fn test_convert_f32() {
     assert_eq!(BigInt::from_f32(f32::NEG_INFINITY), None);
 
     // largest BigInt that will round to a finite f32 value
-    let big_num = (BigInt::one() << 128) - BigInt::one() - (BigInt::one() << (128 - 25));
+    let big_num = (BigInt::one() << 128u8) - 1u8 - (BigInt::one() << (128u8 - 25));
     assert_eq!(big_num.to_f32(), Some(f32::MAX));
-    assert_eq!((&big_num + BigInt::one()).to_f32(), None);
+    assert_eq!((&big_num + 1u8).to_f32(), None);
     assert_eq!((-&big_num).to_f32(), Some(f32::MIN));
-    assert_eq!(((-&big_num) - BigInt::one()).to_f32(), None);
+    assert_eq!(((-&big_num) - 1u8).to_f32(), None);
 
-    assert_eq!(((BigInt::one() << 128) - BigInt::one()).to_f32(), None);
-    assert_eq!((BigInt::one() << 128).to_f32(), None);
-    assert_eq!((-((BigInt::one() << 128) - BigInt::one())).to_f32(), None);
-    assert_eq!((-(BigInt::one() << 128)).to_f32(), None);
+    assert_eq!(((BigInt::one() << 128u8) - 1u8).to_f32(), None);
+    assert_eq!((BigInt::one() << 128u8).to_f32(), None);
+    assert_eq!((-((BigInt::one() << 128u8) - 1u8)).to_f32(), None);
+    assert_eq!((-(BigInt::one() << 128u8)).to_f32(), None);
 }
 
 #[test]
@@ -529,16 +529,16 @@ fn test_convert_f64() {
     assert_eq!(BigInt::from_f64(f64::NEG_INFINITY), None);
 
     // largest BigInt that will round to a finite f64 value
-    let big_num = (BigInt::one() << 1024) - BigInt::one() - (BigInt::one() << (1024 - 54));
+    let big_num = (BigInt::one() << 1024u16) - 1u8 - (BigInt::one() << (1024u16 - 54));
     assert_eq!(big_num.to_f64(), Some(f64::MAX));
-    assert_eq!((&big_num + BigInt::one()).to_f64(), None);
+    assert_eq!((&big_num + 1u8).to_f64(), None);
     assert_eq!((-&big_num).to_f64(), Some(f64::MIN));
-    assert_eq!(((-&big_num) - BigInt::one()).to_f64(), None);
+    assert_eq!(((-&big_num) - 1u8).to_f64(), None);
 
-    assert_eq!(((BigInt::one() << 1024) - BigInt::one()).to_f64(), None);
-    assert_eq!((BigInt::one() << 1024).to_f64(), None);
-    assert_eq!((-((BigInt::one() << 1024) - BigInt::one())).to_f64(), None);
-    assert_eq!((-(BigInt::one() << 1024)).to_f64(), None);
+    assert_eq!(((BigInt::one() << 1024u16) - 1u8).to_f64(), None);
+    assert_eq!((BigInt::one() << 1024u16).to_f64(), None);
+    assert_eq!((-((BigInt::one() << 1024u16) - 1u8)).to_f64(), None);
+    assert_eq!((-(BigInt::one() << 1024u16)).to_f64(), None);
 }
 
 #[test]

--- a/tests/biguint.rs
+++ b/tests/biguint.rs
@@ -671,12 +671,12 @@ fn test_convert_f32() {
     assert_eq!(BigUint::from_f32(f32::MIN), None);
 
     // largest BigUint that will round to a finite f32 value
-    let big_num = (BigUint::one() << 128) - BigUint::one() - (BigUint::one() << (128 - 25));
+    let big_num = (BigUint::one() << 128u8) - 1u8 - (BigUint::one() << (128u8 - 25));
     assert_eq!(big_num.to_f32(), Some(f32::MAX));
-    assert_eq!((big_num + BigUint::one()).to_f32(), None);
+    assert_eq!((big_num + 1u8).to_f32(), None);
 
-    assert_eq!(((BigUint::one() << 128) - BigUint::one()).to_f32(), None);
-    assert_eq!((BigUint::one() << 128).to_f32(), None);
+    assert_eq!(((BigUint::one() << 128u8) - 1u8).to_f32(), None);
+    assert_eq!((BigUint::one() << 128u8).to_f32(), None);
 }
 
 #[test]
@@ -744,12 +744,12 @@ fn test_convert_f64() {
     assert_eq!(BigUint::from_f64(f64::MIN), None);
 
     // largest BigUint that will round to a finite f64 value
-    let big_num = (BigUint::one() << 1024) - BigUint::one() - (BigUint::one() << (1024 - 54));
+    let big_num = (BigUint::one() << 1024u16) - 1u8 - (BigUint::one() << (1024u16 - 54));
     assert_eq!(big_num.to_f64(), Some(f64::MAX));
-    assert_eq!((big_num + BigUint::one()).to_f64(), None);
+    assert_eq!((big_num + 1u8).to_f64(), None);
 
-    assert_eq!(((BigInt::one() << 1024) - BigInt::one()).to_f64(), None);
-    assert_eq!((BigUint::one() << 1024).to_f64(), None);
+    assert_eq!(((BigUint::one() << 1024u16) - 1u8).to_f64(), None);
+    assert_eq!((BigUint::one() << 1024u16).to_f64(), None);
 }
 
 #[test]
@@ -1087,8 +1087,8 @@ fn test_is_even() {
     assert!(thousand.is_even());
     assert!(big.is_even());
     assert!(bigger.is_odd());
-    assert!((&one << 64).is_even());
-    assert!(((&one << 64) + one).is_odd());
+    assert!((&one << 64u8).is_even());
+    assert!(((&one << 64u8) + one).is_odd());
 }
 
 fn to_str_pairs() -> Vec<(BigUint, Vec<(u32, String)>)> {
@@ -1668,7 +1668,7 @@ fn test_bits() {
     let n: BigUint = BigUint::from_str_radix("4000000000", 16).unwrap();
     assert_eq!(n.bits(), 39);
     let one: BigUint = One::one();
-    assert_eq!((one << 426).bits(), 427);
+    assert_eq!((one << 426u16).bits(), 427);
 }
 
 #[test]

--- a/tests/modpow.rs
+++ b/tests/modpow.rs
@@ -117,7 +117,7 @@ mod bigint {
         fn check(b: &BigInt, e: &BigInt, m: &BigInt, r: &BigInt) {
             assert_eq!(&b.modpow(e, m), r, "{} ** {} (mod {}) != {}", b, e, m, r);
 
-            let even_m = m << 1;
+            let even_m = m << 1u8;
             let even_modpow = b.modpow(e, m);
             assert!(even_modpow.abs() < even_m.abs());
             assert_eq!(&even_modpow.mod_floor(&m), r);


### PR DESCRIPTION
The primitive integers all support shift operators with the right-hand side as any other primitive integer, by value or by reference. Now `BigInt` and `BigUint` support this too. This is a minor breaking change, because it can cause type inference failures if a user has an ambiguous integer for a shift count, whereas before it could only be `usize`.