### PR TITLE
silenced a bunch of misleading Clippy warnings

### DIFF
--- a/src/algorithms.rs
+++ b/src/algorithms.rs
@@ -349,6 +349,7 @@ fn bigint_from_slice(slice: &[BigDigit]) -> BigInt {
 
 /// Three argument multiply accumulate:
 /// acc += b * c
+#[allow(clippy::many_single_char_names)]
 fn mac3(acc: &mut [BigDigit], b: &[BigDigit], c: &[BigDigit]) {
     let (x, y) = if b.len() < c.len() { (b, c) } else { (c, b) };
 

--- a/src/bigint.rs
+++ b/src/bigint.rs
@@ -2707,7 +2707,9 @@ impl TryFrom<&BigInt> for BigUint {
 
     #[inline]
     fn try_from(value: &BigInt) -> Result<BigUint, TryFromBigIntError<()>> {
-        value.to_biguint().ok_or(TryFromBigIntError::new(()))
+        value
+            .to_biguint()
+            .ok_or_else(|| TryFromBigIntError::new(()))
     }
 }
 

--- a/src/biguint.rs
+++ b/src/biguint.rs
@@ -1814,7 +1814,12 @@ impl Roots for BigUint {
 fn high_bits_to_u64(v: &BigUint) -> u64 {
     match v.data.len() {
         0 => 0,
-        1 => u64::from(v.data[0]),
+        1 => {
+            // XXX Conversion is useless if already 64-bit.
+            #[allow(clippy::useless_conversion)]
+            let v0 = u64::from(v.data[0]);
+            v0
+        }
         _ => {
             let mut bits = v.bits();
             let mut ret = 0u64;
@@ -1827,7 +1832,10 @@ fn high_bits_to_u64(v: &BigUint) -> u64 {
                 if bits_want != 64 {
                     ret <<= bits_want;
                 }
-                ret |= u64::from(*d) >> (digit_bits - bits_want);
+                // XXX Conversion is useless if already 64-bit.
+                #[allow(clippy::useless_conversion)]
+                let d0 = u64::from(*d) >> (digit_bits - bits_want);
+                ret |= d0;
                 ret_bits += bits_want;
                 bits -= bits_want;
 
@@ -1852,6 +1860,7 @@ impl ToPrimitive for BigUint {
         self.to_u128().as_ref().and_then(u128::to_i128)
     }
 
+    #[allow(clippy::useless_conversion)]
     #[inline]
     fn to_u64(&self) -> Option<u64> {
         let mut ret: u64 = 0;
@@ -1862,6 +1871,7 @@ impl ToPrimitive for BigUint {
                 return None;
             }
 
+            // XXX Conversion is useless if already 64-bit.
             ret += u64::from(*i) << bits;
             bits += big_digit::BITS;
         }

--- a/src/monty.rs
+++ b/src/monty.rs
@@ -41,6 +41,7 @@ impl MontyReducer {
 /// In the terminology of that paper, this is an "Almost Montgomery Multiplication":
 /// x and y are required to satisfy 0 <= z < 2**(n*_W) and then the result
 /// z is guaranteed to satisfy 0 <= z < 2**(n*_W), but it may not be < m.
+#[allow(clippy::many_single_char_names)]
 fn montgomery(x: &BigUint, y: &BigUint, m: &BigUint, k: BigDigit, n: usize) -> BigUint {
     // This code assumes x, y, m are all the same length, n.
     // (required by addMulVVW and the for loop).
@@ -131,6 +132,7 @@ fn mul_add_www(x: BigDigit, y: BigDigit, c: BigDigit) -> (BigDigit, BigDigit) {
 }
 
 /// Calculates x ** y mod m using a fixed, 4-bit window.
+#[allow(clippy::many_single_char_names)]
 pub(crate) fn monty_modpow(x: &BigUint, y: &BigUint, m: &BigUint) -> BigUint {
     assert!(m.data[0] & 1 == 1);
     let mr = MontyReducer::new(m);


### PR DESCRIPTION
* There were a bunch of code quality Clippy warnings that didn't apply for various reasons.

* There was an ok_or() that could have been an ok_or_else() that Clippy caught. Turns out it's for a ZST, so doesn't matter, but was "fixed" anyway to silence Clippy.

This will hopefully make "cargo clippy" more useful for the next person.