### PR TITLE
Reduce carry/borrow size to 1 digit

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -250,6 +250,12 @@ mod big_digit {
     #[cfg(u64_digit)]
     pub(crate) type DoubleBigDigit = u128;
 
+    /// A `SignedBigDigit` is the signed version of `BigDigit`.
+    #[cfg(not(u64_digit))]
+    pub(crate) type SignedBigDigit = i32;
+    #[cfg(u64_digit)]
+    pub(crate) type SignedBigDigit = i64;
+
     /// A `SignedDoubleBigDigit` is the signed version of `DoubleBigDigit`.
     #[cfg(not(u64_digit))]
     pub(crate) type SignedDoubleBigDigit = i64;
@@ -265,15 +271,13 @@ mod big_digit {
     pub(crate) const HALF_BITS: u8 = BITS / 2;
     pub(crate) const HALF: BigDigit = (1 << HALF_BITS) - 1;
 
-    const LO_MASK: DoubleBigDigit = (1 << BITS) - 1;
-
     #[inline]
     fn get_hi(n: DoubleBigDigit) -> BigDigit {
         (n >> BITS) as BigDigit
     }
     #[inline]
     fn get_lo(n: DoubleBigDigit) -> BigDigit {
-        (n & LO_MASK) as BigDigit
+        n as BigDigit
     }
 
     /// Split one `DoubleBigDigit` into two `BigDigit`s.


### PR DESCRIPTION
Carries and borrows are formed by taking the high digit of a double-digit value, so they will always fit in a single digit. This should avoid the allocation of an unnecessary register. The benchmarks don't appear to show any significant changes.

I think the `sbb` borrow value would make more sense as a `SignedBigDigit` since it only ever stores 0 or -1. However, `__sub2rev()` returns the borrow as a `BigDigit`. (I think it would be better for `__sub2rev()` to also return a `SignedBigDigit`, however it is marked `pub`, so I didn't want to change its signature.)

Here's a comparison of the x86-64 assembly generated for the inner loop of `__add2()`, which adds together 2 digits of each integer. Before:
```
210:	4c 03 0c c7 	addq	(%rdi,%rax,8), %r9
214:	48 83 d3 00 	adcq	$0, %rbx
218:	4c 03 0c c2 	addq	(%rdx,%rax,8), %r9
21c:	48 83 d3 00 	adcq	$0, %rbx
220:	4c 89 0c c7 	movq	%r9, (%rdi,%rax,8)
224:	45 31 c9 	xorl	%r9d, %r9d
227:	48 03 5c c7 08 	addq	8(%rdi,%rax,8), %rbx
22c:	41 0f 92 c1 	setb	%r9b
230:	48 03 5c c2 08 	addq	8(%rdx,%rax,8), %rbx
235:	49 83 d1 00 	adcq	$0, %r9
239:	48 89 5c c7 08 	movq	%rbx, 8(%rdi,%rax,8)
23e:	48 83 c0 02 	addq	$2, %rax
242:	bb 00 00 00 00 	movl	$0, %ebx
247:	49 39 c3 	cmpq	%rax, %r11
24a:	75 c4 	jne	-60 <__ZN10num_bigint7biguint10algorithms6__add217h61a47fbf83d7a789E.llvm.1204343605305460342+0x50>
```
After:
```
250:	31 db 	xorl	%ebx, %ebx
252:	4a 03 04 c7 	addq	(%rdi,%r8,8), %rax
256:	0f 92 c3 	setb	%bl
259:	4a 03 04 c2 	addq	(%rdx,%r8,8), %rax
25d:	4a 89 04 c7 	movq	%rax, (%rdi,%r8,8)
261:	4a 13 5c c7 08 	adcq	8(%rdi,%r8,8), %rbx
266:	0f 92 c0 	setb	%al
269:	0f b6 c0 	movzbl	%al, %eax
26c:	4a 03 5c c2 08 	addq	8(%rdx,%r8,8), %rbx
271:	48 83 d0 00 	adcq	$0, %rax
275:	4a 89 5c c7 08 	movq	%rbx, 8(%rdi,%r8,8)
27a:	49 83 c0 02 	addq	$2, %r8
27e:	4d 39 c3 	cmpq	%r8, %r11
281:	75 cd 	jne	-51 <__ZN10num_bigint7biguint10algorithms6__add217hdc6b95dafddae44dE.llvm.9567749049756708424+0x40>
```
Only 5 `add`/`adc` instructions are used instead of the 7 previously (ignoring the `addq $2, ...` to advance the loop index).