### PR TITLE
Create feature to override with u64, which would force u64 emulation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,6 +68,7 @@ default-features = false
 [features]
 default = ["std"]
 std = ["num-integer/std", "num-traits/std"]
+override-u64 = []
 
 [build-dependencies]
 autocfg = "1"

--- a/build.rs
+++ b/build.rs
@@ -7,7 +7,7 @@ use std::path::Path;
 fn main() {
     let pointer_width = env::var("CARGO_CFG_TARGET_POINTER_WIDTH");
     let u64_digit = pointer_width.as_ref().map(String::as_str) == Ok("64");
-    if u64_digit {
+    if u64_digit || cfg!(feature = "override-u64") {
         autocfg::emit("u64_digit");
     }
     let ac = autocfg::new();


### PR DESCRIPTION
LLVM should handle the u64 emulation on 32-bit platforms just fine, if this is the desire of the lib user.