### PR TITLE
impl From<&Big[U]Int> for Big[U]Int

### DIFF
--- a/src/bigint.rs
+++ b/src/bigint.rs
@@ -82,6 +82,13 @@ impl Clone for BigInt {
     }
 }
 
+impl From<&BigInt> for BigInt {
+    #[inline]
+    fn from(value: &BigInt) -> Self {
+        value.clone()
+    }
+}
+
 impl hash::Hash for BigInt {
     #[inline]
     fn hash<H: hash::Hasher>(&self, state: &mut H) {

--- a/src/biguint.rs
+++ b/src/biguint.rs
@@ -55,6 +55,13 @@ impl Clone for BigUint {
     }
 }
 
+impl From<&BigUint> for BigUint {
+    #[inline]
+    fn from(value: &BigUint) -> Self {
+        value.clone()
+    }
+}
+
 impl hash::Hash for BigUint {
     #[inline]
     fn hash<H: hash::Hasher>(&self, state: &mut H) {


### PR DESCRIPTION
I know this impl is a little strange, but I have a use case and a rationale.

So, I have a function that takes any `T: Into<BigInt> + ToPrimitive`. It converts the operand to an i32 and checks whether it's in some low range, and if it is, it can do an optimized version with the i32. Otherwise, it converts the operand to a BigInt and uses that. Currently, we have 2 versions of the function, one taking that generic and the other taking a `&BigInt`, since it wouldn't have to clone the BigInt unless it's not in the low range. I could probably just make my own trait, but due to orphan rules I wouldn't be able to do the blanket impl, so it'd just be a bunch of manual impls. If this were implemented, I'd be able to have just the one function, and it would get the optimization for free.

Also, the standard library containers like `Vec` or `String` have a `From<&slicetype>` impl (where `slicetype` is `[T]` or `str`), but since BigInt doesn't deref to anything and you pass it by reference just as `&BigInt`, I think it makes sense in general to have a impl `From<BorrowedFoo<'a>> for Foo` like standard library types do.

Alternatively, I guess there could be a `IntoBigInt` trait in addition to the `ToBigInt` one.