### PR TITLE
Add iter_u32_digits , iter_u64_digits, to_u64_digits to both BigInt and BigUint

### DIFF
--- a/benches/bigint.rs
+++ b/benches/bigint.rs
@@ -393,3 +393,35 @@ fn modpow_even(b: &mut Bencher) {
 
     b.iter(|| base.modpow(&e, &m));
 }
+
+#[bench]
+fn to_u32_digits(b: &mut Bencher) {
+    let mut rng = get_rng();
+    let n = rng.gen_biguint(2048);
+
+    b.iter(|| n.to_u32_digits());
+}
+
+#[bench]
+fn iter_u32_digits(b: &mut Bencher) {
+    let mut rng = get_rng();
+    let n = rng.gen_biguint(2048);
+
+    b.iter(|| n.iter_u32_digits().max());
+}
+
+#[bench]
+fn to_u64_digits(b: &mut Bencher) {
+    let mut rng = get_rng();
+    let n = rng.gen_biguint(2048);
+
+    b.iter(|| n.to_u64_digits());
+}
+
+#[bench]
+fn iter_u64_digits(b: &mut Bencher) {
+    let mut rng = get_rng();
+    let n = rng.gen_biguint(2048);
+
+    b.iter(|| n.iter_u64_digits().max());
+}

--- a/src/bigint.rs
+++ b/src/bigint.rs
@@ -3007,8 +3007,8 @@ impl BigInt {
         (self.sign, self.data.to_u64_digits())
     }
 
-    /// Returns the `u32` digits representation of the `BigUint` ordered least significant digit
-    /// first.
+    /// Returns an iterator of `u64` digits representation of the `BigUint` ordered least
+    /// significant digit first.
     ///
     /// # Examples
     ///
@@ -3026,8 +3026,8 @@ impl BigInt {
         self.data.iter_u32_digits()
     }
 
-    /// Returns the `u64` digits representation of the `BigUint` ordered least significant digit
-    /// first.
+    /// Returns an iterator of `u64` digits representation of the `BigUint` ordered least
+    /// significant digit first.
     ///
     /// # Examples
     ///

--- a/src/bigint.rs
+++ b/src/bigint.rs
@@ -31,7 +31,7 @@ use self::Sign::{Minus, NoSign, Plus};
 use crate::big_digit::{self, BigDigit, DoubleBigDigit};
 use crate::biguint;
 use crate::biguint::to_str_radix_reversed;
-use crate::biguint::{BigUint, IntDigits};
+use crate::biguint::{BigUint, IntDigits, IterU32Digits, IterU64Digits};
 use crate::ParseBigIntError;
 #[cfg(has_try_from)]
 use crate::TryFromBigIntError;
@@ -2986,6 +2986,63 @@ impl BigInt {
     #[inline]
     pub fn to_u32_digits(&self) -> (Sign, Vec<u32>) {
         (self.sign, self.data.to_u32_digits())
+    }
+
+    /// Returns the sign and the `u32` digits representation of the `BigInt` ordered least
+    /// significant digit first.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use num_bigint::{BigInt, Sign};
+    ///
+    /// assert_eq!(BigInt::from(-1125).to_u64_digits(), (Sign::Minus, vec![1125]));
+    /// assert_eq!(BigInt::from(4294967295u32).to_u64_digits(), (Sign::Plus, vec![4294967295]));
+    /// assert_eq!(BigInt::from(4294967296u64).to_u64_digits(), (Sign::Plus, vec![4294967296]));
+    /// assert_eq!(BigInt::from(-112500000000i64).to_u64_digits(), (Sign::Minus, vec![112500000000]));
+    /// assert_eq!(BigInt::from(112500000000i64).to_u64_digits(), (Sign::Plus, vec![112500000000]));
+    /// ```
+    #[inline]
+    pub fn to_u64_digits(&self) -> (Sign, Vec<u64>) {
+        (self.sign, self.data.to_u64_digits())
+    }
+
+    /// Returns the `u32` digits representation of the `BigUint` ordered least significant digit
+    /// first.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use num_bigint::BigInt;
+    ///
+    /// assert_eq!(BigInt::from(-1125).iter_u32_digits().collect::<Vec<u32>>(), vec![1125]);
+    /// assert_eq!(BigInt::from(4294967295u32).iter_u32_digits().collect::<Vec<u32>>(), vec![4294967295]);
+    /// assert_eq!(BigInt::from(4294967296u64).iter_u32_digits().collect::<Vec<u32>>(), vec![0, 1]);
+    /// assert_eq!(BigInt::from(-112500000000i64).iter_u32_digits().collect::<Vec<u32>>(), vec![830850304, 26]);
+    /// assert_eq!(BigInt::from(112500000000i64).iter_u32_digits().collect::<Vec<u32>>(), vec![830850304, 26]);
+    /// ```
+    #[inline]
+    pub fn iter_u32_digits<'a>(&'a self) -> IterU32Digits<'a> {
+        self.data.iter_u32_digits()
+    }
+
+    /// Returns the `u32` digits representation of the `BigUint` ordered least significant digit
+    /// first.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use num_bigint::BigInt;
+    ///
+    /// assert_eq!(BigInt::from(-1125).iter_u64_digits().collect::<Vec<u64>>(), vec![1125u64]);
+    /// assert_eq!(BigInt::from(4294967295u32).iter_u64_digits().collect::<Vec<u64>>(), vec![4294967295u64]);
+    /// assert_eq!(BigInt::from(4294967296u64).iter_u64_digits().collect::<Vec<u64>>(), vec![4294967296u64]);
+    /// assert_eq!(BigInt::from(-112500000000i64).iter_u64_digits().collect::<Vec<u64>>(), vec![112500000000u64]);
+    /// assert_eq!(BigInt::from(112500000000i64).iter_u64_digits().collect::<Vec<u64>>(), vec![112500000000u64]);
+    /// ```
+    #[inline]
+    pub fn iter_u64_digits<'a>(&'a self) -> IterU64Digits<'a> {
+        self.data.iter_u64_digits()
     }
 
     /// Returns the two's-complement byte representation of the `BigInt` in big-endian byte order.

--- a/src/bigint.rs
+++ b/src/bigint.rs
@@ -3041,7 +3041,7 @@ impl BigInt {
     /// assert_eq!(BigInt::from(112500000000i64).iter_u64_digits().collect::<Vec<u64>>(), vec![112500000000u64]);
     /// ```
     #[inline]
-    pub fn iter_u64_digits<'a>(&'a self) -> IterU64Digits<'a> {
+    pub fn iter_u64_digits(&self) -> IterU64Digits<'_> {
         self.data.iter_u64_digits()
     }
 

--- a/src/bigint.rs
+++ b/src/bigint.rs
@@ -2988,7 +2988,7 @@ impl BigInt {
         (self.sign, self.data.to_u32_digits())
     }
 
-    /// Returns the sign and the `u32` digits representation of the `BigInt` ordered least
+    /// Returns the sign and the `u64` digits representation of the `BigInt` ordered least
     /// significant digit first.
     ///
     /// # Examples
@@ -3022,11 +3022,11 @@ impl BigInt {
     /// assert_eq!(BigInt::from(112500000000i64).iter_u32_digits().collect::<Vec<u32>>(), vec![830850304, 26]);
     /// ```
     #[inline]
-    pub fn iter_u32_digits<'a>(&'a self) -> IterU32Digits<'a> {
+    pub fn iter_u32_digits(&self) -> IterU32Digits<'_> {
         self.data.iter_u32_digits()
     }
 
-    /// Returns the `u32` digits representation of the `BigUint` ordered least significant digit
+    /// Returns the `u64` digits representation of the `BigUint` ordered least significant digit
     /// first.
     ///
     /// # Examples

--- a/src/bigint.rs
+++ b/src/bigint.rs
@@ -3007,7 +3007,7 @@ impl BigInt {
         (self.sign, self.data.to_u64_digits())
     }
 
-    /// Returns an iterator of `u64` digits representation of the `BigUint` ordered least
+    /// Returns an iterator of `u32` digits representation of the `BigUint` ordered least
     /// significant digit first.
     ///
     /// # Examples

--- a/src/biguint.rs
+++ b/src/biguint.rs
@@ -2281,6 +2281,7 @@ pub struct IterU32Digits<'a> {
 }
 #[cfg(u64_digit)]
 impl<'a> IterU32Digits<'a> {
+    #[inline]
     fn new(data: &'a [u64]) -> Self {
         let last_hi_is_zero = data
             .last()
@@ -2299,6 +2300,7 @@ impl<'a> IterU32Digits<'a> {
 #[cfg(u64_digit)]
 impl Iterator for IterU32Digits<'_> {
     type Item = u32;
+    #[inline]
     fn next(&mut self) -> Option<u32> {
         match self.data.split_first() {
             Some((&first, data)) => {
@@ -2320,11 +2322,13 @@ impl Iterator for IterU32Digits<'_> {
         }
     }
 
+    #[inline]
     fn size_hint(&self) -> (usize, Option<usize>) {
         let len = self.len();
         (len, Some(len))
     }
 
+    #[inline]
     fn last(self) -> Option<u32> {
         self.data.last().map(|&last| {
             if self.last_hi_is_zero {
@@ -2335,12 +2339,14 @@ impl Iterator for IterU32Digits<'_> {
         })
     }
 
+    #[inline]
     fn count(self) -> usize {
         self.len()
     }
 }
 #[cfg(u64_digit)]
 impl ExactSizeIterator for IterU32Digits<'_> {
+    #[inline]
     fn len(&self) -> usize {
         self.data.len() * 2 - usize::from(self.last_hi_is_zero) - usize::from(!self.next_is_lo)
     }
@@ -2348,6 +2354,7 @@ impl ExactSizeIterator for IterU32Digits<'_> {
 
 #[cfg(not(u64_digit))]
 impl<'a> IterU32Digits<'a> {
+    #[inline]
     fn new(data: &'a [u32]) -> Self {
         Self { it: data.iter() }
     }
@@ -2355,28 +2362,34 @@ impl<'a> IterU32Digits<'a> {
 #[cfg(not(u64_digit))]
 impl Iterator for IterU32Digits<'_> {
     type Item = u32;
+    #[inline]
     fn next(&mut self) -> Option<u32> {
         self.it.next().cloned()
     }
 
+    #[inline]
     fn size_hint(&self) -> (usize, Option<usize>) {
         self.it.size_hint()
     }
 
+    #[inline]
     fn nth(&mut self, n: usize) -> Option<u32> {
         self.it.nth(n).cloned()
     }
 
+    #[inline]
     fn last(self) -> Option<u32> {
         self.it.last().cloned()
     }
 
+    #[inline]
     fn count(self) -> usize {
         self.it.count()
     }
 }
 #[cfg(not(u64_digit))]
 impl ExactSizeIterator for IterU32Digits<'_> {
+    #[inline]
     fn len(&self) -> usize {
         self.it.len()
     }
@@ -2395,6 +2408,7 @@ pub struct IterU64Digits<'a> {
 }
 #[cfg(not(u64_digit))]
 impl<'a> IterU64Digits<'a> {
+    #[inline]
     fn new(data: &'a [u32]) -> Self {
         IterU64Digits { it: data.chunks(2) }
     }
@@ -2403,25 +2417,30 @@ impl<'a> IterU64Digits<'a> {
 #[cfg(not(u64_digit))]
 impl Iterator for IterU64Digits<'_> {
     type Item = u64;
+    #[inline]
     fn next(&mut self) -> Option<u64> {
         self.it.next().map(u32_chunk_to_u64)
     }
 
+    #[inline]
     fn size_hint(&self) -> (usize, Option<usize>) {
         let len = self.len();
         (len, Some(len))
     }
 
+    #[inline]
     fn last(self) -> Option<u64> {
         self.it.last().map(u32_chunk_to_u64)
     }
 
+    #[inline]
     fn count(self) -> usize {
         self.len()
     }
 }
 #[cfg(not(u64_digit))]
 impl ExactSizeIterator for IterU64Digits<'_> {
+    #[inline]
     fn len(&self) -> usize {
         self.it.len()
     }
@@ -2429,6 +2448,7 @@ impl ExactSizeIterator for IterU64Digits<'_> {
 
 #[cfg(u64_digit)]
 impl<'a> IterU64Digits<'a> {
+    #[inline]
     fn new(data: &'a [u64]) -> Self {
         Self { it: data.iter() }
     }
@@ -2436,28 +2456,34 @@ impl<'a> IterU64Digits<'a> {
 #[cfg(u64_digit)]
 impl Iterator for IterU64Digits<'_> {
     type Item = u64;
+    #[inline]
     fn next(&mut self) -> Option<u64> {
         self.it.next().cloned()
     }
 
+    #[inline]
     fn size_hint(&self) -> (usize, Option<usize>) {
         self.it.size_hint()
     }
 
+    #[inline]
     fn nth(&mut self, n: usize) -> Option<u64> {
         self.it.nth(n).cloned()
     }
 
+    #[inline]
     fn last(self) -> Option<u64> {
         self.it.last().cloned()
     }
 
+    #[inline]
     fn count(self) -> usize {
         self.it.count()
     }
 }
 #[cfg(u64_digit)]
 impl ExactSizeIterator for IterU64Digits<'_> {
+    #[inline]
     fn len(&self) -> usize {
         self.it.len()
     }

--- a/src/biguint.rs
+++ b/src/biguint.rs
@@ -2330,7 +2330,7 @@ impl<'a> ExactSizeIterator for IterU32Digits<'a> {
 
 #[cfg(not(u64_digit))]
 pub struct IterU32Digits<'a> {
-    it: std::slice::Iter<'a, u32>,
+    it: core::slice::Iter<'a, u32>,
 }
 #[cfg(not(u64_digit))]
 impl<'a> IterU32Digits<'a> {
@@ -2372,7 +2372,7 @@ impl<'a> FusedIterator for IterU32Digits<'a> {}
 
 #[cfg(not(u64_digit))]
 pub struct IterU64Digits<'a> {
-    it: std::slice::Chunks<'a, u32>,
+    it: core::slice::Chunks<'a, u32>,
 }
 #[cfg(not(u64_digit))]
 impl<'a> IterU64Digits<'a> {
@@ -2421,7 +2421,7 @@ impl<'a> ExactSizeIterator for IterU64Digits<'a> {
 
 #[cfg(u64_digit)]
 pub struct IterU64Digits<'a> {
-    it: std::slice::Iter<'a, u64>,
+    it: core::slice::Iter<'a, u64>,
 }
 #[cfg(u64_digit)]
 impl<'a> IterU64Digits<'a> {

--- a/src/biguint.rs
+++ b/src/biguint.rs
@@ -2290,7 +2290,7 @@ impl<'a> IterU32Digits<'a> {
     }
 }
 #[cfg(u64_digit)]
-impl<'a> Iterator for IterU32Digits<'a> {
+impl Iterator for IterU32Digits<'_> {
     type Item = u32;
     fn next(&mut self) -> Option<u32> {
         match self.data.split_first() {
@@ -2717,7 +2717,7 @@ impl BigUint {
         self.iter_u32_digits().collect()
     }
 
-    /// Returns the `u32` digits representation of the `BigUint` ordered least significant digit
+    /// Returns the `u64` digits representation of the `BigUint` ordered least significant digit
     /// first.
     ///
     /// # Examples

--- a/src/biguint.rs
+++ b/src/biguint.rs
@@ -2340,7 +2340,7 @@ impl Iterator for IterU32Digits<'_> {
     }
 }
 #[cfg(u64_digit)]
-impl<'a> ExactSizeIterator for IterU32Digits<'a> {
+impl ExactSizeIterator for IterU32Digits<'_> {
     fn len(&self) -> usize {
         self.data.len() * 2 - usize::from(self.last_hi_is_zero) - usize::from(!self.next_is_lo)
     }
@@ -2353,7 +2353,7 @@ impl<'a> IterU32Digits<'a> {
     }
 }
 #[cfg(not(u64_digit))]
-impl<'a> Iterator for IterU32Digits<'a> {
+impl Iterator for IterU32Digits<'_> {
     type Item = u32;
     fn next(&mut self) -> Option<u32> {
         self.it.next().cloned()
@@ -2376,13 +2376,13 @@ impl<'a> Iterator for IterU32Digits<'a> {
     }
 }
 #[cfg(not(u64_digit))]
-impl<'a> ExactSizeIterator for IterU32Digits<'a> {
+impl ExactSizeIterator for IterU32Digits<'_> {
     fn len(&self) -> usize {
         self.it.len()
     }
 }
 
-impl<'a> FusedIterator for IterU32Digits<'a> {}
+impl FusedIterator for IterU32Digits<'_> {}
 
 /// An iterator of `u64` digits representation of the `BigUint` ordered least
 /// significant digit first.
@@ -2401,7 +2401,7 @@ impl<'a> IterU64Digits<'a> {
 }
 
 #[cfg(not(u64_digit))]
-impl<'a> Iterator for IterU64Digits<'a> {
+impl Iterator for IterU64Digits<'_> {
     type Item = u64;
     fn next(&mut self) -> Option<u64> {
         self.it.next().map(u32_chunk_to_u64)
@@ -2421,7 +2421,7 @@ impl<'a> Iterator for IterU64Digits<'a> {
     }
 }
 #[cfg(not(u64_digit))]
-impl<'a> ExactSizeIterator for IterU64Digits<'a> {
+impl ExactSizeIterator for IterU64Digits<'_> {
     fn len(&self) -> usize {
         self.it.len()
     }
@@ -2434,7 +2434,7 @@ impl<'a> IterU64Digits<'a> {
     }
 }
 #[cfg(u64_digit)]
-impl<'a> Iterator for IterU64Digits<'a> {
+impl Iterator for IterU64Digits<'_> {
     type Item = u64;
     fn next(&mut self) -> Option<u64> {
         self.it.next().cloned()
@@ -2457,12 +2457,12 @@ impl<'a> Iterator for IterU64Digits<'a> {
     }
 }
 #[cfg(u64_digit)]
-impl<'a> ExactSizeIterator for IterU64Digits<'a> {
+impl ExactSizeIterator for IterU64Digits<'_> {
     fn len(&self) -> usize {
         self.it.len()
     }
 }
-impl<'a> FusedIterator for IterU64Digits<'a> {}
+impl FusedIterator for IterU64Digits<'_> {}
 
 /// Creates and initializes a `BigUint`.
 ///

--- a/src/biguint.rs
+++ b/src/biguint.rs
@@ -2735,8 +2735,8 @@ impl BigUint {
         self.iter_u64_digits().collect()
     }
 
-    /// Returns the `u32` digits representation of the `BigUint` ordered least significant digit
-    /// first.
+    /// Returns an iterator of `u32` digits representation of the `BigUint` ordered least
+    /// significant digit first.
     ///
     /// # Examples
     ///
@@ -2753,8 +2753,8 @@ impl BigUint {
         IterU32Digits::new(self.data.as_slice())
     }
 
-    /// Returns the `u32` digits representation of the `BigUint` ordered least significant digit
-    /// first.
+    /// Returns an iterator of `u64` digits representation of the `BigUint` ordered least
+    /// significant digit first.
     ///
     /// # Examples
     ///

--- a/src/biguint.rs
+++ b/src/biguint.rs
@@ -2335,7 +2335,7 @@ impl Iterator for IterU32Digits<'_> {
 #[cfg(u64_digit)]
 impl<'a> ExactSizeIterator for IterU32Digits<'a> {
     fn len(&self) -> usize {
-        self.data.len() * 2 - usize::from(self.last_hi_is_zero)
+        self.data.len() * 2 - usize::from(self.last_hi_is_zero) - usize::from(!self.next_is_lo)
     }
 }
 
@@ -3283,4 +3283,46 @@ fn test_pow_biguint() {
     let exponent = BigUint::from(3u8);
 
     assert_eq!(BigUint::from(125u8), base.pow(exponent));
+}
+
+#[test]
+fn test_iter_u32_digits() {
+    let n = BigUint::from(5u8);
+    let mut it = n.iter_u32_digits();
+    assert_eq!(it.len(), 1);
+    assert_eq!(it.next(), Some(5));
+    assert_eq!(it.len(), 0);
+    assert_eq!(it.next(), None);
+    assert_eq!(it.len(), 0);
+    assert_eq!(it.next(), None);
+
+    let n = BigUint::from(112500000000u64);
+    let mut it = n.iter_u32_digits();
+    assert_eq!(it.len(), 2);
+    assert_eq!(it.next(), Some(830850304));
+    assert_eq!(it.len(), 1);
+    assert_eq!(it.next(), Some(26));
+    assert_eq!(it.len(), 0);
+    assert_eq!(it.next(), None);
+}
+
+#[test]
+fn test_iter_u64_digits() {
+    let n = BigUint::from(5u8);
+    let mut it = n.iter_u64_digits();
+    assert_eq!(it.len(), 1);
+    assert_eq!(it.next(), Some(5));
+    assert_eq!(it.len(), 0);
+    assert_eq!(it.next(), None);
+    assert_eq!(it.len(), 0);
+    assert_eq!(it.next(), None);
+
+    let n = BigUint::from(18_446_744_073_709_551_616u128);
+    let mut it = n.iter_u64_digits();
+    assert_eq!(it.len(), 2);
+    assert_eq!(it.next(), Some(0));
+    assert_eq!(it.len(), 1);
+    assert_eq!(it.next(), Some(1));
+    assert_eq!(it.len(), 0);
+    assert_eq!(it.next(), None);
 }

--- a/src/biguint.rs
+++ b/src/biguint.rs
@@ -163,6 +163,17 @@ impl FromStr for BigUint {
     }
 }
 
+/// Convert a u32 chunk (len is either 1 or 2) to a single u64 digit
+#[inline]
+fn u32_chunk_to_u64(chunk: &[u32]) -> u64 {
+    // raw could have odd length
+    let mut digit = chunk[0] as u64;
+    if let Some(&hi) = chunk.get(1) {
+        digit |= (hi as u64) << 32;
+    }
+    digit
+}
+
 // Convert from a power of two radix (bits == ilog2(radix)) where bits evenly divides
 // BigDigit::BITS
 fn from_bitwise_digits_le(v: &[u8], bits: u8) -> BigUint {
@@ -2377,20 +2388,15 @@ pub struct IterU64Digits<'a> {
 #[cfg(not(u64_digit))]
 impl<'a> IterU64Digits<'a> {
     fn new(data: &'a [u32]) -> Self {
-        IterU32Digits { it: data.chunks(2) }
+        IterU64Digits { it: data.chunks(2) }
     }
 }
+
 #[cfg(not(u64_digit))]
 impl<'a> Iterator for IterU64Digits<'a> {
     type Item = u64;
     fn next(&mut self) -> Option<u64> {
-        self.it.next(|chunk| {
-            let mut digit = chunk[0] as u64;
-            if let Some(&hi) = chunk.get(1) {
-                digit |= (hi as u64) << 32;
-            }
-            digit
-        })
+        self.it.next().map(u32_chunk_to_u64)
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
@@ -2398,14 +2404,8 @@ impl<'a> Iterator for IterU64Digits<'a> {
         (len, Some(len))
     }
 
-    fn last(self) -> Option<u32> {
-        self.data.last().map(|&last| {
-            if self.last_hi_is_zero {
-                last as u32
-            } else {
-                (last >> 32) as u32
-            }
-        })
+    fn last(self) -> Option<u64> {
+        self.it.last().map(u32_chunk_to_u64)
     }
 
     fn count(self) -> usize {
@@ -2415,7 +2415,7 @@ impl<'a> Iterator for IterU64Digits<'a> {
 #[cfg(not(u64_digit))]
 impl<'a> ExactSizeIterator for IterU64Digits<'a> {
     fn len(&self) -> usize {
-        self.data.len() * 2 - usize::from(self.last_hi_is_zero)
+        self.it.len()
     }
 }
 
@@ -2509,14 +2509,7 @@ impl BigUint {
         self.data.extend_from_slice(slice);
 
         #[cfg(u64_digit)]
-        self.data.extend(slice.chunks(2).map(|chunk| {
-            // raw could have odd length
-            let mut digit = BigDigit::from(chunk[0]);
-            if let Some(&hi) = chunk.get(1) {
-                digit |= BigDigit::from(hi) << 32;
-            }
-            digit
-        }));
+        self.data.extend(slice.chunks(2).map(u32_chunk_to_u64));
 
         self.normalize();
     }

--- a/src/biguint.rs
+++ b/src/biguint.rs
@@ -2353,7 +2353,7 @@ impl<'a> IterU32Digits<'a> {
 impl<'a> Iterator for IterU32Digits<'a> {
     type Item = u32;
     fn next(&mut self) -> Option<u32> {
-        self.it.next().map(|&t| t)
+        self.it.next().cloned()
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {

--- a/src/biguint.rs
+++ b/src/biguint.rs
@@ -2266,11 +2266,18 @@ pub(crate) fn to_str_radix_reversed(u: &BigUint, radix: u32) -> Vec<u8> {
     res
 }
 
-#[cfg(u64_digit)]
+/// An iterator of `u32` digits representation of the `BigUint` ordered least
+/// significant digit first.
 pub struct IterU32Digits<'a> {
+    #[cfg(u64_digit)]
     data: &'a [u64],
+    #[cfg(u64_digit)]
     next_is_lo: bool,
+    #[cfg(u64_digit)]
     last_hi_is_zero: bool,
+
+    #[cfg(not(u64_digit))]
+    it: core::slice::Iter<'a, u32>,
 }
 #[cfg(u64_digit)]
 impl<'a> IterU32Digits<'a> {
@@ -2340,10 +2347,6 @@ impl<'a> ExactSizeIterator for IterU32Digits<'a> {
 }
 
 #[cfg(not(u64_digit))]
-pub struct IterU32Digits<'a> {
-    it: core::slice::Iter<'a, u32>,
-}
-#[cfg(not(u64_digit))]
 impl<'a> IterU32Digits<'a> {
     fn new(data: &'a [u32]) -> Self {
         Self { it: data.iter() }
@@ -2381,9 +2384,14 @@ impl<'a> ExactSizeIterator for IterU32Digits<'a> {
 
 impl<'a> FusedIterator for IterU32Digits<'a> {}
 
-#[cfg(not(u64_digit))]
+/// An iterator of `u64` digits representation of the `BigUint` ordered least
+/// significant digit first.
 pub struct IterU64Digits<'a> {
+    #[cfg(not(u64_digit))]
     it: core::slice::Chunks<'a, u32>,
+
+    #[cfg(u64_digit)]
+    it: core::slice::Iter<'a, u64>,
 }
 #[cfg(not(u64_digit))]
 impl<'a> IterU64Digits<'a> {
@@ -2419,10 +2427,6 @@ impl<'a> ExactSizeIterator for IterU64Digits<'a> {
     }
 }
 
-#[cfg(u64_digit)]
-pub struct IterU64Digits<'a> {
-    it: core::slice::Iter<'a, u64>,
-}
 #[cfg(u64_digit)]
 impl<'a> IterU64Digits<'a> {
     fn new(data: &'a [u64]) -> Self {

--- a/src/biguint.rs
+++ b/src/biguint.rs
@@ -2330,21 +2330,19 @@ impl<'a> ExactSizeIterator for IterU32Digits<'a> {
 
 #[cfg(not(u64_digit))]
 pub struct IterU32Digits<'a> {
-    it: std::iter::Copied<std::slice::Iter<'a, u32>>,
+    it: std::slice::Iter<'a, u32>,
 }
 #[cfg(not(u64_digit))]
 impl<'a> IterU32Digits<'a> {
     fn new(data: &'a [u32]) -> Self {
-        Self {
-            it: data.iter().copied(),
-        }
+        Self { it: data.iter() }
     }
 }
 #[cfg(not(u64_digit))]
 impl<'a> Iterator for IterU32Digits<'a> {
     type Item = u32;
     fn next(&mut self) -> Option<u32> {
-        self.it.next()
+        self.it.next().map(|&t| t)
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
@@ -2352,11 +2350,11 @@ impl<'a> Iterator for IterU32Digits<'a> {
     }
 
     fn nth(&mut self, n: usize) -> Option<u32> {
-        self.it.nth(n)
+        self.it.nth(n).map(|&t| t)
     }
 
     fn last(self) -> Option<u32> {
-        self.it.last()
+        self.it.last().map(|&t| t)
     }
 
     fn count(self) -> usize {
@@ -2423,21 +2421,19 @@ impl<'a> ExactSizeIterator for IterU64Digits<'a> {
 
 #[cfg(u64_digit)]
 pub struct IterU64Digits<'a> {
-    it: std::iter::Copied<std::slice::Iter<'a, u64>>,
+    it: std::slice::Iter<'a, u64>,
 }
 #[cfg(u64_digit)]
 impl<'a> IterU64Digits<'a> {
     fn new(data: &'a [u64]) -> Self {
-        Self {
-            it: data.iter().copied(),
-        }
+        Self { it: data.iter() }
     }
 }
 #[cfg(u64_digit)]
 impl<'a> Iterator for IterU64Digits<'a> {
     type Item = u64;
     fn next(&mut self) -> Option<u64> {
-        self.it.next()
+        self.it.next().map(|&t| t)
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
@@ -2445,11 +2441,11 @@ impl<'a> Iterator for IterU64Digits<'a> {
     }
 
     fn nth(&mut self, n: usize) -> Option<u64> {
-        self.it.nth(n)
+        self.it.nth(n).map(|&t| t)
     }
 
     fn last(self) -> Option<u64> {
-        self.it.last()
+        self.it.last().map(|&t| t)
     }
 
     fn count(self) -> usize {
@@ -2718,14 +2714,14 @@ impl BigUint {
     /// ```
     /// use num_bigint::BigUint;
     ///
-    /// assert_eq!(BigUint::from(1125u32).to_u64_digits(), vec![1125]);
-    /// assert_eq!(BigUint::from(4294967295u32).to_u64_digits(), vec![4294967295]);
-    /// assert_eq!(BigUint::from(4294967296u64).to_u64_digits(), vec![4294967296]);
-    /// assert_eq!(BigUint::from(112500000000u64).to_u64_digits(), vec![112500000000]);
+    /// assert_eq!(BigUint::from(1125u32).to_u32_digits(), vec![1125]);
+    /// assert_eq!(BigUint::from(4294967295u32).to_u32_digits(), vec![4294967295]);
+    /// assert_eq!(BigUint::from(4294967296u64).to_u32_digits(), vec![0, 1]);
+    /// assert_eq!(BigUint::from(112500000000u64).to_u32_digits(), vec![830850304, 26]);
     /// ```
     #[inline]
-    pub fn to_u64_digits(&self) -> Vec<u64> {
-        self.iter_u64_digits().collect()
+    pub fn to_u32_digits(&self) -> Vec<u32> {
+        self.iter_u32_digits().collect()
     }
 
     /// Returns the `u32` digits representation of the `BigUint` ordered least significant digit
@@ -2736,14 +2732,14 @@ impl BigUint {
     /// ```
     /// use num_bigint::BigUint;
     ///
-    /// assert_eq!(BigUint::from(1125u32).to_u32_digits(), vec![1125]);
-    /// assert_eq!(BigUint::from(4294967295u32).to_u32_digits(), vec![4294967295]);
-    /// assert_eq!(BigUint::from(4294967296u64).to_u32_digits(), vec![0, 1]);
-    /// assert_eq!(BigUint::from(112500000000u64).to_u32_digits(), vec![830850304, 26]);
+    /// assert_eq!(BigUint::from(1125u32).to_u64_digits(), vec![1125]);
+    /// assert_eq!(BigUint::from(4294967295u32).to_u64_digits(), vec![4294967295]);
+    /// assert_eq!(BigUint::from(4294967296u64).to_u64_digits(), vec![4294967296]);
+    /// assert_eq!(BigUint::from(112500000000u64).to_u64_digits(), vec![112500000000]);
     /// ```
     #[inline]
-    pub fn to_u32_digits(&self) -> Vec<u32> {
-        self.iter_u32_digits().collect()
+    pub fn to_u64_digits(&self) -> Vec<u64> {
+        self.iter_u64_digits().collect()
     }
 
     /// Returns the `u32` digits representation of the `BigUint` ordered least significant digit

--- a/src/biguint.rs
+++ b/src/biguint.rs
@@ -2361,11 +2361,11 @@ impl<'a> Iterator for IterU32Digits<'a> {
     }
 
     fn nth(&mut self, n: usize) -> Option<u32> {
-        self.it.nth(n).map(|&t| t)
+        self.it.nth(n).cloned()
     }
 
     fn last(self) -> Option<u32> {
-        self.it.last().map(|&t| t)
+        self.it.last().cloned()
     }
 
     fn count(self) -> usize {
@@ -2433,7 +2433,7 @@ impl<'a> IterU64Digits<'a> {
 impl<'a> Iterator for IterU64Digits<'a> {
     type Item = u64;
     fn next(&mut self) -> Option<u64> {
-        self.it.next().map(|&t| t)
+        self.it.next().cloned()
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
@@ -2441,11 +2441,11 @@ impl<'a> Iterator for IterU64Digits<'a> {
     }
 
     fn nth(&mut self, n: usize) -> Option<u64> {
-        self.it.nth(n).map(|&t| t)
+        self.it.nth(n).cloned()
     }
 
     fn last(self) -> Option<u64> {
-        self.it.last().map(|&t| t)
+        self.it.last().cloned()
     }
 
     fn count(self) -> usize {
@@ -2749,7 +2749,7 @@ impl BigUint {
     /// assert_eq!(BigUint::from(112500000000u64).iter_u32_digits().collect::<Vec<u32>>(), vec![830850304, 26]);
     /// ```
     #[inline]
-    pub fn iter_u32_digits<'a>(&'a self) -> IterU32Digits<'a> {
+    pub fn iter_u32_digits(&self) -> IterU32Digits<'_> {
         IterU32Digits::new(self.data.as_slice())
     }
 
@@ -2767,7 +2767,7 @@ impl BigUint {
     /// assert_eq!(BigUint::from(112500000000u64).iter_u64_digits().collect::<Vec<u64>>(), vec![112500000000]);
     /// ```
     #[inline]
-    pub fn iter_u64_digits<'a>(&'a self) -> IterU64Digits<'a> {
+    pub fn iter_u64_digits(&self) -> IterU64Digits<'_> {
         IterU64Digits::new(self.data.as_slice())
     }
 


### PR DESCRIPTION
This adds: `iter_u32_digits` , `iter_u64_digits`, `to_u64_digits` to both `BigInt` and `BigUint`