### PR TITLE
Improve performance of the basic division algorithm.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -266,6 +266,7 @@ mod big_digit {
     pub(crate) const HALF: BigDigit = (1 << HALF_BITS) - 1;
 
     const LO_MASK: DoubleBigDigit = (1 << BITS) - 1;
+    pub(crate) const MAX: BigDigit = LO_MASK as BigDigit;
 
     #[inline]
     fn get_hi(n: DoubleBigDigit) -> BigDigit {

--- a/tests/biguint.rs
+++ b/tests/biguint.rs
@@ -898,6 +898,20 @@ fn test_div_rem() {
 }
 
 #[test]
+fn test_div_rem_big_multiple() {
+    let a = BigUint::from(3u32).pow(100u32);
+    let a2 = &a * &a;
+
+    let (div, rem) = a2.div_rem(&a);
+    assert_eq!(div, a);
+    assert!(rem.is_zero());
+
+    let (div, rem) = (&a2 - 1u32).div_rem(&a);
+    assert_eq!(div, &a - 1u32);
+    assert_eq!(rem, &a - 1u32);
+}
+
+#[test]
 fn test_div_ceil() {
     fn check(a: &BigUint, b: &BigUint, d: &BigUint, m: &BigUint) {
         if m.is_zero() {


### PR DESCRIPTION
Avoid computing a multiple of the divisor (and thus allocating memory) in the division loop.
Instead, directly subtract a multiple of the divisor from the dividend.

Also compute a more accurate guess for the next digit of the result. The guess is now exact in
almost all cases. In those cases where it's not exact, it will be off by exactly 1.