### PR TITLE
Add zero constants

### DIFF
--- a/src/bigint.rs
+++ b/src/bigint.rs
@@ -849,10 +849,7 @@ fn shr_round_down<T: PrimInt>(i: &BigInt, shift: T) -> bool {
 impl Zero for BigInt {
     #[inline]
     fn zero() -> BigInt {
-        BigInt {
-            sign: NoSign,
-            data: BigUint::zero(),
-        }
+        BigInt::ZERO.clone()
     }
 
     #[inline]
@@ -2763,6 +2760,12 @@ impl_to_bigint!(f32, FromPrimitive::from_f32);
 impl_to_bigint!(f64, FromPrimitive::from_f64);
 
 impl BigInt {
+    /// The value 0 as a `BigInt`
+    pub const ZERO: BigInt = BigInt {
+        sign: Sign::NoSign,
+        data: BigUint::ZERO,
+    };
+    
     /// Creates and initializes a BigInt.
     ///
     /// The base 2<sup>32</sup> digits are ordered least significant digit first.

--- a/src/biguint.rs
+++ b/src/biguint.rs
@@ -501,7 +501,7 @@ impl_shift! { i8, i16, i32, i64, i128, isize }
 impl Zero for BigUint {
     #[inline]
     fn zero() -> BigUint {
-        BigUint { data: Vec::new() }
+        BigUint::ZERO.clone()
     }
 
     #[inline]
@@ -2264,6 +2264,11 @@ pub(crate) fn biguint_from_vec(digits: Vec<BigDigit>) -> BigUint {
 }
 
 impl BigUint {
+    /// The value 0 as a `BigUint`
+    pub const ZERO: BigUint = BigUint {
+        data: Vec::new(),
+    };
+
     /// Creates and initializes a `BigUint`.
     ///
     /// The base 2<sup>32</sup> digits are ordered least significant digit first.


### PR DESCRIPTION
This adds `ZERO` as constants for `BigInt` and `BigUint`. Having a constant is more useful than the `zero` function, as the lifetime of the const will be `'static` whereas the function will create a new zero on the stack.