### PR TITLE
Change Debug to match Display

### DIFF
--- a/src/bigint.rs
+++ b/src/bigint.rs
@@ -59,7 +59,6 @@ impl Neg for Sign {
 }
 
 /// A big signed integer type.
-#[derive(Debug)]
 pub struct BigInt {
     sign: Sign,
     data: BigUint,
@@ -134,6 +133,12 @@ impl Default for BigInt {
     #[inline]
     fn default() -> BigInt {
         Zero::zero()
+    }
+}
+
+impl fmt::Debug for BigInt {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(self, f)
     }
 }
 

--- a/src/biguint.rs
+++ b/src/biguint.rs
@@ -35,7 +35,6 @@ pub(crate) use self::convert::to_str_radix_reversed;
 pub use self::iter::{U32Digits, U64Digits};
 
 /// A big unsigned integer type.
-#[derive(Debug)]
 pub struct BigUint {
     data: Vec<BigDigit>,
 }
@@ -103,6 +102,12 @@ impl Default for BigUint {
     #[inline]
     fn default() -> BigUint {
         Zero::zero()
+    }
+}
+
+impl fmt::Debug for BigUint {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(self, f)
     }
 }
 


### PR DESCRIPTION
The derived `Debug` showed the raw digit data, which is sometimes useful
if you're debugging `num-bigint` itself, but annoying in many other
contexts. For something like a simple `dbg!` call in a program, you
probably just want to see the numeric value.

This is not _necessarily_ a breaking change, but we'll treat it so.