### PR TITLE
Shrink overallocated capacity if a number gets a lot smaller.

### DIFF
--- a/src/biguint.rs
+++ b/src/biguint.rs
@@ -2617,6 +2617,9 @@ impl BigUint {
         while let Some(&0) = self.data.last() {
             self.data.pop();
         }
+        if self.data.len() < self.data.capacity() / 4 {
+            self.data.shrink_to_fit();
+        }
     }
 
     /// Returns a normalized `BigUint`.


### PR DESCRIPTION
If a number gets below 1/4 of capacity, shrink_to_fit. Since Vec grows by 2, this amortizes well
for any sequence of sizes.