### PR TITLE
Count big bits in u64 instead of usize

### DIFF
--- a/benches/bigint.rs
+++ b/benches/bigint.rs
@@ -18,7 +18,7 @@ fn get_rng() -> StdRng {
     SeedableRng::from_seed(seed)
 }
 
-fn multiply_bench(b: &mut Bencher, xbits: usize, ybits: usize) {
+fn multiply_bench(b: &mut Bencher, xbits: u64, ybits: u64) {
     let mut rng = get_rng();
     let x = rng.gen_bigint(xbits);
     let y = rng.gen_bigint(ybits);
@@ -26,7 +26,7 @@ fn multiply_bench(b: &mut Bencher, xbits: usize, ybits: usize) {
     b.iter(|| &x * &y);
 }
 
-fn divide_bench(b: &mut Bencher, xbits: usize, ybits: usize) {
+fn divide_bench(b: &mut Bencher, xbits: u64, ybits: u64) {
     let mut rng = get_rng();
     let x = rng.gen_bigint(xbits);
     let y = rng.gen_bigint(ybits);
@@ -34,7 +34,7 @@ fn divide_bench(b: &mut Bencher, xbits: usize, ybits: usize) {
     b.iter(|| &x / &y);
 }
 
-fn remainder_bench(b: &mut Bencher, xbits: usize, ybits: usize) {
+fn remainder_bench(b: &mut Bencher, xbits: u64, ybits: u64) {
     let mut rng = get_rng();
     let x = rng.gen_bigint(xbits);
     let y = rng.gen_bigint(ybits);
@@ -245,7 +245,7 @@ fn from_str_radix_36(b: &mut Bencher) {
     from_str_radix_bench(b, 36);
 }
 
-fn rand_bench(b: &mut Bencher, bits: usize) {
+fn rand_bench(b: &mut Bencher, bits: u64) {
     let mut rng = get_rng();
 
     b.iter(|| rng.gen_bigint(bits));

--- a/benches/gcd.rs
+++ b/benches/gcd.rs
@@ -18,7 +18,7 @@ fn get_rng() -> StdRng {
     SeedableRng::from_seed(seed)
 }
 
-fn bench(b: &mut Bencher, bits: usize, gcd: fn(&BigUint, &BigUint) -> BigUint) {
+fn bench(b: &mut Bencher, bits: u64, gcd: fn(&BigUint, &BigUint) -> BigUint) {
     let mut rng = get_rng();
     let x = rng.gen_biguint(bits);
     let y = rng.gen_biguint(bits);

--- a/benches/roots.rs
+++ b/benches/roots.rs
@@ -43,7 +43,7 @@ fn check(x: &BigUint, n: u32) {
     assert_eq!((&hi - 1u32).nth_root(n), root);
 }
 
-fn bench_sqrt(b: &mut Bencher, bits: usize) {
+fn bench_sqrt(b: &mut Bencher, bits: u64) {
     let x = get_rng().gen_biguint(bits);
     eprintln!("bench_sqrt({})", x);
 
@@ -71,7 +71,7 @@ fn big4k_sqrt(b: &mut Bencher) {
     bench_sqrt(b, 4096);
 }
 
-fn bench_cbrt(b: &mut Bencher, bits: usize) {
+fn bench_cbrt(b: &mut Bencher, bits: u64) {
     let x = get_rng().gen_biguint(bits);
     eprintln!("bench_cbrt({})", x);
 
@@ -99,7 +99,7 @@ fn big4k_cbrt(b: &mut Bencher) {
     bench_cbrt(b, 4096);
 }
 
-fn bench_nth_root(b: &mut Bencher, bits: usize, n: u32) {
+fn bench_nth_root(b: &mut Bencher, bits: u64, n: u32) {
     let x = get_rng().gen_biguint(bits);
     eprintln!("bench_{}th_root({})", n, x);
 

--- a/ci/big_rand/src/lib.rs
+++ b/ci/big_rand/src/lib.rs
@@ -102,7 +102,7 @@ mod biguint {
         let mut rng = R::from_seed(seed);
         for (i, &s) in expected.iter().enumerate() {
             let n: BigUint = s.parse().unwrap();
-            let r = rng.gen_biguint((1 << i) + i);
+            let r = rng.gen_biguint((1 << i) + i as u64);
             assert_eq!(n, r);
         }
     }
@@ -302,7 +302,7 @@ mod bigint {
         let mut rng = R::from_seed(seed);
         for (i, &s) in expected.iter().enumerate() {
             let n: BigInt = s.parse().unwrap();
-            let r = rng.gen_bigint((1 << i) + i);
+            let r = rng.gen_bigint((1 << i) + i as u64);
             assert_eq!(n, r);
         }
     }

--- a/src/algorithms.rs
+++ b/src/algorithms.rs
@@ -521,7 +521,7 @@ fn mac3(acc: &mut [BigDigit], b: &[BigDigit], c: &[BigDigit]) {
         // Recomposition. The coefficients of the polynomial are now known.
         //
         // Evaluate at w(t) where t is our given base to get the result.
-        let bits = big_digit::BITS * i;
+        let bits = u64::from(big_digit::BITS) * i as u64;
         let result = r0
             + (comp1 << bits)
             + (comp2 << (2 * bits))
@@ -720,11 +720,11 @@ fn div_rem_core(mut a: BigUint, b: &BigUint) -> (BigUint, BigUint) {
 
 /// Find last set bit
 /// fls(0) == 0, fls(u32::MAX) == 32
-pub(crate) fn fls<T: PrimInt>(v: T) -> usize {
-    mem::size_of::<T>() * 8 - v.leading_zeros() as usize
+pub(crate) fn fls<T: PrimInt>(v: T) -> u8 {
+    mem::size_of::<T>() as u8 * 8 - v.leading_zeros() as u8
 }
 
-pub(crate) fn ilog2<T: PrimInt>(v: T) -> usize {
+pub(crate) fn ilog2<T: PrimInt>(v: T) -> u8 {
     fls(v) - 1
 }
 

--- a/src/bigint.rs
+++ b/src/bigint.rs
@@ -875,7 +875,7 @@ impl_shift! { i8, i16, i32, i64, i128, isize }
 fn shr_round_down<T: PrimInt>(i: &BigInt, shift: T) -> bool {
     if i.is_negative() {
         let zeros = i.trailing_zeros().expect("negative values are non-zero");
-        shift > T::zero() && shift.to_usize().map(|shift| zeros < shift).unwrap_or(true)
+        shift > T::zero() && shift.to_u64().map(|shift| zeros < shift).unwrap_or(true)
     } else {
         false
     }
@@ -3195,7 +3195,7 @@ impl BigInt {
     /// Determines the fewest bits necessary to express the `BigInt`,
     /// not including the sign.
     #[inline]
-    pub fn bits(&self) -> usize {
+    pub fn bits(&self) -> u64 {
         self.data.bits()
     }
 
@@ -3290,7 +3290,7 @@ impl BigInt {
 
     /// Returns the number of least-significant bits that are zero,
     /// or `None` if the entire number is zero.
-    pub fn trailing_zeros(&self) -> Option<usize> {
+    pub fn trailing_zeros(&self) -> Option<u64> {
         self.data.trailing_zeros()
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -258,11 +258,11 @@ mod big_digit {
 
     // `DoubleBigDigit` size dependent
     #[cfg(not(u64_digit))]
-    pub(crate) const BITS: usize = 32;
+    pub(crate) const BITS: u8 = 32;
     #[cfg(u64_digit)]
-    pub(crate) const BITS: usize = 64;
+    pub(crate) const BITS: u8 = 64;
 
-    pub(crate) const HALF_BITS: usize = BITS / 2;
+    pub(crate) const HALF_BITS: u8 = BITS / 2;
     pub(crate) const HALF: BigDigit = (1 << HALF_BITS) - 1;
 
     const LO_MASK: DoubleBigDigit = (1 << BITS) - 1;

--- a/src/monty.rs
+++ b/src/monty.rs
@@ -150,7 +150,7 @@ pub(crate) fn monty_modpow(x: &BigUint, y: &BigUint, m: &BigUint) -> BigUint {
 
     // rr = 2**(2*_W*len(m)) mod m
     let mut rr = BigUint::one();
-    rr = (rr.shl(2 * num_words * big_digit::BITS)) % m;
+    rr = (rr.shl(2 * num_words as u64 * u64::from(big_digit::BITS))) % m;
     if rr.data.len() < num_words {
         rr.data.resize(num_words, 0);
     }


### PR DESCRIPTION
A 32-bit target _could_ create a giant `BigUint` over 2²⁹ bytes = 512MB,
not that this would be computationally useful, but that value would have
more than `usize::MAX` bits. To avoid that possibility of overflow, we
can better represent bit counts in `u64`.

For 64-bit targets, a `BigUint` over 2⁶¹ bytes is not realistic.

This changes the public API in the return values of `bits()` and
`trailing_zeros()`, as well as the `bit_size` parameter of `RandBigInt`
and `RandomBits`. Trying to randomize an absurd size will naturally
cause a capacity overflow, just as if you'd made a huge `Vec`.