### PR TITLE
Get/set n-th bit of `BigUint` and `BigInt`

### DIFF
--- a/ci/big_quickcheck/Cargo.toml
+++ b/ci/big_quickcheck/Cargo.toml
@@ -7,8 +7,11 @@ edition = "2018"
 [dependencies]
 num-integer = "0.1.42"
 num-traits = "0.2.11"
-quickcheck = "0.9"
 quickcheck_macros = "0.9"
+
+[dependencies.quickcheck]
+version = "0.9"
+default-features = false
 
 [dependencies.num-bigint]
 features = ["quickcheck"]

--- a/src/bigint.rs
+++ b/src/bigint.rs
@@ -3256,7 +3256,7 @@ impl BigInt {
     }
 
     /// Returns whether the bit in position `bit` is set,
-    /// uses the two's complement for negative numbers
+    /// using the two's complement for negative numbers
     pub fn bit(&self, bit: u64) -> bool {
         // Let the binary representation of a number be
         //   ... 0  x 1 0 ... 0
@@ -3273,7 +3273,7 @@ impl BigInt {
     }
 
     /// Sets or clears the bit in the given position,
-    /// uses the two's complement for negative numbers
+    /// using the two's complement for negative numbers
     pub fn set_bit(&mut self, bit: u64, value: bool) {
         match self.sign {
             Sign::Plus => self.data.set_bit(bit, value),
@@ -3297,7 +3297,7 @@ impl BigInt {
                     // This is the general case that basically corresponds to what `bitor_neg_pos`
                     // (when setting bit) or `bitand_neg_pos` (when clearing bit) does, except there
                     // is no need to explicitly iterate over the digits of the right-hand side
-                    let bit_index = (bit / bits_per_digit) as usize;
+                    let bit_index = (bit / bits_per_digit).to_usize().unwrap();
                     let bit_mask = (1 as BigDigit) << (bit % bits_per_digit);
                     let mut carry_in = 1;
                     let mut carry_out = 1;

--- a/src/bigint.rs
+++ b/src/bigint.rs
@@ -3306,75 +3306,66 @@ impl BigInt {
                     //            |-- bit at position 'trailing_zeros'
                     // where !x is obtained from x by flipping each bit
                     let trailing_zeros = self.data.trailing_zeros().unwrap();
-                    match Ord::cmp(&bit, &trailing_zeros) {
-                        Less => {
-                            if value {
-                                // We need to flip each bit from position 'bit' to 'trailing_zeros', both inclusive
-                                //       ... 1 !x 1 0 ... 0 ... 0
-                                //                        |-- bit at position 'bit'
-                                //                |-- bit at position 'trailing_zeros'
-                                // bit_mask:      1 1 ... 1 0 .. 0
-                                // We do this by xor'ing with the bit_mask
-                                let index_lo = (bit / bits_per_digit).to_usize().unwrap();
-                                let index_hi =
-                                    (trailing_zeros / bits_per_digit).to_usize().unwrap();
-                                let bit_mask_lo = BigDigit::MAX << (bit % bits_per_digit);
-                                let bit_mask_hi = BigDigit::MAX
-                                    >> (bits_per_digit - 1 - (trailing_zeros % bits_per_digit));
-                                let digits = self.digits_mut();
+                    if bit > trailing_zeros {
+                        self.data.set_bit(bit, !value);
+                    } else if bit == trailing_zeros && !value {
+                        // Clearing the bit at position `trailing_zeros` is dealt with by doing
+                        // similarly to what `bitand_neg_pos` does, except we start at digit
+                        // `bit_index`. All digits below `bit_index` are guaranteed to be zero,
+                        // so initially we have `carry_in` = `carry_out` = 1.
+                        let bit_index = (bit / bits_per_digit).to_usize().unwrap();
+                        let bit_mask = (1 as BigDigit) << (bit % bits_per_digit);
+                        let mut digit_iter = self.digits_mut().iter_mut().skip(bit_index);
+                        let mut carry_in = 1;
+                        let mut carry_out = 1;
 
-                                if index_lo == index_hi {
-                                    digits[index_lo] ^= bit_mask_lo & bit_mask_hi;
-                                } else {
-                                    digits[index_lo] ^= bit_mask_lo;
-                                    for index in (index_lo + 1)..index_hi {
-                                        digits[index] = BigDigit::MAX;
-                                    }
-                                    digits[index_hi] ^= bit_mask_hi;
-                                }
-                            } else {
-                                // Bit is already cleared
+                        let digit = digit_iter.next().unwrap();
+                        let twos_in = negate_carry(*digit, &mut carry_in);
+                        let twos_out = twos_in & !bit_mask;
+                        *digit = negate_carry(twos_out, &mut carry_out);
+
+                        for digit in digit_iter {
+                            if carry_in == 0 && carry_out == 0 {
+                                // Exit the loop since no more digits can change
+                                break;
                             }
+                            let twos = negate_carry(*digit, &mut carry_in);
+                            *digit = negate_carry(twos, &mut carry_out);
                         }
-                        Equal => {
-                            if value {
-                                // Bit is already set
-                            } else {
-                                // Clearing the bit at position `trailing_zeros` is the only non-trivial
-                                // case and is dealt with by doing similarly to what `bitand_neg_pos`
-                                // does, except we start at digit `bit_index`; all digits below `bit_index`
-                                // are guaranteed to be zero, so initially we must have
-                                // `carry_in` = `carry_out` = 1
-                                let bit_index = (bit / bits_per_digit).to_usize().unwrap();
-                                let bit_mask = (1 as BigDigit) << (bit % bits_per_digit);
-                                let mut digit_iter = self.digits_mut().iter_mut().skip(bit_index);
-                                let mut carry_in = 1;
-                                let mut carry_out = 1;
 
-                                let digit = digit_iter.next().unwrap();
-                                let twos_in = negate_carry(*digit, &mut carry_in);
-                                let twos_out = twos_in & !bit_mask;
-                                *digit = negate_carry(twos_out, &mut carry_out);
+                        if carry_out != 0 {
+                            // All digits have been traversed and there is a carry
+                            debug_assert_eq!(carry_in, 0);
+                            self.digits_mut().push(1);
+                        }
+                    } else if bit < trailing_zeros && value {
+                        // Flip each bit from position 'bit' to 'trailing_zeros', both inclusive
+                        //       ... 1 !x 1 0 ... 0 ... 0
+                        //                        |-- bit at position 'bit'
+                        //                |-- bit at position 'trailing_zeros'
+                        // bit_mask:      1 1 ... 1 0 .. 0
+                        // We do this by xor'ing with the bit_mask
+                        let index_lo = (bit / bits_per_digit).to_usize().unwrap();
+                        let index_hi =
+                            (trailing_zeros / bits_per_digit).to_usize().unwrap();
+                        let bit_mask_lo = big_digit::MAX << (bit % bits_per_digit);
+                        let bit_mask_hi = big_digit::MAX
+                            >> (bits_per_digit - 1 - (trailing_zeros % bits_per_digit));
+                        let digits = self.digits_mut();
 
-                                for digit in digit_iter {
-                                    if carry_in == 0 && carry_out == 0 {
-                                        // Exit the loop since no more digits can change
-                                        break;
-                                    }
-                                    let twos = negate_carry(*digit, &mut carry_in);
-                                    *digit = negate_carry(twos, &mut carry_out);
-                                }
-
-                                if carry_out != 0 {
-                                    // All digits have been traversed and there is a carry
-                                    debug_assert_eq!(carry_in, 0);
-                                    self.digits_mut().push(1);
-                                }
+                        if index_lo == index_hi {
+                            digits[index_lo] ^= bit_mask_lo & bit_mask_hi;
+                        } else {
+                            digits[index_lo] ^= bit_mask_lo;
+                            for index in (index_lo + 1)..index_hi {
+                                digits[index] = big_digit::MAX;
                             }
+                            digits[index_hi] ^= bit_mask_hi;
                         }
-                        Greater => {
-                            self.data.set_bit(bit, !value);
-                        }
+                    } else {
+                        // We end up here in two cases:
+                        // * bit == trailing_zeros && value: Bit is already set
+                        // * bit < trailing_zeros && !value: Bit is already cleared
                     }
                 }
             }

--- a/src/bigint.rs
+++ b/src/bigint.rs
@@ -3254,6 +3254,17 @@ impl BigInt {
     pub fn trailing_zeros(&self) -> Option<u64> {
         self.data.trailing_zeros()
     }
+
+    /// Returns whether the bit in position `bit` is set,
+    /// uses the two's complement for negative numbers
+    pub fn bit(&self, bit: u64) -> bool {
+        let b = self.data.bit(bit);
+        if self.is_negative() && bit > self.data.trailing_zeros().unwrap() {
+            !b
+        } else {
+            b
+        }
+    }
 }
 
 impl_sum_iter_type!(BigInt);

--- a/src/bigint.rs
+++ b/src/bigint.rs
@@ -3271,6 +3271,8 @@ impl BigInt {
         }
     }
 
+    /// Sets or clears the bit in the given position,
+    /// uses the two's complement for negative numbers
     pub fn set_bit(&mut self, bit: u64, value: bool) {
         match self.sign {
             Sign::Plus => self.data.set_bit(bit, value),

--- a/src/bigint.rs
+++ b/src/bigint.rs
@@ -3263,11 +3263,12 @@ impl BigInt {
         // Then the two's complement is
         //   ... 1 !x 1 0 ... 0
         // where !x is obtained from x by flipping each bit
-        let b = self.data.bit(bit);
-        if self.is_negative() && bit > self.data.trailing_zeros().unwrap() {
-            !b
+        if bit >= u64::from(big_digit::BITS) * self.len() as u64 {
+            self.is_negative()
+        } else if self.is_negative() && bit > self.data.trailing_zeros().unwrap() {
+            !self.data.bit(bit)
         } else {
-            b
+            self.data.bit(bit)
         }
     }
 

--- a/src/bigint.rs
+++ b/src/bigint.rs
@@ -3346,8 +3346,7 @@ impl BigInt {
                         // bit_mask:      1 1 ... 1 0 .. 0
                         // We do this by xor'ing with the bit_mask
                         let index_lo = (bit / bits_per_digit).to_usize().unwrap();
-                        let index_hi =
-                            (trailing_zeros / bits_per_digit).to_usize().unwrap();
+                        let index_hi = (trailing_zeros / bits_per_digit).to_usize().unwrap();
                         let bit_mask_lo = big_digit::MAX << (bit % bits_per_digit);
                         let bit_mask_hi = big_digit::MAX
                             >> (bits_per_digit - 1 - (trailing_zeros % bits_per_digit));

--- a/src/bigint.rs
+++ b/src/bigint.rs
@@ -3259,9 +3259,9 @@ impl BigInt {
     /// uses the two's complement for negative numbers
     pub fn bit(&self, bit: u64) -> bool {
         // Let the binary representation of a number be
-        //   x 1 0 ... 0
+        //   ... 0  x 1 0 ... 0
         // Then the two's complement is
-        //  !x 1 0 ... 0
+        //   ... 1 !x 1 0 ... 0
         // where !x is obtained from x by flipping each bit
         let b = self.data.bit(bit);
         if self.is_negative() && bit > self.data.trailing_zeros().unwrap() {
@@ -3275,6 +3275,7 @@ impl BigInt {
         match self.sign {
             Sign::Plus => self.data.set_bit(bit, value),
             Sign::NoSign => {
+                // clearing a bit for zero is a no-op
                 if value {
                     self.data.set_bit(bit, true);
                     self.sign = Sign::Plus;
@@ -3283,25 +3284,28 @@ impl BigInt {
             Sign::Minus => {
                 let bits_per_digit = u64::from(big_digit::BITS);
                 if bit < bits_per_digit * self.len() as u64 {
-                    let digit_index = (bit / bits_per_digit) as usize;
+                    // This implementation corresponds to what the function `bitand_neg_pos` does when
+                    // value=false and what `bitor_neg_pos` does when value=true, except there is no
+                    // need to explicitly iterate over the digits of the right-hand side
+                    let bit_index = (bit / bits_per_digit) as usize;
                     let bit_mask = (1 as BigDigit) << (bit % bits_per_digit);
                     let mut carry_in = 1;
                     let mut carry_out = 1;
-                    for (i, d) in self.digits_mut().iter_mut().enumerate() {
-                        let twos_in = negate_carry(*d, &mut carry_in);
-                        let twos_out = if i != digit_index {
-                            // leave as-is
+                    for (index, digit) in self.digits_mut().iter_mut().enumerate() {
+                        let twos_in = negate_carry(*digit, &mut carry_in);
+                        let twos_out = if index != bit_index {
                             twos_in
                         } else if value {
-                            // set bit
                             twos_in | bit_mask
                         } else {
-                            // clear bit
                             twos_in & !bit_mask
                         };
-                        *d = negate_carry(twos_out, &mut carry_out);
+                        *digit = negate_carry(twos_out, &mut carry_out);
                     }
                 } else {
+                    // The bit to set/clear is outside the represented digits, and thus more significant
+                    // than the most significant bit of the current number. This corresponds to setting
+                    // the bit to the negated value (no-op for value=true)
                     if !value {
                         self.data.set_bit(bit, true);
                     }

--- a/src/biguint.rs
+++ b/src/biguint.rs
@@ -2736,12 +2736,10 @@ impl BigUint {
                 self.data.resize(digit_index + 1, 0);
             }
             self.data[digit_index] |= bit_mask;
-        } else {
-            if digit_index < self.data.len() {
-                self.data[digit_index] &= !bit_mask;
-                // the top bit may have been cleared, so normalize
-                self.normalize();
-            }
+        } else if digit_index < self.data.len() {
+            self.data[digit_index] &= !bit_mask;
+            // the top bit may have been cleared, so normalize
+            self.normalize();
         }
     }
 }

--- a/src/biguint.rs
+++ b/src/biguint.rs
@@ -2729,9 +2729,13 @@ impl BigUint {
     /// Returns whether the bit in the given position is set
     pub fn bit(&self, bit: u64) -> bool {
         let bits_per_digit = u64::from(big_digit::BITS);
-        let digit_index = (bit / bits_per_digit).to_usize().unwrap();
-        digit_index < self.data.len()
-            && (self.data[digit_index] & ((1 as BigDigit) << (bit % bits_per_digit))) != 0
+        if let Some(digit_index) = (bit / bits_per_digit).to_usize() {
+            if let Some(digit) = self.data.get(digit_index) {
+                let bit_mask = (1 as BigDigit) << (bit % bits_per_digit);
+                return (digit & bit_mask) != 0;
+            }
+        }
+        false
     }
 
     /// Sets or clears the bit in the given position

--- a/src/biguint.rs
+++ b/src/biguint.rs
@@ -2729,19 +2729,23 @@ impl BigUint {
     /// Returns whether the bit in the given position is set
     pub fn bit(&self, bit: u64) -> bool {
         let bits_per_digit = u64::from(big_digit::BITS);
-        let digit_index = (bit / bits_per_digit) as usize;
+        let digit_index = (bit / bits_per_digit).to_usize().unwrap();
         digit_index < self.data.len()
             && (self.data[digit_index] & ((1 as BigDigit) << (bit % bits_per_digit))) != 0
     }
 
     /// Sets or clears the bit in the given position
+    ///
+    /// Note that setting a bit greater than the current bit length, a reallocation may be needed
+    /// to store the new digits
     pub fn set_bit(&mut self, bit: u64, value: bool) {
         let bits_per_digit = u64::from(big_digit::BITS);
-        let digit_index = (bit / bits_per_digit) as usize;
+        let digit_index = (bit / bits_per_digit).to_usize().unwrap();
         let bit_mask = (1 as BigDigit) << (bit % bits_per_digit);
         if value {
             if digit_index >= self.data.len() {
-                self.data.resize(digit_index + 1, 0);
+                let new_len = digit_index.checked_add(1).unwrap();
+                self.data.resize(new_len, 0);
             }
             self.data[digit_index] |= bit_mask;
         } else if digit_index < self.data.len() {

--- a/src/biguint.rs
+++ b/src/biguint.rs
@@ -2739,6 +2739,8 @@ impl BigUint {
         } else {
             if digit_index < self.data.len() {
                 self.data[digit_index] &= !bit_mask;
+                // the top bit may have been cleared, so normalize
+                self.normalize();
             }
         }
     }

--- a/src/biguint.rs
+++ b/src/biguint.rs
@@ -2717,6 +2717,31 @@ impl BigUint {
     pub fn count_ones(&self) -> u64 {
         self.data.iter().map(|&d| u64::from(d.count_ones())).sum()
     }
+
+    /// Returns whether the bit in the given position is set
+    pub fn bit(&self, bit: u64) -> bool {
+        let bits_per_digit = u64::from(big_digit::BITS);
+        let digit_index = (bit / bits_per_digit) as usize;
+        digit_index < self.data.len()
+            && (self.data[digit_index] & ((1 as BigDigit) << (bit % bits_per_digit))) != 0
+    }
+
+    /// Sets or clears the bit in the given position
+    pub fn set_bit(&mut self, bit: u64, value: bool) {
+        let bits_per_digit = u64::from(big_digit::BITS);
+        let digit_index = (bit / bits_per_digit) as usize;
+        let bit_mask = (1 as BigDigit) << (bit % bits_per_digit);
+        if value {
+            if digit_index >= self.data.len() {
+                self.data.resize(digit_index + 1, 0);
+            }
+            self.data[digit_index] |= bit_mask;
+        } else {
+            if digit_index < self.data.len() {
+                self.data[digit_index] &= !bit_mask;
+            }
+        }
+    }
 }
 
 fn plain_modpow(base: &BigUint, exp_data: &[BigDigit], modulus: &BigUint) -> BigUint {

--- a/tests/bigint.rs
+++ b/tests/bigint.rs
@@ -1342,15 +1342,27 @@ fn test_set_bit() {
     x.set_bit(200, true);
     assert_eq!(x, BigInt::from(-12i8));
     x.set_bit(200, false);
-    assert_eq!(x, BigInt::from_biguint(Minus, BigUint::from(12u8) | (BigUint::one() << 200)));
+    assert_eq!(
+        x,
+        BigInt::from_biguint(Minus, BigUint::from(12u8) | (BigUint::one() << 200))
+    );
     x.set_bit(6, false);
-    assert_eq!(x, BigInt::from_biguint(Minus, BigUint::from(76u8) | (BigUint::one() << 200)));
+    assert_eq!(
+        x,
+        BigInt::from_biguint(Minus, BigUint::from(76u8) | (BigUint::one() << 200))
+    );
     x.set_bit(6, true);
-    assert_eq!(x, BigInt::from_biguint(Minus, BigUint::from(12u8) | (BigUint::one() << 200)));
+    assert_eq!(
+        x,
+        BigInt::from_biguint(Minus, BigUint::from(12u8) | (BigUint::one() << 200))
+    );
     x.set_bit(200, true);
     assert_eq!(x, BigInt::from(-12i8));
 
     x = BigInt::from_biguint(Minus, BigUint::one() << 200);
     x.set_bit(40, true);
-    assert_eq!(x, BigInt::from_biguint(Minus, (BigUint::one() << 200) - (BigUint::one() << 40)));
+    assert_eq!(
+        x,
+        BigInt::from_biguint(Minus, (BigUint::one() << 200) - (BigUint::one() << 40))
+    );
 }

--- a/tests/bigint.rs
+++ b/tests/bigint.rs
@@ -1328,9 +1328,18 @@ fn test_bit() {
 
 #[test]
 fn test_set_bit() {
-    let mut x = BigInt::zero();
+    let mut x: BigInt;
+
+    // zero
+    x = BigInt::zero();
     x.set_bit(200, true);
     assert_eq!(x, BigInt::one() << 200);
+    x = BigInt::zero();
+    x.set_bit(200, false);
+    assert_eq!(x, BigInt::zero());
+
+    // positive numbers
+    x = BigInt::from_biguint(Plus, BigUint::one() << 200);
     x.set_bit(10, true);
     x.set_bit(200, false);
     assert_eq!(x, BigInt::one() << 10);
@@ -1338,6 +1347,7 @@ fn test_set_bit() {
     x.set_bit(5, false);
     assert_eq!(x, BigInt::zero());
 
+    // negative numbers
     x = BigInt::from(-12i8);
     x.set_bit(200, true);
     assert_eq!(x, BigInt::from(-12i8));
@@ -1359,6 +1369,13 @@ fn test_set_bit() {
     x.set_bit(200, true);
     assert_eq!(x, BigInt::from(-12i8));
 
+    x = BigInt::from_biguint(Minus, BigUint::one() << 30);
+    x.set_bit(10, true);
+    assert_eq!(
+        x,
+        BigInt::from_biguint(Minus, (BigUint::one() << 30) - (BigUint::one() << 10))
+    );
+
     x = BigInt::from_biguint(Minus, BigUint::one() << 200);
     x.set_bit(40, true);
     assert_eq!(
@@ -1376,4 +1393,8 @@ fn test_set_bit() {
     x = BigInt::from_biguint(Minus, (BigUint::one() << 63) | (BigUint::one() << 62));
     x.set_bit(62, false);
     assert_eq!(x, BigInt::from_biguint(Minus, BigUint::one() << 64));
+
+    x = BigInt::from_biguint(Minus, (BigUint::one() << 200) - BigUint::one());
+    x.set_bit(0, false);
+    assert_eq!(x, BigInt::from_biguint(Minus, BigUint::one() << 200));
 }

--- a/tests/bigint.rs
+++ b/tests/bigint.rs
@@ -1349,4 +1349,8 @@ fn test_set_bit() {
     assert_eq!(x, BigInt::from_biguint(Minus, BigUint::from(12u8) | (BigUint::one() << 200)));
     x.set_bit(200, true);
     assert_eq!(x, BigInt::from(-12i8));
+
+    x = BigInt::from_biguint(Minus, BigUint::one() << 200);
+    x.set_bit(40, true);
+    assert_eq!(x, BigInt::from_biguint(Minus, (BigUint::one() << 200) - (BigUint::one() << 40)));
 }

--- a/tests/bigint.rs
+++ b/tests/bigint.rs
@@ -1316,10 +1316,37 @@ fn test_bit() {
     assert!(BigInt::from(12u8).bit(2));
     assert!(BigInt::from(12u8).bit(3));
     assert!(!BigInt::from(12u8).bit(4));
+    assert!(!BigInt::from(12u8).bit(200));
     // -12 = (...110100)_2
     assert!(!BigInt::from(-12i8).bit(0));
     assert!(!BigInt::from(-12i8).bit(1));
     assert!(BigInt::from(-12i8).bit(2));
     assert!(!BigInt::from(-12i8).bit(3));
     assert!(BigInt::from(-12i8).bit(4));
+    assert!(BigInt::from(-12i8).bit(200));
+}
+
+#[test]
+fn test_set_bit() {
+    let mut x = BigInt::zero();
+    x.set_bit(200, true);
+    assert_eq!(x, BigInt::one() << 200);
+    x.set_bit(10, true);
+    x.set_bit(200, false);
+    assert_eq!(x, BigInt::one() << 10);
+    x.set_bit(10, false);
+    x.set_bit(5, false);
+    assert_eq!(x, BigInt::zero());
+
+    x = BigInt::from(-12i8);
+    x.set_bit(200, true);
+    assert_eq!(x, BigInt::from(-12i8));
+    x.set_bit(200, false);
+    assert_eq!(x, BigInt::from_biguint(Minus, BigUint::from(12u8) | (BigUint::one() << 200)));
+    x.set_bit(6, false);
+    assert_eq!(x, BigInt::from_biguint(Minus, BigUint::from(76u8) | (BigUint::one() << 200)));
+    x.set_bit(6, true);
+    assert_eq!(x, BigInt::from_biguint(Minus, BigUint::from(12u8) | (BigUint::one() << 200)));
+    x.set_bit(200, true);
+    assert_eq!(x, BigInt::from(-12i8));
 }

--- a/tests/bigint.rs
+++ b/tests/bigint.rs
@@ -1311,12 +1311,12 @@ fn test_pow() {
 #[test]
 fn test_bit() {
     // 12 = (1100)_2
-    assert!(!BigInt::from(12u8).bit(0));
-    assert!(!BigInt::from(12u8).bit(1));
-    assert!(BigInt::from(12u8).bit(2));
-    assert!(BigInt::from(12u8).bit(3));
-    assert!(!BigInt::from(12u8).bit(4));
-    assert!(!BigInt::from(12u8).bit(200));
+    assert!(!BigInt::from(0b1100u8).bit(0));
+    assert!(!BigInt::from(0b1100u8).bit(1));
+    assert!(BigInt::from(0b1100u8).bit(2));
+    assert!(BigInt::from(0b1100u8).bit(3));
+    assert!(!BigInt::from(0b1100u8).bit(4));
+    assert!(!BigInt::from(0b1100u8).bit(200));
     // -12 = (...110100)_2
     assert!(!BigInt::from(-12i8).bit(0));
     assert!(!BigInt::from(-12i8).bit(1));
@@ -1365,4 +1365,15 @@ fn test_set_bit() {
         x,
         BigInt::from_biguint(Minus, (BigUint::one() << 200) - (BigUint::one() << 40))
     );
+
+    x = BigInt::from_biguint(Minus, (BigUint::one() << 200) | (BigUint::one() << 100));
+    x.set_bit(100, false);
+    assert_eq!(
+        x,
+        BigInt::from_biguint(Minus, (BigUint::one() << 200) | (BigUint::one() << 101))
+    );
+
+    x = BigInt::from_biguint(Minus, (BigUint::one() << 63) | (BigUint::one() << 62));
+    x.set_bit(62, false);
+    assert_eq!(x, BigInt::from_biguint(Minus, BigUint::one() << 64));
 }

--- a/tests/bigint.rs
+++ b/tests/bigint.rs
@@ -1307,3 +1307,19 @@ fn test_pow() {
     check!(u64);
     check!(usize);
 }
+
+#[test]
+fn test_bit() {
+    // 12 = (1100)_2
+    assert!(!BigInt::from(12u8).bit(0));
+    assert!(!BigInt::from(12u8).bit(1));
+    assert!(BigInt::from(12u8).bit(2));
+    assert!(BigInt::from(12u8).bit(3));
+    assert!(!BigInt::from(12u8).bit(4));
+    // -12 = (...110100)_2
+    assert!(!BigInt::from(-12i8).bit(0));
+    assert!(!BigInt::from(-12i8).bit(1));
+    assert!(BigInt::from(-12i8).bit(2));
+    assert!(!BigInt::from(-12i8).bit(3));
+    assert!(BigInt::from(-12i8).bit(4));
+}

--- a/tests/bigint.rs
+++ b/tests/bigint.rs
@@ -1317,6 +1317,7 @@ fn test_bit() {
     assert!(BigInt::from(0b1100u8).bit(3));
     assert!(!BigInt::from(0b1100u8).bit(4));
     assert!(!BigInt::from(0b1100u8).bit(200));
+    assert!(!BigInt::from(0b1100u8).bit(u64::MAX));
     // -12 = (...110100)_2
     assert!(!BigInt::from(-12i8).bit(0));
     assert!(!BigInt::from(-12i8).bit(1));
@@ -1324,6 +1325,7 @@ fn test_bit() {
     assert!(!BigInt::from(-12i8).bit(3));
     assert!(BigInt::from(-12i8).bit(4));
     assert!(BigInt::from(-12i8).bit(200));
+    assert!(BigInt::from(-12i8).bit(u64::MAX));
 }
 
 #[test]

--- a/tests/biguint.rs
+++ b/tests/biguint.rs
@@ -1828,4 +1828,7 @@ fn test_set_bit() {
     x.set_bit(128, false);
     x.set_bit(130, false);
     assert_eq!(x, (BigUint::from(2u8) << 128) | BigUint::from(2u8));
+    x.set_bit(129, false);
+    x.set_bit(1, false);
+    assert_eq!(x, BigUint::zero());
 }

--- a/tests/biguint.rs
+++ b/tests/biguint.rs
@@ -1806,3 +1806,26 @@ fn test_count_ones() {
     let x: BigUint = (BigUint::from(3u8) << 128) | BigUint::from(3u8);
     assert_eq!(x.count_ones(), 4);
 }
+
+#[test]
+fn test_bit() {
+    assert!(!BigUint::from(0u8).bit(0));
+    assert!(!BigUint::from(0u8).bit(100));
+    assert!(!BigUint::from(42u8).bit(4));
+    assert!(BigUint::from(42u8).bit(5));
+    let x: BigUint = (BigUint::from(3u8) << 128) | BigUint::from(3u8);
+    assert!(x.bit(129));
+    assert!(!x.bit(130));
+}
+
+#[test]
+fn test_set_bit() {
+    let mut x = BigUint::from(3u8);
+    x.set_bit(128, true);
+    x.set_bit(129, true);
+    assert_eq!(x, (BigUint::from(3u8) << 128) | BigUint::from(3u8));
+    x.set_bit(0, false);
+    x.set_bit(128, false);
+    x.set_bit(130, false);
+    assert_eq!(x, (BigUint::from(2u8) << 128) | BigUint::from(2u8));
+}


### PR DESCRIPTION
This PR implements `bit` and `set_bit` for `BigUint` and `BigInt`.

The method names have been chosen to match those of Ramp (https://docs.rs/ramp/0.5.9/ramp/int/struct.Int.html#method.bit).

For `BigInt` the implementation uses the number's two's complement representation when the number is negative. This matches what libraries like Ramp or languages like Python do.

Resolves #172 