### PR TITLE
Use SmallVec to optimize for small integer sizes.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,6 @@ edition = "2018"
 
 [features]
 default = ["std"]
-union = ["smallvec/union"]
 std = ["num-integer/std", "num-traits/std"]
 
 [package.metadata.docs.rs]
@@ -39,7 +38,7 @@ harness = false
 name = "shootout-pidigits"
 
 [dependencies]
-smallvec = { version = "1.6.1" }
+smallvec = { version = "1.6.1", optional = true, features = ["union"] }
 
 [dependencies.num-integer]
 version = "0.1.42"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ edition = "2018"
 
 [features]
 default = ["std"]
+union = ["smallvec/union"]
 std = ["num-integer/std", "num-traits/std"]
 
 [package.metadata.docs.rs]
@@ -38,6 +39,7 @@ harness = false
 name = "shootout-pidigits"
 
 [dependencies]
+smallvec = { version = "1.6.1" }
 
 [dependencies.num-integer]
 version = "0.1.42"

--- a/src/bigint.rs
+++ b/src/bigint.rs
@@ -14,6 +14,8 @@ use core::{i64, u64};
 use num_integer::{Integer, Roots};
 use num_traits::{Num, One, Pow, Signed, Zero};
 
+use smallvec::SmallVec;
+
 use self::Sign::{Minus, NoSign, Plus};
 
 use crate::big_digit::BigDigit;
@@ -538,7 +540,7 @@ impl IntDigits for BigInt {
         self.data.digits()
     }
     #[inline]
-    fn digits_mut(&mut self) -> &mut Vec<BigDigit> {
+    fn digits_mut(&mut self) -> &mut SmallVec<[BigDigit; BigUint::INLINED]> {
         self.data.digits_mut()
     }
     #[inline]

--- a/src/bigint.rs
+++ b/src/bigint.rs
@@ -14,13 +14,11 @@ use core::{i64, u64};
 use num_integer::{Integer, Roots};
 use num_traits::{Num, One, Pow, Signed, Zero};
 
-use smallvec::SmallVec;
-
 use self::Sign::{Minus, NoSign, Plus};
 
 use crate::big_digit::BigDigit;
 use crate::biguint::to_str_radix_reversed;
-use crate::biguint::{BigUint, IntDigits, U32Digits, U64Digits};
+use crate::biguint::{BigDigitVec, BigUint, IntDigits, U32Digits, U64Digits};
 
 mod addition;
 mod division;
@@ -540,7 +538,7 @@ impl IntDigits for BigInt {
         self.data.digits()
     }
     #[inline]
-    fn digits_mut(&mut self) -> &mut SmallVec<[BigDigit; BigUint::INLINED]> {
+    fn digits_mut(&mut self) -> &mut BigDigitVec {
         self.data.digits_mut()
     }
     #[inline]

--- a/src/bigint/bits.rs
+++ b/src/bigint/bits.rs
@@ -2,10 +2,7 @@ use super::BigInt;
 use super::Sign::{Minus, NoSign, Plus};
 
 use crate::big_digit::{self, BigDigit, DoubleBigDigit};
-use crate::biguint::IntDigits;
-use crate::BigUint;
-
-use smallvec::SmallVec;
+use crate::biguint::{BigDigitVec, IntDigits};
 
 use core::cmp::Ordering::{Equal, Greater, Less};
 use core::ops::{BitAnd, BitAndAssign, BitOr, BitOrAssign, BitXor, BitXorAssign};
@@ -38,7 +35,7 @@ fn negate_carry(a: BigDigit, acc: &mut DoubleBigDigit) -> BigDigit {
 // + 1 & -ff = ...0 01 & ...f 01 = ...0 01 = + 1
 // +ff & - 1 = ...0 ff & ...f ff = ...0 ff = +ff
 // answer is pos, has length of a
-fn bitand_pos_neg(a: &mut SmallVec<[BigDigit; BigUint::INLINED]>, b: &[BigDigit]) {
+fn bitand_pos_neg(a: &mut BigDigitVec, b: &[BigDigit]) {
     let mut carry_b = 1;
     for (ai, &bi) in a.iter_mut().zip(b.iter()) {
         let twos_b = negate_carry(bi, &mut carry_b);
@@ -50,7 +47,7 @@ fn bitand_pos_neg(a: &mut SmallVec<[BigDigit; BigUint::INLINED]>, b: &[BigDigit]
 // - 1 & +ff = ...f ff & ...0 ff = ...0 ff = +ff
 // -ff & + 1 = ...f 01 & ...0 01 = ...0 01 = + 1
 // answer is pos, has length of b
-fn bitand_neg_pos(a: &mut SmallVec<[BigDigit; BigUint::INLINED]>, b: &[BigDigit]) {
+fn bitand_neg_pos(a: &mut BigDigitVec, b: &[BigDigit]) {
     let mut carry_a = 1;
     for (ai, &bi) in a.iter_mut().zip(b.iter()) {
         let twos_a = negate_carry(*ai, &mut carry_a);
@@ -71,7 +68,7 @@ fn bitand_neg_pos(a: &mut SmallVec<[BigDigit; BigUint::INLINED]>, b: &[BigDigit]
 // -ff & - 1 = ...f 01 & ...f ff = ...f 01 = - ff
 // -ff & -fe = ...f 01 & ...f 02 = ...f 00 = -100
 // answer is neg, has length of longest with a possible carry
-fn bitand_neg_neg(a: &mut SmallVec<[BigDigit; BigUint::INLINED]>, b: &[BigDigit]) {
+fn bitand_neg_neg(a: &mut BigDigitVec, b: &[BigDigit]) {
     let mut carry_a = 1;
     let mut carry_b = 1;
     let mut carry_and = 1;
@@ -175,7 +172,7 @@ impl<'a> BitAndAssign<&'a BigInt> for BigInt {
 // + 1 | -ff = ...0 01 | ...f 01 = ...f 01 = -ff
 // +ff | - 1 = ...0 ff | ...f ff = ...f ff = - 1
 // answer is neg, has length of b
-fn bitor_pos_neg(a: &mut SmallVec<[BigDigit; BigUint::INLINED]>, b: &[BigDigit]) {
+fn bitor_pos_neg(a: &mut BigDigitVec, b: &[BigDigit]) {
     let mut carry_b = 1;
     let mut carry_or = 1;
     for (ai, &bi) in a.iter_mut().zip(b.iter()) {
@@ -204,7 +201,7 @@ fn bitor_pos_neg(a: &mut SmallVec<[BigDigit; BigUint::INLINED]>, b: &[BigDigit])
 // - 1 | +ff = ...f ff | ...0 ff = ...f ff = - 1
 // -ff | + 1 = ...f 01 | ...0 01 = ...f 01 = -ff
 // answer is neg, has length of a
-fn bitor_neg_pos(a: &mut SmallVec<[BigDigit; BigUint::INLINED]>, b: &[BigDigit]) {
+fn bitor_neg_pos(a: &mut BigDigitVec, b: &[BigDigit]) {
     let mut carry_a = 1;
     let mut carry_or = 1;
     for (ai, &bi) in a.iter_mut().zip(b.iter()) {
@@ -226,7 +223,7 @@ fn bitor_neg_pos(a: &mut SmallVec<[BigDigit; BigUint::INLINED]>, b: &[BigDigit])
 // - 1 | -ff = ...f ff | ...f 01 = ...f ff = -1
 // -ff | - 1 = ...f 01 | ...f ff = ...f ff = -1
 // answer is neg, has length of shortest
-fn bitor_neg_neg(a: &mut SmallVec<[BigDigit; BigUint::INLINED]>, b: &[BigDigit]) {
+fn bitor_neg_neg(a: &mut BigDigitVec, b: &[BigDigit]) {
     let mut carry_a = 1;
     let mut carry_b = 1;
     let mut carry_or = 1;
@@ -310,7 +307,7 @@ impl<'a> BitOrAssign<&'a BigInt> for BigInt {
 // + 1 ^ -ff = ...0 01 ^ ...f 01 = ...f 00 = -100
 // +ff ^ - 1 = ...0 ff ^ ...f ff = ...f 00 = -100
 // answer is neg, has length of longest with a possible carry
-fn bitxor_pos_neg(a: &mut SmallVec<[BigDigit; BigUint::INLINED]>, b: &[BigDigit]) {
+fn bitxor_pos_neg(a: &mut BigDigitVec, b: &[BigDigit]) {
     let mut carry_b = 1;
     let mut carry_xor = 1;
     for (ai, &bi) in a.iter_mut().zip(b.iter()) {
@@ -343,7 +340,7 @@ fn bitxor_pos_neg(a: &mut SmallVec<[BigDigit; BigUint::INLINED]>, b: &[BigDigit]
 // - 1 ^ +ff = ...f ff ^ ...0 ff = ...f 00 = -100
 // -ff ^ + 1 = ...f 01 ^ ...0 01 = ...f 00 = -100
 // answer is neg, has length of longest with a possible carry
-fn bitxor_neg_pos(a: &mut SmallVec<[BigDigit; BigUint::INLINED]>, b: &[BigDigit]) {
+fn bitxor_neg_pos(a: &mut BigDigitVec, b: &[BigDigit]) {
     let mut carry_a = 1;
     let mut carry_xor = 1;
     for (ai, &bi) in a.iter_mut().zip(b.iter()) {
@@ -376,7 +373,7 @@ fn bitxor_neg_pos(a: &mut SmallVec<[BigDigit; BigUint::INLINED]>, b: &[BigDigit]
 // - 1 ^ -ff = ...f ff ^ ...f 01 = ...0 fe = +fe
 // -ff & - 1 = ...f 01 ^ ...f ff = ...0 fe = +fe
 // answer is pos, has length of longest
-fn bitxor_neg_neg(a: &mut SmallVec<[BigDigit; BigUint::INLINED]>, b: &[BigDigit]) {
+fn bitxor_neg_neg(a: &mut BigDigitVec, b: &[BigDigit]) {
     let mut carry_a = 1;
     let mut carry_b = 1;
     for (ai, &bi) in a.iter_mut().zip(b.iter()) {

--- a/src/bigint/bits.rs
+++ b/src/bigint/bits.rs
@@ -3,7 +3,9 @@ use super::Sign::{Minus, NoSign, Plus};
 
 use crate::big_digit::{self, BigDigit, DoubleBigDigit};
 use crate::biguint::IntDigits;
-use crate::std_alloc::Vec;
+use crate::BigUint;
+
+use smallvec::SmallVec;
 
 use core::cmp::Ordering::{Equal, Greater, Less};
 use core::ops::{BitAnd, BitAndAssign, BitOr, BitOrAssign, BitXor, BitXorAssign};
@@ -36,7 +38,7 @@ fn negate_carry(a: BigDigit, acc: &mut DoubleBigDigit) -> BigDigit {
 // + 1 & -ff = ...0 01 & ...f 01 = ...0 01 = + 1
 // +ff & - 1 = ...0 ff & ...f ff = ...0 ff = +ff
 // answer is pos, has length of a
-fn bitand_pos_neg(a: &mut Vec<BigDigit>, b: &[BigDigit]) {
+fn bitand_pos_neg(a: &mut SmallVec<[BigDigit; BigUint::INLINED]>, b: &[BigDigit]) {
     let mut carry_b = 1;
     for (ai, &bi) in a.iter_mut().zip(b.iter()) {
         let twos_b = negate_carry(bi, &mut carry_b);
@@ -48,7 +50,7 @@ fn bitand_pos_neg(a: &mut Vec<BigDigit>, b: &[BigDigit]) {
 // - 1 & +ff = ...f ff & ...0 ff = ...0 ff = +ff
 // -ff & + 1 = ...f 01 & ...0 01 = ...0 01 = + 1
 // answer is pos, has length of b
-fn bitand_neg_pos(a: &mut Vec<BigDigit>, b: &[BigDigit]) {
+fn bitand_neg_pos(a: &mut SmallVec<[BigDigit; BigUint::INLINED]>, b: &[BigDigit]) {
     let mut carry_a = 1;
     for (ai, &bi) in a.iter_mut().zip(b.iter()) {
         let twos_a = negate_carry(*ai, &mut carry_a);
@@ -69,7 +71,7 @@ fn bitand_neg_pos(a: &mut Vec<BigDigit>, b: &[BigDigit]) {
 // -ff & - 1 = ...f 01 & ...f ff = ...f 01 = - ff
 // -ff & -fe = ...f 01 & ...f 02 = ...f 00 = -100
 // answer is neg, has length of longest with a possible carry
-fn bitand_neg_neg(a: &mut Vec<BigDigit>, b: &[BigDigit]) {
+fn bitand_neg_neg(a: &mut SmallVec<[BigDigit; BigUint::INLINED]>, b: &[BigDigit]) {
     let mut carry_a = 1;
     let mut carry_b = 1;
     let mut carry_and = 1;
@@ -173,7 +175,7 @@ impl<'a> BitAndAssign<&'a BigInt> for BigInt {
 // + 1 | -ff = ...0 01 | ...f 01 = ...f 01 = -ff
 // +ff | - 1 = ...0 ff | ...f ff = ...f ff = - 1
 // answer is neg, has length of b
-fn bitor_pos_neg(a: &mut Vec<BigDigit>, b: &[BigDigit]) {
+fn bitor_pos_neg(a: &mut SmallVec<[BigDigit; BigUint::INLINED]>, b: &[BigDigit]) {
     let mut carry_b = 1;
     let mut carry_or = 1;
     for (ai, &bi) in a.iter_mut().zip(b.iter()) {
@@ -202,7 +204,7 @@ fn bitor_pos_neg(a: &mut Vec<BigDigit>, b: &[BigDigit]) {
 // - 1 | +ff = ...f ff | ...0 ff = ...f ff = - 1
 // -ff | + 1 = ...f 01 | ...0 01 = ...f 01 = -ff
 // answer is neg, has length of a
-fn bitor_neg_pos(a: &mut Vec<BigDigit>, b: &[BigDigit]) {
+fn bitor_neg_pos(a: &mut SmallVec<[BigDigit; BigUint::INLINED]>, b: &[BigDigit]) {
     let mut carry_a = 1;
     let mut carry_or = 1;
     for (ai, &bi) in a.iter_mut().zip(b.iter()) {
@@ -224,7 +226,7 @@ fn bitor_neg_pos(a: &mut Vec<BigDigit>, b: &[BigDigit]) {
 // - 1 | -ff = ...f ff | ...f 01 = ...f ff = -1
 // -ff | - 1 = ...f 01 | ...f ff = ...f ff = -1
 // answer is neg, has length of shortest
-fn bitor_neg_neg(a: &mut Vec<BigDigit>, b: &[BigDigit]) {
+fn bitor_neg_neg(a: &mut SmallVec<[BigDigit; BigUint::INLINED]>, b: &[BigDigit]) {
     let mut carry_a = 1;
     let mut carry_b = 1;
     let mut carry_or = 1;
@@ -308,7 +310,7 @@ impl<'a> BitOrAssign<&'a BigInt> for BigInt {
 // + 1 ^ -ff = ...0 01 ^ ...f 01 = ...f 00 = -100
 // +ff ^ - 1 = ...0 ff ^ ...f ff = ...f 00 = -100
 // answer is neg, has length of longest with a possible carry
-fn bitxor_pos_neg(a: &mut Vec<BigDigit>, b: &[BigDigit]) {
+fn bitxor_pos_neg(a: &mut SmallVec<[BigDigit; BigUint::INLINED]>, b: &[BigDigit]) {
     let mut carry_b = 1;
     let mut carry_xor = 1;
     for (ai, &bi) in a.iter_mut().zip(b.iter()) {
@@ -341,7 +343,7 @@ fn bitxor_pos_neg(a: &mut Vec<BigDigit>, b: &[BigDigit]) {
 // - 1 ^ +ff = ...f ff ^ ...0 ff = ...f 00 = -100
 // -ff ^ + 1 = ...f 01 ^ ...0 01 = ...f 00 = -100
 // answer is neg, has length of longest with a possible carry
-fn bitxor_neg_pos(a: &mut Vec<BigDigit>, b: &[BigDigit]) {
+fn bitxor_neg_pos(a: &mut SmallVec<[BigDigit; BigUint::INLINED]>, b: &[BigDigit]) {
     let mut carry_a = 1;
     let mut carry_xor = 1;
     for (ai, &bi) in a.iter_mut().zip(b.iter()) {
@@ -374,7 +376,7 @@ fn bitxor_neg_pos(a: &mut Vec<BigDigit>, b: &[BigDigit]) {
 // - 1 ^ -ff = ...f ff ^ ...f 01 = ...0 fe = +fe
 // -ff & - 1 = ...f 01 ^ ...f ff = ...0 fe = +fe
 // answer is pos, has length of longest
-fn bitxor_neg_neg(a: &mut Vec<BigDigit>, b: &[BigDigit]) {
+fn bitxor_neg_neg(a: &mut SmallVec<[BigDigit; BigUint::INLINED]>, b: &[BigDigit]) {
     let mut carry_a = 1;
     let mut carry_b = 1;
     for (ai, &bi) in a.iter_mut().zip(b.iter()) {

--- a/src/bigint/multiplication.rs
+++ b/src/bigint/multiplication.rs
@@ -29,9 +29,15 @@ macro_rules! impl_mul {
             #[inline]
             fn mul(self, other: $Other) -> BigInt {
                 // automatically match value/ref
+                // from_biguint optimizes poorly if it cannot tell NoSign is impossible.
+                if self.is_zero() || other.is_zero() {
+                    return BigInt::zero();
+                }
+                let new_sign = if (self.sign() == Minus) ^ (other.sign() == Minus) { Minus } else { Plus };
                 let BigInt { data: x, .. } = self;
                 let BigInt { data: y, .. } = other;
-                BigInt::from_biguint(self.sign * other.sign, x * y)
+                BigInt::from_biguint(new_sign, x * y)
+                // BigInt::from_biguint(self.sign * other.sign, x * y)
             }
         }
     )*}

--- a/src/bigrand.rs
+++ b/src/bigrand.rs
@@ -8,7 +8,7 @@ use crate::BigInt;
 use crate::BigUint;
 use crate::Sign::*;
 
-use crate::biguint::biguint_from_smallvec;
+use crate::biguint::biguint_from_vec;
 
 use num_integer::Integer;
 use num_traits::{ToPrimitive, Zero};
@@ -61,20 +61,18 @@ impl<R: Rng + ?Sized> RandBigInt for R {
 
     #[cfg(u64_digit)]
     fn gen_biguint(&mut self, bit_size: u64) -> BigUint {
-        use smallvec::smallvec;
-
         let (digits, rem) = bit_size.div_rem(&64);
         let len = (digits + (rem > 0) as u64)
             .to_usize()
             .expect("capacity overflow");
-        let mut data = smallvec![0u64; len];
+        let mut data = vec![0u64; len];
         gen_bits(self, data.as_mut_slice(), rem);
         #[cfg(target_endian = "big")]
         for digit in &mut data {
             // swap u32 digits into u64 endianness
             *digit = (*digit << 32) | (*digit >> 32);
         }
-        biguint_from_smallvec(data)
+        biguint_from_vec(data)
     }
 
     fn gen_bigint(&mut self, bit_size: u64) -> BigInt {

--- a/src/bigrand.rs
+++ b/src/bigrand.rs
@@ -3,11 +3,12 @@
 use rand::distributions::uniform::{SampleBorrow, SampleUniform, UniformSampler};
 use rand::prelude::*;
 
+use crate::big_digit::BigDigit;
 use crate::BigInt;
 use crate::BigUint;
 use crate::Sign::*;
 
-use crate::biguint::biguint_from_vec;
+use crate::biguint::biguint_from_smallvec;
 
 use num_integer::Integer;
 use num_traits::{ToPrimitive, Zero};
@@ -37,12 +38,12 @@ pub trait RandBigInt {
     fn gen_bigint_range(&mut self, lbound: &BigInt, ubound: &BigInt) -> BigInt;
 }
 
-fn gen_bits<R: Rng + ?Sized>(rng: &mut R, data: &mut [u32], rem: u64) {
+fn gen_bits<R: Rng + ?Sized>(rng: &mut R, data: &mut [BigDigit], rem: u64) {
     // `fill` is faster than many `gen::<u32>` calls
     rng.fill(data);
     if rem > 0 {
         let last = data.len() - 1;
-        data[last] >>= 32 - rem;
+        data[last] >>= crate::big_digit::BITS as u64 - rem;
     }
 }
 
@@ -60,28 +61,20 @@ impl<R: Rng + ?Sized> RandBigInt for R {
 
     #[cfg(u64_digit)]
     fn gen_biguint(&mut self, bit_size: u64) -> BigUint {
-        use core::slice;
+        use smallvec::smallvec;
 
-        let (digits, rem) = bit_size.div_rem(&32);
+        let (digits, rem) = bit_size.div_rem(&64);
         let len = (digits + (rem > 0) as u64)
             .to_usize()
             .expect("capacity overflow");
-        let native_digits = bit_size.div_ceil(&64);
-        let native_len = native_digits.to_usize().expect("capacity overflow");
-        let mut data = vec![0u64; native_len];
-        unsafe {
-            // Generate bits in a `&mut [u32]` slice for value stability
-            let ptr = data.as_mut_ptr() as *mut u32;
-            debug_assert!(native_len * 2 >= len);
-            let data = slice::from_raw_parts_mut(ptr, len);
-            gen_bits(self, data, rem);
-        }
+        let mut data = smallvec![0u64; len];
+        gen_bits(self, data.as_mut_slice(), rem);
         #[cfg(target_endian = "big")]
         for digit in &mut data {
             // swap u32 digits into u64 endianness
             *digit = (*digit << 32) | (*digit >> 32);
         }
-        biguint_from_vec(data)
+        biguint_from_smallvec(data)
     }
 
     fn gen_bigint(&mut self, bit_size: u64) -> BigInt {

--- a/src/biguint.rs
+++ b/src/biguint.rs
@@ -38,8 +38,10 @@ pub use self::iter::{U32Digits, U64Digits};
 
 /// A big unsigned integer type.
 pub struct BigUint {
-    data: SmallVec<[BigDigit; BigUint::INLINED]>,
+    data: BigDigitVec,
 }
+
+pub(crate) type BigDigitVec = SmallVec<[BigDigit; BigUint::INLINED]>;
 
 // Note: derived `Clone` doesn't specialize `clone_from`,
 // but we want to keep the allocation in `data`.
@@ -550,7 +552,7 @@ pub(crate) fn biguint_from_vec(digits: Vec<BigDigit>) -> BigUint {
 ///
 /// The digits are in little-endian base matching `BigDigit`.
 #[inline]
-pub(crate) fn biguint_from_smallvec(digits: SmallVec<[BigDigit; BigUint::INLINED]>) -> BigUint {
+pub(crate) fn biguint_from_bigdigitvec(digits: BigDigitVec) -> BigUint {
     BigUint { data: digits }.normalized()
 }
 
@@ -1002,7 +1004,7 @@ impl BigUint {
 
 pub(crate) trait IntDigits {
     fn digits(&self) -> &[BigDigit];
-    fn digits_mut(&mut self) -> &mut SmallVec<[BigDigit; BigUint::INLINED]>;
+    fn digits_mut(&mut self) -> &mut BigDigitVec;
     fn normalize(&mut self);
     fn capacity(&self) -> usize;
     fn len(&self) -> usize;
@@ -1014,7 +1016,7 @@ impl IntDigits for BigUint {
         &self.data
     }
     #[inline]
-    fn digits_mut(&mut self) -> &mut SmallVec<[BigDigit; BigUint::INLINED]> {
+    fn digits_mut(&mut self) -> &mut BigDigitVec {
         &mut self.data
     }
     #[inline]

--- a/src/biguint/addition.rs
+++ b/src/biguint/addition.rs
@@ -5,6 +5,8 @@ use super::{BigUint, IntDigits};
 use crate::big_digit::{self, BigDigit};
 use crate::UsizePromotion;
 
+use crate::backend;
+
 use core::iter::Sum;
 use core::ops::{Add, AddAssign};
 use num_traits::{CheckedAdd, Zero};
@@ -91,7 +93,7 @@ impl<'a> Add<&'a BigUint> for BigUint {
 
     #[inline]
     fn add(mut self, other: &BigUint) -> BigUint {
-        if !other.data.spilled() {
+        if backend::inlined(&other.data) {
             use num_traits::ToPrimitive;
             if let Some(x) = other.to_u64() {
                 return self + x;
@@ -104,7 +106,7 @@ impl<'a> Add<&'a BigUint> for BigUint {
 impl<'a> AddAssign<&'a BigUint> for BigUint {
     #[inline]
     fn add_assign(&mut self, other: &BigUint) {
-        if !other.data.spilled() {
+        if backend::inlined(&other.data) {
             use num_traits::ToPrimitive;
             if let Some(x) = other.to_u64() {
                 self.add_assign(x);
@@ -163,7 +165,7 @@ impl Add<u64> for BigUint {
     #[inline]
     fn add(mut self, other: u64) -> BigUint {
         use num_traits::ToPrimitive;
-        if !self.data.spilled() {
+        if backend::inlined(&self.data) {
             if let Some(x) = self.to_u64() {
                 return BigUint::from(x as u128 + other as u128);
             }

--- a/src/biguint/arbitrary.rs
+++ b/src/biguint/arbitrary.rs
@@ -14,7 +14,7 @@ impl quickcheck::Arbitrary for BigUint {
 
     fn shrink(&self) -> Box<dyn Iterator<Item = Self>> {
         // Use shrinker from Vec
-        Box::new(self.data.shrink().map(biguint_from_vec))
+        Box::new(self.data.clone().into_vec().shrink().map(biguint_from_vec))
     }
 }
 

--- a/src/biguint/division.rs
+++ b/src/biguint/division.rs
@@ -6,6 +6,8 @@ use super::BigUint;
 use crate::big_digit::{self, BigDigit, DoubleBigDigit};
 use crate::UsizePromotion;
 
+use smallvec::smallvec;
+
 use core::cmp::Ordering::{Equal, Greater, Less};
 use core::mem;
 use core::ops::{Div, DivAssign, Rem, RemAssign};
@@ -43,6 +45,12 @@ fn div_half(rem: BigDigit, digit: BigDigit, divisor: BigDigit) -> (BigDigit, Big
 pub(super) fn div_rem_digit(mut a: BigUint, b: BigDigit) -> (BigUint, BigDigit) {
     if b == 0 {
         panic!("attempt to divide by zero")
+    }
+
+    if !a.data.spilled() {
+        if let Some(x) = a.to_u64() {
+            return (BigUint::from(x / b), x % b);
+        }
     }
 
     let mut rem = 0;
@@ -125,7 +133,7 @@ fn div_rem(mut u: BigUint, mut d: BigUint) -> (BigUint, BigUint) {
     }
 
     if d.data.len() == 1 {
-        if d.data == [1] {
+        if d.data[0] == 1 {
             return (u, Zero::zero());
         }
         let (div, rem) = div_rem_digit(u, d.data[0]);
@@ -172,7 +180,7 @@ pub(super) fn div_rem_ref(u: &BigUint, d: &BigUint) -> (BigUint, BigUint) {
     }
 
     if d.data.len() == 1 {
-        if d.data == [1] {
+        if d.data[0] == 1 {
             return (u.clone(), Zero::zero());
         }
 
@@ -240,7 +248,7 @@ fn div_rem_core(mut a: BigUint, b: &BigUint) -> (BigUint, BigUint) {
 
     let q_len = a.data.len() - b.data.len() + 1;
     let mut q = BigUint {
-        data: vec![0; q_len],
+        data: smallvec![0; q_len],
     };
 
     for j in (0..q_len).rev() {

--- a/src/biguint/division.rs
+++ b/src/biguint/division.rs
@@ -6,7 +6,7 @@ use super::BigUint;
 use crate::big_digit::{self, BigDigit, DoubleBigDigit};
 use crate::UsizePromotion;
 
-use smallvec::smallvec;
+use crate::backend;
 
 use core::cmp::Ordering::{Equal, Greater, Less};
 use core::mem;
@@ -47,7 +47,7 @@ pub(super) fn div_rem_digit(mut a: BigUint, b: BigDigit) -> (BigUint, BigDigit) 
         panic!("attempt to divide by zero")
     }
 
-    if !a.data.spilled() {
+    if backend::inlined(&a.data) {
         if let Some(x) = a.to_u64() {
             return (BigUint::from(x / b), x % b);
         }
@@ -248,7 +248,7 @@ fn div_rem_core(mut a: BigUint, b: &BigUint) -> (BigUint, BigUint) {
 
     let q_len = a.data.len() - b.data.len() + 1;
     let mut q = BigUint {
-        data: smallvec![0; q_len],
+        data: backend::vec![0; q_len],
     };
 
     for j in (0..q_len).rev() {

--- a/src/biguint/monty.rs
+++ b/src/biguint/monty.rs
@@ -6,7 +6,7 @@ use num_traits::{One, Zero};
 use crate::big_digit::{self, BigDigit, DoubleBigDigit, SignedDoubleBigDigit};
 use crate::biguint::BigUint;
 
-use smallvec::SmallVec;
+use crate::backend;
 
 struct MontyReducer {
     n0inv: BigDigit,
@@ -77,13 +77,13 @@ fn montgomery(x: &BigUint, y: &BigUint, m: &BigUint, k: BigDigit, n: usize) -> B
     }
 
     if c == 0 {
-        z.data = SmallVec::from_vec(z.data[n..].to_vec());
+        z.data = backend::from_slice(&z.data[n..]);
     } else {
         {
             let (mut first, second) = z.data.split_at_mut(n);
             sub_vv(&mut first, &second, &m.data);
         }
-        z.data = SmallVec::from_vec(z.data[..n].to_vec());
+        z.data = backend::from_slice(&z.data[..n]);
     }
 
     z

--- a/src/biguint/monty.rs
+++ b/src/biguint/monty.rs
@@ -6,6 +6,8 @@ use num_traits::{One, Zero};
 use crate::big_digit::{self, BigDigit, DoubleBigDigit, SignedDoubleBigDigit};
 use crate::biguint::BigUint;
 
+use smallvec::SmallVec;
+
 struct MontyReducer {
     n0inv: BigDigit,
 }
@@ -75,13 +77,13 @@ fn montgomery(x: &BigUint, y: &BigUint, m: &BigUint, k: BigDigit, n: usize) -> B
     }
 
     if c == 0 {
-        z.data = z.data[n..].to_vec();
+        z.data = SmallVec::from_vec(z.data[n..].to_vec());
     } else {
         {
             let (mut first, second) = z.data.split_at_mut(n);
             sub_vv(&mut first, &second, &m.data);
         }
-        z.data = z.data[..n].to_vec();
+        z.data = SmallVec::from_vec(z.data[..n].to_vec());
     }
 
     z

--- a/src/biguint/multiplication.rs
+++ b/src/biguint/multiplication.rs
@@ -8,7 +8,7 @@ use crate::big_digit::{self, BigDigit, DoubleBigDigit};
 use crate::Sign::{self, Minus, NoSign, Plus};
 use crate::{BigInt, UsizePromotion};
 
-use smallvec::smallvec;
+use crate::backend;
 
 use core::cmp::Ordering;
 use core::iter::Product;
@@ -172,7 +172,7 @@ fn mac3(mut acc: &mut [BigDigit], mut b: &[BigDigit], mut c: &[BigDigit]) {
         // appropriately here: x1.len() >= x0.len and y1.len() >= y0.len():
         let len = x1.len() + y1.len();
         let mut p = BigUint {
-            data: smallvec![0; len],
+            data: backend::vec![0; len],
         };
 
         // p2 = x1 * y1
@@ -350,7 +350,7 @@ fn mac3(mut acc: &mut [BigDigit], mut b: &[BigDigit], mut c: &[BigDigit]) {
 fn mul3(x: &[BigDigit], y: &[BigDigit]) -> BigUint {
     let len = x.len() + y.len();
     let mut prod = BigUint {
-        data: smallvec![0; len],
+        data: backend::vec![0; len],
     };
 
     mac3(&mut prod.data, x, y);

--- a/src/biguint/shift.rs
+++ b/src/biguint/shift.rs
@@ -3,7 +3,7 @@ use super::{biguint_from_bigdigitvec, BigUint};
 use crate::big_digit;
 use crate::std_alloc::Cow;
 
-use smallvec::SmallVec;
+use crate::backend;
 
 use core::mem;
 use core::ops::{Shl, ShlAssign, Shr, ShrAssign};
@@ -28,7 +28,7 @@ fn biguint_shl2(n: Cow<'_, BigUint>, digits: usize, shift: u8) -> BigUint {
         0 => n.into_owned().data,
         _ => {
             let len = digits.saturating_add(n.data.len() + 1);
-            let mut data = SmallVec::with_capacity(len);
+            let mut data = backend::Vec::with_capacity(len);
             data.resize(digits, 0);
             data.extend(n.data.iter().copied());
             data
@@ -72,7 +72,7 @@ fn biguint_shr2(n: Cow<'_, BigUint>, digits: usize, shift: u8) -> BigUint {
         return n;
     }
     let mut data = match n {
-        Cow::Borrowed(n) => SmallVec::from_slice(&n.data[digits..]),
+        Cow::Borrowed(n) => backend::from_slice(&n.data[digits..]),
         Cow::Owned(mut n) => {
             n.data.drain(..digits);
             n.data

--- a/src/biguint/shift.rs
+++ b/src/biguint/shift.rs
@@ -1,4 +1,4 @@
-use super::{biguint_from_smallvec, BigUint};
+use super::{biguint_from_bigdigitvec, BigUint};
 
 use crate::big_digit;
 use crate::std_alloc::Cow;
@@ -48,7 +48,7 @@ fn biguint_shl2(n: Cow<'_, BigUint>, digits: usize, shift: u8) -> BigUint {
         }
     }
 
-    biguint_from_smallvec(data)
+    biguint_from_bigdigitvec(data)
 }
 
 #[inline]
@@ -89,7 +89,7 @@ fn biguint_shr2(n: Cow<'_, BigUint>, digits: usize, shift: u8) -> BigUint {
         }
     }
 
-    biguint_from_smallvec(data)
+    biguint_from_bigdigitvec(data)
 }
 
 use crate::big_digit::BigDigit;

--- a/src/biguint/shift.rs
+++ b/src/biguint/shift.rs
@@ -92,6 +92,44 @@ fn biguint_shr2(n: Cow<'_, BigUint>, digits: usize, shift: u8) -> BigUint {
     biguint_from_smallvec(data)
 }
 
+use crate::big_digit::BigDigit;
+#[inline]
+pub(crate) fn biguint_shr_mut<T: PrimInt>(n: &mut BigUint, shift: T) {
+    if shift < T::zero() {
+        panic!("attempt to shift right with negative");
+    }
+    if n.is_zero() || shift.is_zero() {
+        return;
+    }
+    let bits = T::from(big_digit::BITS).unwrap();
+    let digits = (shift / bits).to_usize().unwrap_or(core::usize::MAX);
+    let shift = (shift % bits).to_u8().unwrap();
+    slice_shr2(&mut n.data, digits, shift);
+    n.data.truncate(n.data.len() - digits);
+    n.normalize();
+}
+
+fn slice_shr2(mut data: &mut [BigDigit], digits: usize, shift: u8) {
+    if digits >= data.len() {
+        return;
+    }
+    if digits > 0 {
+        let len = data.len();
+        data.copy_within(digits.., 0);
+        data = &mut data[0..len - digits];
+    }
+
+    if shift > 0 {
+        let mut borrow = 0;
+        let borrow_shift = big_digit::BITS as u8 - shift;
+        for elem in data.iter_mut().rev() {
+            let new_borrow = *elem << borrow_shift;
+            *elem = (*elem >> shift) | borrow;
+            borrow = new_borrow;
+        }
+    }
+}
+
 macro_rules! impl_shift {
     (@ref $Shx:ident :: $shx:ident, $ShxAssign:ident :: $shx_assign:ident, $rhs:ty) => {
         impl<'b> $Shx<&'b $rhs> for BigUint {
@@ -162,8 +200,7 @@ macro_rules! impl_shift {
         impl ShrAssign<$rhs> for BigUint {
             #[inline]
             fn shr_assign(&mut self, rhs: $rhs) {
-                let n = mem::replace(self, BigUint::zero());
-                *self = n >> rhs;
+                biguint_shr_mut(self, rhs)
             }
         }
         impl_shift! { @ref Shr::shr, ShrAssign::shr_assign, $rhs }

--- a/src/biguint/subtraction.rs
+++ b/src/biguint/subtraction.rs
@@ -5,6 +5,8 @@ use super::BigUint;
 use crate::big_digit::{self, BigDigit};
 use crate::UsizePromotion;
 
+use crate::backend;
+
 use core::cmp::Ordering::{Equal, Greater, Less};
 use core::ops::{Sub, SubAssign};
 use num_traits::{CheckedSub, Zero};
@@ -129,7 +131,7 @@ impl<'a> Sub<BigUint> for &'a BigUint {
 
     fn sub(self, mut other: BigUint) -> BigUint {
         use num_traits::ToPrimitive;
-        if !self.data.spilled() {
+        if backend::inlined(&self.data) {
             if let Some(x) = self.to_u64() {
                 if let Some(y) = other.to_u64() {
                     return BigUint::from(x - y);

--- a/src/biguint/subtraction.rs
+++ b/src/biguint/subtraction.rs
@@ -117,6 +117,7 @@ impl<'a> Sub<&'a BigUint> for BigUint {
     }
 }
 impl<'a> SubAssign<&'a BigUint> for BigUint {
+    #[inline]
     fn sub_assign(&mut self, other: &'a BigUint) {
         sub2(&mut self.data[..], &other.data[..]);
         self.normalize();
@@ -127,6 +128,14 @@ impl<'a> Sub<BigUint> for &'a BigUint {
     type Output = BigUint;
 
     fn sub(self, mut other: BigUint) -> BigUint {
+        use num_traits::ToPrimitive;
+        if !self.data.spilled() {
+            if let Some(x) = self.to_u64() {
+                if let Some(y) = other.to_u64() {
+                    return BigUint::from(x - y);
+                }
+            }
+        }
         let other_len = other.data.len();
         if other_len < self.data.len() {
             let lo_borrow = __sub2rev(&self.data[..other_len], &mut other.data);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -292,3 +292,7 @@ mod big_digit {
         DoubleBigDigit::from(lo) | (DoubleBigDigit::from(hi) << BITS)
     }
 }
+
+pub fn mul_test(a: &BigUint, b: &BigUint) -> BigUint {
+    a * b
+}


### PR DESCRIPTION
This is a proof of concept. I'd like to discuss possible designs and pathways to getting something like this merged.

# Motivation

Using `BigInt` with mostly small (<= word-sized) integers is prohibitively expensive. One numerically intense algorithm from rgeometry is 1000 times slower when using `BigRational` instead of a fixed-precision number.

# Performance

`num-bigint` performs quite well for large input and is competitive with the GMP. Detailed benchmarks can be found here: https://github.com/Lemmih/num-criterion

So why do small integers perform so poorly? Mostly because allocating new memory is significantly more expensive than doing a single addition or multiplication. There are also a few cases where we can use specialized algorithms. For example, there's a particularly fast `gcd` algorithm that only works on word-sized integers.

# SmallVec with two inlined BigDigits

`BigUint` is a `Vec<BigDigit>`. As such, it has a size of 3 words in addition to the actual digits. Switching to a `SmallVec<[BigDigit; 2]>` will not increase the size of a `BigUint` but allows for two BigDigits to be inlined and thus not require a heap allocation.

# Summary of benchmarks:

I've run benchmarks on an M1 Apple MacBook Air and a 3950X AMD desktop. The results I get from these platforms are quite different and I'd love it if other people could help out by running the benchmark on their machines. For instructions, see: https://github.com/Lemmih/num-criterion

 - **GCD**: Slightly faster across all bit sizes. This is mainly because I wrote a more efficient version of `shr_assign`. The previous version interacted poorly with `SmallVec`.
 - **Mul**: Significantly faster for bit sizes <=64. Slightly slower for 128-bit integers. No significant difference for larger integers.
 - **Div**: Significantly faster for bit sizes <=128. No significant difference for larger integers.
 - **Add**: Significantly faster for bit sizes <=128. No significant difference for larger integers.
 - **Clone**: Significantly faster for bit sizes <=128. No significant difference for larger integers.


# Other optimizations

## Specialize for integers that fit in 128 bits.

Ideally, addition, multiplication, and division for integers that fit in 128 bits would be as fast as cloning. Copying the bytes is significantly slower than doing the arithmetic.

 * Signed integer addition/subtraction is quite naive. It is comparing the absolute numbers before subtracting/adding. This has to be improved before specialization will have any noticeable effect. Surely we can get within 2x of GMP.

## Use better GCD implementation.

The GCD implementation in `num-integer` is fairly slow and can be significantly improved by changing a line or two. On my system, this leads to a 10x speed improvement for BigInts when the integer fits in 64 bits.

# Other oddities

* Rug and Ramp are really good at cloning data. How can they clone large integers at more than twice the speed of `num-bigint`? Aren't we all just calling 'memcpy'?
