### PR TITLE
Update bigint modpow documentation

### DIFF
--- a/src/bigint.rs
+++ b/src/bigint.rs
@@ -3207,7 +3207,7 @@ impl BigInt {
     /// Note that this rounds like `mod_floor`, not like the `%` operator,
     /// which makes a difference when given a negative `self` or `modulus`.
     /// The result will be in the interval `[0, modulus)` for `modulus > 0`,
-    /// or in the interval `(modulus, 0]` for `modulus < 0`
+    /// or in the interval `(-modulus, 0]` for `modulus < 0`
     ///
     /// Panics if the exponent is negative or the modulus is zero.
     pub fn modpow(&self, exponent: &Self, modulus: &Self) -> Self {


### PR DESCRIPTION
This commit corrects the range for the case that `modulus < 0`. I know it's a small inconsequential change but it's also an easy fix, so I figured why not.