### PR TITLE
Fix scalar divide-by-zero panics

### DIFF
--- a/src/biguint/division.rs
+++ b/src/biguint/division.rs
@@ -41,6 +41,10 @@ fn div_half(rem: BigDigit, digit: BigDigit, divisor: BigDigit) -> (BigDigit, Big
 
 #[inline]
 pub(super) fn div_rem_digit(mut a: BigUint, b: BigDigit) -> (BigUint, BigDigit) {
+    if b == 0 {
+        panic!("attempt to divide by zero")
+    }
+
     let mut rem = 0;
 
     if b <= big_digit::HALF {
@@ -62,6 +66,10 @@ pub(super) fn div_rem_digit(mut a: BigUint, b: BigDigit) -> (BigUint, BigDigit) 
 
 #[inline]
 fn rem_digit(a: &BigUint, b: BigDigit) -> BigDigit {
+    if b == 0 {
+        panic!("attempt to divide by zero")
+    }
+
     let mut rem = 0;
 
     if b <= big_digit::HALF {

--- a/tests/bigint_scalar.rs
+++ b/tests/bigint_scalar.rs
@@ -1,8 +1,9 @@
 use num_bigint::BigInt;
 use num_bigint::Sign::Plus;
-use num_traits::{Signed, ToPrimitive, Zero};
+use num_traits::{One, Signed, ToPrimitive, Zero};
 
 use std::ops::Neg;
+use std::panic::catch_unwind;
 
 mod consts;
 use crate::consts::*;
@@ -145,4 +146,12 @@ fn test_scalar_div_rem() {
             check(&a, b, &c, &d);
         }
     }
+}
+
+#[test]
+fn test_scalar_div_rem_zero() {
+    catch_unwind(|| BigInt::zero() / 0u32).unwrap_err();
+    catch_unwind(|| BigInt::zero() % 0u32).unwrap_err();
+    catch_unwind(|| BigInt::one() / 0u32).unwrap_err();
+    catch_unwind(|| BigInt::one() % 0u32).unwrap_err();
 }

--- a/tests/biguint_scalar.rs
+++ b/tests/biguint_scalar.rs
@@ -1,5 +1,7 @@
 use num_bigint::BigUint;
-use num_traits::{ToPrimitive, Zero};
+use num_traits::{One, ToPrimitive, Zero};
+
+use std::panic::catch_unwind;
 
 mod consts;
 use crate::consts::*;
@@ -110,4 +112,12 @@ fn test_scalar_div_rem() {
             assert_unsigned_scalar_assign_op!(a %= b == d);
         }
     }
+}
+
+#[test]
+fn test_scalar_div_rem_zero() {
+    catch_unwind(|| BigUint::zero() / 0u32).unwrap_err();
+    catch_unwind(|| BigUint::zero() % 0u32).unwrap_err();
+    catch_unwind(|| BigUint::one() / 0u32).unwrap_err();
+    catch_unwind(|| BigUint::one() % 0u32).unwrap_err();
 }


### PR DESCRIPTION
There was a gap where `BigUint::zero() / 0u32` wouldn't actually trigger
an expected panic, since there were no digits, so it just returned 0.