### PR TITLE
Add bitwise operations with primitive ints

### DIFF
--- a/src/bigint/bits.rs
+++ b/src/bigint/bits.rs
@@ -1,13 +1,14 @@
 use super::BigInt;
-use super::Sign::{Minus, NoSign, Plus};
+use super::Sign::{self, Minus, NoSign, Plus};
 
+use crate::{IsizePromotion, UsizePromotion};
 use crate::big_digit::{self, BigDigit, DoubleBigDigit};
 use crate::biguint::IntDigits;
 use crate::std_alloc::Vec;
 
 use core::cmp::Ordering::{Equal, Greater, Less};
 use core::ops::{BitAnd, BitAndAssign, BitOr, BitOrAssign, BitXor, BitXorAssign};
-use num_traits::{ToPrimitive, Zero};
+use num_traits::{ToPrimitive, Zero, Signed};
 
 // Negation in two's complement.
 // acc must be initialized as 1 for least-significant digit.
@@ -526,6 +527,321 @@ pub(super) fn set_negative_bit(x: &mut BigInt, bit: u64, value: bool) {
             // We end up here in two cases:
             //   bit == trailing_zeros && value: Bit is already set
             //   bit < trailing_zeros && !value: Bit is already cleared
+        }
+    }
+}
+
+promote_all_scalars!(impl BitAnd for BigInt, bitand);
+promote_all_scalars_assign!(impl BitAndAssign for BigInt, bitand_assign);
+forward_all_scalar_binop_to_val_val_commutative!(impl BitAnd<u32> for BigInt, bitand);
+forward_all_scalar_binop_to_val_val_commutative!(impl BitAnd<u64> for BigInt, bitand);
+forward_all_scalar_binop_to_val_val_commutative!(impl BitAnd<u128> for BigInt, bitand);
+
+impl BitAnd<u32> for BigInt {
+    type Output = BigInt;
+
+    fn bitand(mut self, rhs: u32) -> Self::Output {
+        self &= rhs;
+        self
+    }
+}
+
+impl BitAndAssign<u32> for BigInt {
+    fn bitand_assign(&mut self, rhs: u32) {
+        match self.sign {
+            Minus => {
+                bitand_neg_pos(self.digits_mut(), &[rhs as BigDigit]);
+                self.normalize();
+            }
+            NoSign => self.set_zero(),
+            Plus => {
+                self.data &= rhs;
+                self.normalize();
+            }
+        }
+    }
+}
+
+impl BitAnd<u64> for BigInt {
+    type Output = BigInt;
+
+    fn bitand(mut self, rhs: u64) -> Self::Output {
+        self &= rhs;
+        self
+    }
+}
+
+#[cfg(u64_digit)]
+impl BitAndAssign<u64> for BigInt {
+    fn bitand_assign(&mut self, rhs: u64) {
+        match self.sign {
+            Minus => {
+                bitand_neg_pos(self.digits_mut(), &[rhs as BigDigit]);
+                self.normalize();
+            }
+            NoSign => self.set_zero(),
+            Plus => {
+                self.data &= rhs;
+                self.normalize();
+            }
+        }
+    }
+}
+
+#[cfg(not(u64_digit))]
+impl BitAndAssign<u64> for BigInt {
+    fn bitand_assign(&mut self, rhs: u64) {
+        match self.sign {
+            Minus => {
+                bitand_neg_pos(
+                    self.digits_mut(),
+                    &[rhs as BigDigit, (rhs >> big_digit::BITS) as BigDigit],
+                );
+                self.normalize();
+            }
+            NoSign => self.set_zero(),
+            Plus => {
+                self.data &= rhs;
+                self.normalize();
+            }
+        }
+    }
+}
+
+impl BitAnd<u128> for BigInt {
+    type Output = BigInt;
+
+    fn bitand(mut self, rhs: u128) -> Self::Output {
+        self &= rhs;
+        self
+    }
+}
+
+#[cfg(u64_digit)]
+impl BitAndAssign<u128> for BigInt {
+    fn bitand_assign(&mut self, rhs: u128) {
+        match self.sign {
+            Minus => {
+                bitand_neg_pos(
+                    self.digits_mut(),
+                    &[rhs as BigDigit, (rhs >> big_digit::BITS) as BigDigit],
+                );
+                self.normalize();
+            }
+            NoSign => self.set_zero(),
+            Plus => {
+                self.data &= rhs;
+                self.normalize();
+            }
+        }
+    }
+}
+
+#[cfg(not(u64_digit))]
+impl BitAndAssign<u128> for BigInt {
+    fn bitand_assign(&mut self, rhs: u128) {
+        match self.sign {
+            Minus => {
+                bitand_neg_pos(
+                    self.digits_mut(),
+                    &[
+                        rhs as BigDigit,
+                        (rhs >> big_digit::BITS) as BigDigit,
+                        (rhs >> (big_digit::BITS * 2)) as BigDigit,
+                        (rhs >> (big_digit::BITS * 3)) as BigDigit,
+                    ],
+                );
+                self.normalize();
+            }
+            NoSign => self.set_zero(),
+            Plus => {
+                self.data &= rhs;
+                self.normalize();
+            }
+        }
+    }
+}
+
+#[inline]
+fn get_sign<T: Signed>(x: &T) -> Sign {
+    if x.is_positive() {
+        Sign::Plus
+    } else if x.is_negative() {
+        Sign::Minus
+    } else {
+        Sign::NoSign
+    }
+}
+
+forward_all_scalar_binop_to_val_val_commutative!(impl BitAnd<i32> for BigInt, bitand);
+forward_all_scalar_binop_to_val_val_commutative!(impl BitAnd<i64> for BigInt, bitand);
+forward_all_scalar_binop_to_val_val_commutative!(impl BitAnd<i128> for BigInt, bitand);
+
+impl BitAnd<i32> for BigInt {
+    type Output = BigInt;
+
+    fn bitand(mut self, rhs: i32) -> Self::Output {
+        self &= rhs;
+        self
+    }
+}
+
+impl BitAndAssign<i32> for BigInt {
+    fn bitand_assign(&mut self, rhs: i32) {
+        match (self.sign, get_sign(&rhs)) {
+            (NoSign, _) => self.set_zero(),
+            (_, NoSign) => self.set_zero(),
+            (Minus, Minus) => {
+                let u_rhs = rhs.wrapping_abs() as u32;
+                bitand_neg_neg(self.digits_mut(), &[u_rhs as BigDigit]);
+                self.normalize();
+            },
+            (Minus, Plus) => {
+                bitand_neg_pos(self.digits_mut(), &[rhs as BigDigit]);
+                self.normalize();
+            }
+            (Plus, _) => {
+                self.data &= rhs;
+                self.normalize();
+            }
+        }
+    }
+}
+
+impl BitAnd<i64> for BigInt {
+    type Output = BigInt;
+
+    fn bitand(mut self, rhs: i64) -> Self::Output {
+        self &= rhs;
+        self
+    }
+}
+
+#[cfg(u64_digit)]
+impl BitAndAssign<i64> for BigInt {
+    fn bitand_assign(&mut self, rhs: i64) {
+        match (self.sign, get_sign(&rhs)) {
+            (NoSign, _) => self.set_zero(),
+            (_, NoSign) => self.set_zero(),
+            (Minus, Minus) => {
+                let u_rhs = rhs.wrapping_abs() as u64;
+                bitand_neg_neg(self.digits_mut(), &[u_rhs as BigDigit]);
+                self.normalize();
+            },
+            (Minus, Plus) => {
+                bitand_neg_pos(self.digits_mut(), &[rhs as BigDigit]);
+                self.normalize();
+            }
+            (Plus, _) => {
+                self.data &= rhs;
+                self.normalize();
+            }
+        }
+    }
+}
+
+#[cfg(not(u64_digit))]
+impl BitAndAssign<i64> for BigInt {
+    fn bitand_assign(&mut self, rhs: i64) {
+        match (self.sign, get_sign(&rhs)) {
+            (NoSign, _) => self.set_zero(),
+            (_, NoSign) => self.set_zero(),
+            (Minus, Minus) => {
+                let u_rhs = rhs.wrapping_abs() as u64;
+                bitand_neg_neg(
+                    self.digits_mut(),
+                    &[u_rhs as BigDigit, (u_rhs >> big_digit::BITS) as BigDigit],
+                );
+                self.normalize();
+            },
+            (Minus, Plus) => {
+                bitand_neg_pos(
+                    self.digits_mut(),
+                    &[rhs as BigDigit, (rhs >> big_digit::BITS) as BigDigit],
+                );
+                self.normalize();
+            }
+            (Plus, _) => {
+                self.data &= rhs;
+                self.normalize();
+            }
+        }
+    }
+}
+
+impl BitAnd<i128> for BigInt {
+    type Output = BigInt;
+
+    fn bitand(mut self, rhs: i128) -> Self::Output {
+        self &= rhs;
+        self
+    }
+}
+
+#[cfg(u64_digit)]
+impl BitAndAssign<i128> for BigInt {
+    fn bitand_assign(&mut self, rhs: i128) {
+        match (self.sign, get_sign(&rhs)) {
+            (NoSign, _) => self.set_zero(),
+            (_, NoSign) => self.set_zero(),
+            (Minus, Minus) => {
+                let u_rhs = rhs.wrapping_abs() as u128;
+                bitand_neg_neg(
+                    self.digits_mut(),
+                    &[u_rhs as BigDigit, (u_rhs >> big_digit::BITS) as BigDigit],
+                );
+                self.normalize();
+            },
+            (Minus, Plus) => {
+                bitand_neg_pos(
+                    self.digits_mut(),
+                    &[rhs as BigDigit, (rhs >> big_digit::BITS) as BigDigit],
+                );
+                self.normalize();
+            }
+            (Plus, _) => {
+                self.data &= rhs;
+                self.normalize();
+            }
+        }
+    }
+}
+
+#[cfg(not(u64_digit))]
+impl BitAndAssign<i128> for BigInt {
+    fn bitand_assign(&mut self, rhs: i128) {
+        match (self.sign, get_sign(&rhs)) {
+            (NoSign, _) => self.set_zero(),
+            (_, NoSign) => self.set_zero(),
+            (Minus, Minus) => {
+                let u_rhs = rhs.wrapping_abs() as u128;
+                bitand_neg_neg(
+                    self.digits_mut(),
+                    &[
+                        rhs as BigDigit,
+                        (rhs >> big_digit::BITS) as BigDigit,
+                        (rhs >> (big_digit::BITS * 2)) as BigDigit,
+                        (rhs >> (big_digit::BITS * 3)) as BigDigit,
+                    ],
+                );
+                self.normalize();
+            },
+            (Minus, Plus) => {
+                bitand_neg_pos(
+                    self.digits_mut(),
+                    &[
+                        rhs as BigDigit,
+                        (rhs >> big_digit::BITS) as BigDigit,
+                        (rhs >> (big_digit::BITS * 2)) as BigDigit,
+                        (rhs >> (big_digit::BITS * 3)) as BigDigit,
+                    ],
+                );
+                self.normalize();
+            }
+            (Plus, _) => {
+                self.data &= rhs;
+                self.normalize();
+            }
         }
     }
 }

--- a/src/bigint/bits.rs
+++ b/src/bigint/bits.rs
@@ -577,6 +577,7 @@ impl BitAndAssign<u64> for BigInt {
         match self.sign {
             Minus => {
                 bitand_neg_pos(self.digits_mut(), &[rhs as BigDigit]);
+                self.sign = Plus;
                 self.normalize();
             }
             NoSign => self.set_zero(),
@@ -597,6 +598,7 @@ impl BitAndAssign<u64> for BigInt {
                     self.digits_mut(),
                     &[rhs as BigDigit, (rhs >> big_digit::BITS) as BigDigit],
                 );
+                self.sign = Plus;
                 self.normalize();
             }
             NoSign => self.set_zero(),
@@ -626,6 +628,7 @@ impl BitAndAssign<u128> for BigInt {
                     self.digits_mut(),
                     &[rhs as BigDigit, (rhs >> big_digit::BITS) as BigDigit],
                 );
+                self.sign = Plus;
                 self.normalize();
             }
             NoSign => self.set_zero(),
@@ -651,6 +654,7 @@ impl BitAndAssign<u128> for BigInt {
                         (rhs >> (big_digit::BITS * 3)) as BigDigit,
                     ],
                 );
+                self.sign = Plus;
                 self.normalize();
             }
             NoSign => self.set_zero(),
@@ -698,6 +702,7 @@ impl BitAndAssign<i32> for BigInt {
             },
             (Minus, Plus) => {
                 bitand_neg_pos(self.digits_mut(), &[rhs as BigDigit]);
+                self.sign = Plus;
                 self.normalize();
             }
             (Plus, _) => {
@@ -730,6 +735,7 @@ impl BitAndAssign<i64> for BigInt {
             },
             (Minus, Plus) => {
                 bitand_neg_pos(self.digits_mut(), &[rhs as BigDigit]);
+                self.sign = Plus;
                 self.normalize();
             }
             (Plus, _) => {
@@ -759,6 +765,7 @@ impl BitAndAssign<i64> for BigInt {
                     self.digits_mut(),
                     &[rhs as BigDigit, (rhs >> big_digit::BITS) as BigDigit],
                 );
+                self.sign = Plus;
                 self.normalize();
             }
             (Plus, _) => {
@@ -797,6 +804,7 @@ impl BitAndAssign<i128> for BigInt {
                     self.digits_mut(),
                     &[rhs as BigDigit, (rhs >> big_digit::BITS) as BigDigit],
                 );
+                self.sign = Plus;
                 self.normalize();
             }
             (Plus, _) => {
@@ -836,6 +844,7 @@ impl BitAndAssign<i128> for BigInt {
                         (rhs >> (big_digit::BITS * 3)) as BigDigit,
                     ],
                 );
+                self.sign = Plus;
                 self.normalize();
             }
             (Plus, _) => {
@@ -1011,6 +1020,7 @@ impl BitOrAssign<i32> for BigInt {
             (Plus, Minus) => {
                 let u_rhs = rhs.wrapping_abs() as u32;
                 bitor_pos_neg(self.digits_mut(), &[u_rhs as BigDigit]);
+                self.sign = Minus;
                 self.normalize();
             }
         }
@@ -1048,6 +1058,7 @@ impl BitOrAssign<i64> for BigInt {
             (Plus, Minus) => {
                 let u_rhs = rhs.wrapping_abs() as u64;
                 bitor_pos_neg(self.digits_mut(), &[u_rhs as BigDigit]);
+                self.sign = Minus;
                 self.normalize();
             }
         }
@@ -1085,6 +1096,7 @@ impl BitOrAssign<i64> for BigInt {
                     self.digits_mut(),
                     &[u_rhs as BigDigit, (u_rhs >> big_digit::BITS) as BigDigit],
                 );
+                self.sign = Minus;
                 self.normalize();
             }
         }
@@ -1131,6 +1143,7 @@ impl BitOrAssign<i128> for BigInt {
                     self.digits_mut(),
                     &[u_rhs as BigDigit, (u_rhs >> big_digit::BITS) as BigDigit],
                 );
+                self.sign = Minus;
                 self.normalize();
             }
         }
@@ -1183,6 +1196,7 @@ impl BitOrAssign<i128> for BigInt {
                         (rhs >> (big_digit::BITS * 3)) as BigDigit,
                     ],
                 );
+                self.sign = Minus;
                 self.normalize();
             }
         }
@@ -1341,6 +1355,7 @@ impl BitXorAssign<i32> for BigInt {
             (Minus, Minus) => {
                 let u_rhs = rhs.wrapping_abs() as u32;
                 bitxor_neg_neg(self.digits_mut(), &[u_rhs as BigDigit]);
+                self.sign = Plus;
                 self.normalize();
             },
             (Minus, Plus) => {
@@ -1354,6 +1369,7 @@ impl BitXorAssign<i32> for BigInt {
             (Plus, Minus) => {
                 let u_rhs = rhs.wrapping_abs() as u32;
                 bitxor_pos_neg(self.digits_mut(), &[u_rhs as BigDigit]);
+                self.sign = Minus;
                 self.normalize();
             }
         }
@@ -1378,6 +1394,7 @@ impl BitXorAssign<i64> for BigInt {
             (Minus, Minus) => {
                 let u_rhs = rhs.wrapping_abs() as u64;
                 bitxor_neg_neg(self.digits_mut(), &[u_rhs as BigDigit]);
+                self.sign = Plus;
                 self.normalize();
             },
             (Minus, Plus) => {
@@ -1391,6 +1408,7 @@ impl BitXorAssign<i64> for BigInt {
             (Plus, Minus) => {
                 let u_rhs = rhs.wrapping_abs() as u64;
                 bitxor_pos_neg(self.digits_mut(), &[u_rhs as BigDigit]);
+                self.sign = Minus;
                 self.normalize();
             }
         }
@@ -1409,6 +1427,7 @@ impl BitXorAssign<i64> for BigInt {
                     self.digits_mut(),
                     &[u_rhs as BigDigit, (u_rhs >> big_digit::BITS) as BigDigit],
                 );
+                self.sign = Plus;
                 self.normalize();
             },
             (Minus, Plus) => {
@@ -1428,6 +1447,7 @@ impl BitXorAssign<i64> for BigInt {
                     self.digits_mut(),
                     &[u_rhs as BigDigit, (u_rhs >> big_digit::BITS) as BigDigit],
                 );
+                self.sign = Minus;
                 self.normalize();
             }
         }
@@ -1455,6 +1475,7 @@ impl BitXorAssign<i128> for BigInt {
                     self.digits_mut(),
                     &[u_rhs as BigDigit, (u_rhs >> big_digit::BITS) as BigDigit],
                 );
+                self.sign = Plus;
                 self.normalize();
             },
             (Minus, Plus) => {
@@ -1474,6 +1495,7 @@ impl BitXorAssign<i128> for BigInt {
                     self.digits_mut(),
                     &[u_rhs as BigDigit, (u_rhs >> big_digit::BITS) as BigDigit],
                 );
+                self.sign = Minus;
                 self.normalize();
             }
         }
@@ -1497,6 +1519,7 @@ impl BitXorAssign<i128> for BigInt {
                         (rhs >> (big_digit::BITS * 3)) as BigDigit,
                     ],
                 );
+                self.sign = Plus;
                 self.normalize();
             },
             (Minus, Plus) => {
@@ -1526,6 +1549,7 @@ impl BitXorAssign<i128> for BigInt {
                         (rhs >> (big_digit::BITS * 3)) as BigDigit,
                     ],
                 );
+                self.sign = Minus;
                 self.normalize();
             }
         }

--- a/src/bigint/bits.rs
+++ b/src/bigint/bits.rs
@@ -845,3 +845,346 @@ impl BitAndAssign<i128> for BigInt {
         }
     }
 }
+
+promote_unsigned_scalars!(impl BitOr for BigInt, bitor);
+promote_unsigned_scalars_assign!(impl BitOrAssign for BigInt, bitor_assign);
+forward_all_scalar_binop_to_val_val_commutative!(impl BitOr<u32> for BigInt, bitor);
+forward_all_scalar_binop_to_val_val_commutative!(impl BitOr<u64> for BigInt, bitor);
+forward_all_scalar_binop_to_val_val_commutative!(impl BitOr<u128> for BigInt, bitor);
+
+impl BitOr<u32> for BigInt {
+    type Output = BigInt;
+
+    fn bitor(mut self, rhs: u32) -> Self::Output {
+        self |= rhs;
+        self
+    }
+}
+
+impl BitOrAssign<u32> for BigInt {
+    fn bitor_assign(&mut self, rhs: u32) {
+        match self.sign {
+            Minus => {
+                bitor_neg_pos(self.digits_mut(), &[rhs as BigDigit]);
+                self.normalize();
+            }
+            NoSign => *self = rhs.into(),
+            Plus => {
+                self.data |= rhs;
+                self.normalize();
+            }
+        }
+    }
+}
+
+impl BitOr<u64> for BigInt {
+    type Output = BigInt;
+
+    fn bitor(mut self, rhs: u64) -> Self::Output {
+        self |= rhs;
+        self
+    }
+}
+
+#[cfg(u64_digit)]
+impl BitOrAssign<u64> for BigInt {
+    fn bitor_assign(&mut self, rhs: u64) {
+        match self.sign {
+            Minus => {
+                bitor_neg_pos(self.digits_mut(), &[rhs as BigDigit]);
+                self.normalize();
+            }
+            NoSign => *self = rhs.into(),
+            Plus => {
+                self.data |= rhs;
+                self.normalize();
+            }
+        }
+    }
+}
+
+#[cfg(not(u64_digit))]
+impl BitOrAssign<u64> for BigInt {
+    fn bitor_assign(&mut self, rhs: u64) {
+        match self.sign {
+            Minus => {
+                bitor_neg_pos(
+                    self.digits_mut(),
+                    &[rhs as BigDigit, (rhs >> big_digit::BITS) as BigDigit],
+                );
+                self.normalize();
+            }
+            NoSign => *self = rhs.into(),
+            Plus => {
+                self.data |= rhs;
+                self.normalize();
+            }
+        }
+    }
+}
+
+impl BitOr<u128> for BigInt {
+    type Output = BigInt;
+
+    fn bitor(mut self, rhs: u128) -> Self::Output {
+        self |= rhs;
+        self
+    }
+}
+
+#[cfg(u64_digit)]
+impl BitOrAssign<u128> for BigInt {
+    fn bitor_assign(&mut self, rhs: u128) {
+        match self.sign {
+            Minus => {
+                bitor_neg_pos(
+                    self.digits_mut(),
+                    &[rhs as BigDigit, (rhs >> big_digit::BITS) as BigDigit],
+                );
+                self.normalize();
+            }
+            NoSign => *self = rhs.into(),
+            Plus => {
+                self.data |= rhs;
+                self.normalize();
+            }
+        }
+    }
+}
+
+#[cfg(not(u64_digit))]
+impl BitOrAssign<u128> for BigInt {
+    fn bitor_assign(&mut self, rhs: u128) {
+        match self.sign {
+            Minus => {
+                bitor_neg_pos(
+                    self.digits_mut(),
+                    &[
+                        rhs as BigDigit,
+                        (rhs >> big_digit::BITS) as BigDigit,
+                        (rhs >> (big_digit::BITS * 2)) as BigDigit,
+                        (rhs >> (big_digit::BITS * 3)) as BigDigit,
+                    ],
+                );
+                self.normalize();
+            }
+            NoSign => *self = rhs.into(),
+            Plus => {
+                self.data |= rhs;
+                self.normalize();
+            }
+        }
+    }
+}
+
+forward_all_scalar_binop_to_val_val_commutative!(impl BitOr<i32> for BigInt, bitor);
+forward_all_scalar_binop_to_val_val_commutative!(impl BitOr<i64> for BigInt, bitor);
+forward_all_scalar_binop_to_val_val_commutative!(impl BitOr<i128> for BigInt, bitor);
+
+impl BitOr<i32> for BigInt {
+    type Output = BigInt;
+
+    fn bitor(mut self, rhs: i32) -> Self::Output {
+        self &= rhs;
+        self
+    }
+}
+
+impl BitOrAssign<i32> for BigInt {
+    fn bitor_assign(&mut self, rhs: i32) {
+        match (self.sign, get_sign(&rhs)) {
+            (NoSign, _) => *self = rhs.into(),
+            (_, NoSign) => {}
+            (Minus, Minus) => {
+                let u_rhs = rhs.wrapping_abs() as u32;
+                bitor_neg_neg(self.digits_mut(), &[u_rhs as BigDigit]);
+                self.normalize();
+            },
+            (Minus, Plus) => {
+                bitor_neg_pos(self.digits_mut(), &[rhs as BigDigit]);
+                self.normalize();
+            }
+            (Plus, Plus) => {
+                self.data |= rhs as u32;
+                self.normalize();
+            }
+            (Plus, Minus) => {
+                let u_rhs = rhs.wrapping_abs() as u32;
+                bitor_pos_neg(self.digits_mut(), &[u_rhs as BigDigit]);
+                self.normalize();
+            }
+        }
+    }
+}
+
+impl BitOr<i64> for BigInt {
+    type Output = BigInt;
+
+    fn bitor(mut self, rhs: i64) -> Self::Output {
+        self |= rhs;
+        self
+    }
+}
+
+#[cfg(u64_digit)]
+impl BitOrAssign<i64> for BigInt {
+    fn bitor_assign(&mut self, rhs: i64) {
+        match (self.sign, get_sign(&rhs)) {
+            (NoSign, _) => *self = rhs.into(),
+            (_, NoSign) => {}
+            (Minus, Minus) => {
+                let u_rhs = rhs.wrapping_abs() as u64;
+                bitor_neg_neg(self.digits_mut(), &[u_rhs as BigDigit]);
+                self.normalize();
+            },
+            (Minus, Plus) => {
+                bitor_neg_pos(self.digits_mut(), &[rhs as BigDigit]);
+                self.normalize();
+            }
+            (Plus, Plus) => {
+                self.data |= rhs as u64;
+                self.normalize();
+            }
+            (Plus, Minus) => {
+                let u_rhs = rhs.wrapping_abs() as u64;
+                bitor_pos_neg(self.digits_mut(), &[u_rhs as BigDigit]);
+                self.normalize();
+            }
+        }
+    }
+}
+
+#[cfg(not(u64_digit))]
+impl BitOrAssign<i64> for BigInt {
+    fn bitor_assign(&mut self, rhs: i64) {
+        match (self.sign, get_sign(&rhs)) {
+            (NoSign, _) => *self = rhs.into(),
+            (_, NoSign) => {}
+            (Minus, Minus) => {
+                let u_rhs = rhs.wrapping_abs() as u64;
+                bitor_neg_neg(
+                    self.digits_mut(),
+                    &[u_rhs as BigDigit, (u_rhs >> big_digit::BITS) as BigDigit],
+                );
+                self.normalize();
+            },
+            (Minus, Plus) => {
+                bitor_neg_pos(
+                    self.digits_mut(),
+                    &[rhs as BigDigit, (rhs >> big_digit::BITS) as BigDigit],
+                );
+                self.normalize();
+            }
+            (Plus, Plus) => {
+                self.data |= rhs as u64;
+                self.normalize();
+            }
+            (Plus, Minus) => {
+                let u_rhs = rhs.wrapping_abs() as u64;
+                bitor_pos_neg(
+                    self.digits_mut(),
+                    &[u_rhs as BigDigit, (u_rhs >> big_digit::BITS) as BigDigit],
+                );
+                self.normalize();
+            }
+        }
+    }
+}
+
+impl BitOr<i128> for BigInt {
+    type Output = BigInt;
+
+    fn bitor(mut self, rhs: i128) -> Self::Output {
+        self |= rhs;
+        self
+    }
+}
+
+#[cfg(u64_digit)]
+impl BitOrAssign<i128> for BigInt {
+    fn bitor_assign(&mut self, rhs: i128) {
+        match (self.sign, get_sign(&rhs)) {
+            (NoSign, _) => *self = rhs.into(),
+            (_, NoSign) => {}
+            (Minus, Minus) => {
+                let u_rhs = rhs.wrapping_abs() as u128;
+                bitor_neg_neg(
+                    self.digits_mut(),
+                    &[u_rhs as BigDigit, (u_rhs >> big_digit::BITS) as BigDigit],
+                );
+                self.normalize();
+            },
+            (Minus, Plus) => {
+                bitor_neg_pos(
+                    self.digits_mut(),
+                    &[rhs as BigDigit, (rhs >> big_digit::BITS) as BigDigit],
+                );
+                self.normalize();
+            }
+            (Plus, Plus) => {
+                self.data |= rhs as u128;
+                self.normalize();
+            }
+            (Plus, Minus) => {
+                let u_rhs = rhs.wrapping_abs() as u128;
+                bitor_pos_neg(
+                    self.digits_mut(),
+                    &[u_rhs as BigDigit, (u_rhs >> big_digit::BITS) as BigDigit],
+                );
+                self.normalize();
+            }
+        }
+    }
+}
+
+#[cfg(not(u64_digit))]
+impl BitOrAssign<i128> for BigInt {
+    fn bitor_assign(&mut self, rhs: i128) {
+        match (self.sign, get_sign(&rhs)) {
+            (NoSign, _) => *self = rhs.into(),
+            (_, NoSign) => {}
+            (Minus, Minus) => {
+                let u_rhs = rhs.wrapping_abs() as u128;
+                bitor_neg_neg(
+                    self.digits_mut(),
+                    &[
+                        rhs as BigDigit,
+                        (rhs >> big_digit::BITS) as BigDigit,
+                        (rhs >> (big_digit::BITS * 2)) as BigDigit,
+                        (rhs >> (big_digit::BITS * 3)) as BigDigit,
+                    ],
+                );
+                self.normalize();
+            },
+            (Minus, Plus) => {
+                bitor_neg_pos(
+                    self.digits_mut(),
+                    &[
+                        rhs as BigDigit,
+                        (rhs >> big_digit::BITS) as BigDigit,
+                        (rhs >> (big_digit::BITS * 2)) as BigDigit,
+                        (rhs >> (big_digit::BITS * 3)) as BigDigit,
+                    ],
+                );
+                self.normalize();
+            }
+            (Plus, Plus) => {
+                self.data |= rhs as u128;
+                self.normalize();
+            }
+            (Plus, Minus) => {
+                let u_rhs = rhs.wrapping_abs() as u128;
+                bitor_pos_neg(
+                    self.digits_mut(),
+                    &[
+                        rhs as BigDigit,
+                        (rhs >> big_digit::BITS) as BigDigit,
+                        (rhs >> (big_digit::BITS * 2)) as BigDigit,
+                        (rhs >> (big_digit::BITS * 3)) as BigDigit,
+                    ],
+                );
+                self.normalize();
+            }
+        }
+    }
+}

--- a/src/bigint/bits.rs
+++ b/src/bigint/bits.rs
@@ -1188,3 +1188,346 @@ impl BitOrAssign<i128> for BigInt {
         }
     }
 }
+
+promote_unsigned_scalars!(impl BitXor for BigInt, bitxor);
+promote_unsigned_scalars_assign!(impl BitXorAssign for BigInt, bitxor_assign);
+forward_all_scalar_binop_to_val_val_commutative!(impl BitXor<u32> for BigInt, bitxor);
+forward_all_scalar_binop_to_val_val_commutative!(impl BitXor<u64> for BigInt, bitxor);
+forward_all_scalar_binop_to_val_val_commutative!(impl BitXor<u128> for BigInt, bitxor);
+
+impl BitXor<u32> for BigInt {
+    type Output = BigInt;
+
+    fn bitxor(mut self, rhs: u32) -> Self::Output {
+        self ^= rhs;
+        self
+    }
+}
+
+impl BitXorAssign<u32> for BigInt {
+    fn bitxor_assign(&mut self, rhs: u32) {
+        match self.sign {
+            Minus => {
+                bitxor_neg_pos(self.digits_mut(), &[rhs as BigDigit]);
+                self.normalize();
+            }
+            NoSign => *self = rhs.into(),
+            Plus => {
+                self.data ^= rhs;
+                self.normalize();
+            }
+        }
+    }
+}
+
+impl BitXor<u64> for BigInt {
+    type Output = BigInt;
+
+    fn bitxor(mut self, rhs: u64) -> Self::Output {
+        self ^= rhs;
+        self
+    }
+}
+
+#[cfg(u64_digit)]
+impl BitXorAssign<u64> for BigInt {
+    fn bitxor_assign(&mut self, rhs: u64) {
+        match self.sign {
+            Minus => {
+                bitxor_neg_pos(self.digits_mut(), &[rhs as BigDigit]);
+                self.normalize();
+            }
+            NoSign => *self = rhs.into(),
+            Plus => {
+                self.data ^= rhs;
+                self.normalize();
+            }
+        }
+    }
+}
+
+#[cfg(not(u64_digit))]
+impl BitXorAssign<u64> for BigInt {
+    fn bitxor_assign(&mut self, rhs: u64) {
+        match self.sign {
+            Minus => {
+                bitxor_neg_pos(
+                    self.digits_mut(),
+                    &[rhs as BigDigit, (rhs >> big_digit::BITS) as BigDigit],
+                );
+                self.normalize();
+            }
+            NoSign => *self = rhs.into(),
+            Plus => {
+                self.data ^= rhs;
+                self.normalize();
+            }
+        }
+    }
+}
+
+impl BitXor<u128> for BigInt {
+    type Output = BigInt;
+
+    fn bitxor(mut self, rhs: u128) -> Self::Output {
+        self ^= rhs;
+        self
+    }
+}
+
+#[cfg(u64_digit)]
+impl BitXorAssign<u128> for BigInt {
+    fn bitxor_assign(&mut self, rhs: u128) {
+        match self.sign {
+            Minus => {
+                bitxor_neg_pos(
+                    self.digits_mut(),
+                    &[rhs as BigDigit, (rhs >> big_digit::BITS) as BigDigit],
+                );
+                self.normalize();
+            }
+            NoSign => *self = rhs.into(),
+            Plus => {
+                self.data ^= rhs;
+                self.normalize();
+            }
+        }
+    }
+}
+
+#[cfg(not(u64_digit))]
+impl BitXorAssign<u128> for BigInt {
+    fn bitxor_assign(&mut self, rhs: u128) {
+        match self.sign {
+            Minus => {
+                bitxor_neg_pos(
+                    self.digits_mut(),
+                    &[
+                        rhs as BigDigit,
+                        (rhs >> big_digit::BITS) as BigDigit,
+                        (rhs >> (big_digit::BITS * 2)) as BigDigit,
+                        (rhs >> (big_digit::BITS * 3)) as BigDigit,
+                    ],
+                );
+                self.normalize();
+            }
+            NoSign => *self = rhs.into(),
+            Plus => {
+                self.data ^= rhs;
+                self.normalize();
+            }
+        }
+    }
+}
+
+forward_all_scalar_binop_to_val_val_commutative!(impl BitXor<i32> for BigInt, bitxor);
+forward_all_scalar_binop_to_val_val_commutative!(impl BitXor<i64> for BigInt, bitxor);
+forward_all_scalar_binop_to_val_val_commutative!(impl BitXor<i128> for BigInt, bitxor);
+
+impl BitXor<i32> for BigInt {
+    type Output = BigInt;
+
+    fn bitxor(mut self, rhs: i32) -> Self::Output {
+        self ^= rhs;
+        self
+    }
+}
+
+impl BitXorAssign<i32> for BigInt {
+    fn bitxor_assign(&mut self, rhs: i32) {
+        match (self.sign, get_sign(&rhs)) {
+            (NoSign, _) => *self = rhs.into(),
+            (_, NoSign) => {}
+            (Minus, Minus) => {
+                let u_rhs = rhs.wrapping_abs() as u32;
+                bitxor_neg_neg(self.digits_mut(), &[u_rhs as BigDigit]);
+                self.normalize();
+            },
+            (Minus, Plus) => {
+                bitxor_neg_pos(self.digits_mut(), &[rhs as BigDigit]);
+                self.normalize();
+            }
+            (Plus, Plus) => {
+                self.data ^= rhs as u32;
+                self.normalize();
+            }
+            (Plus, Minus) => {
+                let u_rhs = rhs.wrapping_abs() as u32;
+                bitxor_pos_neg(self.digits_mut(), &[u_rhs as BigDigit]);
+                self.normalize();
+            }
+        }
+    }
+}
+
+impl BitXor<i64> for BigInt {
+    type Output = BigInt;
+
+    fn bitxor(mut self, rhs: i64) -> Self::Output {
+        self ^= rhs;
+        self
+    }
+}
+
+#[cfg(u64_digit)]
+impl BitXorAssign<i64> for BigInt {
+    fn bitxor_assign(&mut self, rhs: i64) {
+        match (self.sign, get_sign(&rhs)) {
+            (NoSign, _) => *self = rhs.into(),
+            (_, NoSign) => {}
+            (Minus, Minus) => {
+                let u_rhs = rhs.wrapping_abs() as u64;
+                bitxor_neg_neg(self.digits_mut(), &[u_rhs as BigDigit]);
+                self.normalize();
+            },
+            (Minus, Plus) => {
+                bitxor_neg_pos(self.digits_mut(), &[rhs as BigDigit]);
+                self.normalize();
+            }
+            (Plus, Plus) => {
+                self.data ^= rhs as u64;
+                self.normalize();
+            }
+            (Plus, Minus) => {
+                let u_rhs = rhs.wrapping_abs() as u64;
+                bitxor_pos_neg(self.digits_mut(), &[u_rhs as BigDigit]);
+                self.normalize();
+            }
+        }
+    }
+}
+
+#[cfg(not(u64_digit))]
+impl BitXorAssign<i64> for BigInt {
+    fn bitxor_assign(&mut self, rhs: i64) {
+        match (self.sign, get_sign(&rhs)) {
+            (NoSign, _) => *self = rhs.into(),
+            (_, NoSign) => {}
+            (Minus, Minus) => {
+                let u_rhs = rhs.wrapping_abs() as u64;
+                bitxor_neg_neg(
+                    self.digits_mut(),
+                    &[u_rhs as BigDigit, (u_rhs >> big_digit::BITS) as BigDigit],
+                );
+                self.normalize();
+            },
+            (Minus, Plus) => {
+                bitxor_neg_pos(
+                    self.digits_mut(),
+                    &[rhs as BigDigit, (rhs >> big_digit::BITS) as BigDigit],
+                );
+                self.normalize();
+            }
+            (Plus, Plus) => {
+                self.data ^= rhs as u64;
+                self.normalize();
+            }
+            (Plus, Minus) => {
+                let u_rhs = rhs.wrapping_abs() as u64;
+                bitxor_pos_neg(
+                    self.digits_mut(),
+                    &[u_rhs as BigDigit, (u_rhs >> big_digit::BITS) as BigDigit],
+                );
+                self.normalize();
+            }
+        }
+    }
+}
+
+impl BitXor<i128> for BigInt {
+    type Output = BigInt;
+
+    fn bitxor(mut self, rhs: i128) -> Self::Output {
+        self ^= rhs;
+        self
+    }
+}
+
+#[cfg(u64_digit)]
+impl BitXorAssign<i128> for BigInt {
+    fn bitxor_assign(&mut self, rhs: i128) {
+        match (self.sign, get_sign(&rhs)) {
+            (NoSign, _) => *self = rhs.into(),
+            (_, NoSign) => {}
+            (Minus, Minus) => {
+                let u_rhs = rhs.wrapping_abs() as u128;
+                bitxor_neg_neg(
+                    self.digits_mut(),
+                    &[u_rhs as BigDigit, (u_rhs >> big_digit::BITS) as BigDigit],
+                );
+                self.normalize();
+            },
+            (Minus, Plus) => {
+                bitxor_neg_pos(
+                    self.digits_mut(),
+                    &[rhs as BigDigit, (rhs >> big_digit::BITS) as BigDigit],
+                );
+                self.normalize();
+            }
+            (Plus, Plus) => {
+                self.data ^= rhs as u128;
+                self.normalize();
+            }
+            (Plus, Minus) => {
+                let u_rhs = rhs.wrapping_abs() as u128;
+                bitxor_pos_neg(
+                    self.digits_mut(),
+                    &[u_rhs as BigDigit, (u_rhs >> big_digit::BITS) as BigDigit],
+                );
+                self.normalize();
+            }
+        }
+    }
+}
+
+#[cfg(not(u64_digit))]
+impl BitXorAssign<i128> for BigInt {
+    fn bitxor_assign(&mut self, rhs: i128) {
+        match (self.sign, get_sign(&rhs)) {
+            (NoSign, _) => *self = rhs.into(),
+            (_, NoSign) => {}
+            (Minus, Minus) => {
+                let u_rhs = rhs.wrapping_abs() as u128;
+                bitxor_neg_neg(
+                    self.digits_mut(),
+                    &[
+                        rhs as BigDigit,
+                        (rhs >> big_digit::BITS) as BigDigit,
+                        (rhs >> (big_digit::BITS * 2)) as BigDigit,
+                        (rhs >> (big_digit::BITS * 3)) as BigDigit,
+                    ],
+                );
+                self.normalize();
+            },
+            (Minus, Plus) => {
+                bitxor_neg_pos(
+                    self.digits_mut(),
+                    &[
+                        rhs as BigDigit,
+                        (rhs >> big_digit::BITS) as BigDigit,
+                        (rhs >> (big_digit::BITS * 2)) as BigDigit,
+                        (rhs >> (big_digit::BITS * 3)) as BigDigit,
+                    ],
+                );
+                self.normalize();
+            }
+            (Plus, Plus) => {
+                self.data ^= rhs as u128;
+                self.normalize();
+            }
+            (Plus, Minus) => {
+                let u_rhs = rhs.wrapping_abs() as u128;
+                bitxor_pos_neg(
+                    self.digits_mut(),
+                    &[
+                        rhs as BigDigit,
+                        (rhs >> big_digit::BITS) as BigDigit,
+                        (rhs >> (big_digit::BITS * 2)) as BigDigit,
+                        (rhs >> (big_digit::BITS * 3)) as BigDigit,
+                    ],
+                );
+                self.normalize();
+            }
+        }
+    }
+}

--- a/src/biguint/bits.rs
+++ b/src/biguint/bits.rs
@@ -1,7 +1,7 @@
 use super::{BigUint, IntDigits};
 
 use crate::big_digit::{self, BigDigit};
-use crate::{IsizePromotion, UsizePromotion};
+use crate::UsizePromotion;
 
 #[cfg(not(u64_digit))]
 use crate::std_alloc::Vec;
@@ -99,8 +99,8 @@ impl<'a> BitXorAssign<&'a BigUint> for BigUint {
     }
 }
 
-promote_all_scalars!(impl BitAnd for BigUint, bitand);
-promote_all_scalars_assign!(impl BitAndAssign for BigUint, bitand_assign);
+promote_unsigned_scalars!(impl BitAnd for BigUint, bitand);
+promote_unsigned_scalars_assign!(impl BitAndAssign for BigUint, bitand_assign);
 forward_all_scalar_binop_to_val_val_commutative!(impl BitAnd<u32> for BigUint, bitand);
 forward_all_scalar_binop_to_val_val_commutative!(impl BitAnd<u64> for BigUint, bitand);
 forward_all_scalar_binop_to_val_val_commutative!(impl BitAnd<u128> for BigUint, bitand);
@@ -198,125 +198,6 @@ impl BitAndAssign<u128> for BigUint {
                 self.data[2] &= (rhs >> (big_digit::BITS * 2)) as BigDigit;
                 self.data[3] &= (rhs >> (big_digit::BITS * 3)) as BigDigit;
                 self.data.drain(4..);
-            }
-        }
-    }
-}
-
-// Implementation note: The signed bitwise variants work because `i* as u*`
-// produces numbers with identical bit patterns, thus bitwise operations will
-// return identical results. The only semantic difference lies in the leading
-// zeroes, which (conceptually) are all 0 if positive, and all one when
-// negative. As such, this will only truncate the leading bits when positive,
-// since x & 0 == 0.
-
-forward_all_scalar_binop_to_val_val_commutative!(impl BitAnd<i32> for BigUint, bitand);
-forward_all_scalar_binop_to_val_val_commutative!(impl BitAnd<i64> for BigUint, bitand);
-forward_all_scalar_binop_to_val_val_commutative!(impl BitAnd<i128> for BigUint, bitand);
-
-impl BitAnd<i32> for BigUint {
-    type Output = BigUint;
-
-    fn bitand(mut self, rhs: i32) -> Self::Output {
-        self &= rhs;
-        self
-    }
-}
-
-impl BitAndAssign<i32> for BigUint {
-    fn bitand_assign(&mut self, rhs: i32) {
-        if !self.is_zero() {
-            self.data[0] &= rhs as BigDigit;
-            if rhs >= 0 {
-                self.data.drain(1..);
-            }
-        }
-    }
-}
-
-impl BitAnd<i64> for BigUint {
-    type Output = BigUint;
-
-    fn bitand(mut self, rhs: i64) -> Self::Output {
-        self &= rhs;
-        self
-    }
-}
-
-#[cfg(u64_digit)]
-impl BitAndAssign<i64> for BigUint {
-    fn bitand_assign(&mut self, rhs: i64) {
-        if !self.is_zero() {
-            self.data[0] &= rhs as BigDigit;
-            if rhs >= 0 {
-                self.data.drain(1..);
-            }
-        }
-    }
-}
-
-#[cfg(not(u64_digit))]
-impl BitAndAssign<i64> for BigUint {
-    fn bitand_assign(&mut self, rhs: i64) {
-        if !self.is_zero() {
-            self.data[0] &= rhs as BigDigit;
-            if self.data.len() > 1 {
-                self.data[1] &= (rhs >> big_digit::BITS) as BigDigit;
-                if rhs >= 0 {
-                    self.data.drain(2..);
-                }
-            }
-        }
-    }
-}
-
-impl BitAnd<i128> for BigUint {
-    type Output = BigUint;
-
-    fn bitand(mut self, rhs: i128) -> Self::Output {
-        self &= rhs;
-        self
-    }
-}
-
-#[cfg(u64_digit)]
-impl BitAndAssign<i128> for BigUint {
-    fn bitand_assign(&mut self, rhs: i128) {
-        if !self.is_zero() {
-            self.data[0] &= rhs as BigDigit;
-            if self.data.len() > 1 {
-                self.data[1] &= (rhs >> big_digit::BITS) as BigDigit;
-                if rhs >= 0 {
-                    self.data.drain(2..);
-                }
-            }
-        }
-    }
-}
-
-#[cfg(not(u64_digit))]
-impl BitAndAssign<i128> for BigUint {
-    fn bitand_assign(&mut self, rhs: i128) {
-        match self.data.len() {
-            0 => {}
-            1 => self.data[0] &= rhs as BigDigit,
-            2 => {
-                self.data[0] &= rhs as BigDigit;
-                self.data[1] &= (rhs >> big_digit::BITS) as BigDigit;
-            }
-            3 => {
-                self.data[0] &= rhs as BigDigit;
-                self.data[1] &= (rhs >> big_digit::BITS) as BigDigit;
-                self.data[2] &= (rhs >> (big_digit::BITS * 2)) as BigDigit;
-            }
-            _ => {
-                self.data[0] &= rhs as BigDigit;
-                self.data[1] &= (rhs >> big_digit::BITS) as BigDigit;
-                self.data[2] &= (rhs >> (big_digit::BITS * 2)) as BigDigit;
-                self.data[3] &= (rhs >> (big_digit::BITS * 3)) as BigDigit;
-                if rhs >= 0 {
-                    self.data.drain(4..);
-                }
             }
         }
     }

--- a/src/biguint/bits.rs
+++ b/src/biguint/bits.rs
@@ -1,6 +1,10 @@
 use super::{BigUint, IntDigits};
 
+use crate::big_digit::{self, BigDigit};
+use crate::{IsizePromotion, UsizePromotion};
+
 use core::ops::{BitAnd, BitAndAssign, BitOr, BitOrAssign, BitXor, BitXorAssign};
+use num_traits::Zero;
 
 forward_val_val_binop!(impl BitAnd for BigUint, bitand);
 forward_ref_val_binop!(impl BitAnd for BigUint, bitand);
@@ -89,5 +93,228 @@ impl<'a> BitXorAssign<&'a BigUint> for BigUint {
             self.data.extend(extra.iter().cloned());
         }
         self.normalize();
+    }
+}
+
+promote_all_scalars!(impl BitAnd for BigUint, bitand);
+promote_all_scalars_assign!(impl BitAndAssign for BigUint, bitand_assign);
+forward_all_scalar_binop_to_val_val_commutative!(impl BitAnd<u32> for BigUint, bitand);
+forward_all_scalar_binop_to_val_val_commutative!(impl BitAnd<u64> for BigUint, bitand);
+forward_all_scalar_binop_to_val_val_commutative!(impl BitAnd<u128> for BigUint, bitand);
+
+impl BitAnd<u32> for BigUint {
+    type Output = BigUint;
+
+    fn bitand(mut self, rhs: u32) -> Self::Output {
+        self &= rhs;
+        self
+    }
+}
+
+impl BitAndAssign<u32> for BigUint {
+    fn bitand_assign(&mut self, rhs: u32) {
+        if !self.is_zero() {
+            self.data[0] &= rhs as BigDigit;
+            self.data.drain(1..);
+        }
+    }
+}
+
+impl BitAnd<u64> for BigUint {
+    type Output = BigUint;
+
+    fn bitand(mut self, rhs: u64) -> Self::Output {
+        self &= rhs;
+        self
+    }
+}
+
+#[cfg(u64_digit)]
+impl BitAndAssign<u64> for BigUint {
+    fn bitand_assign(&mut self, rhs: u64) {
+        if !self.is_zero() {
+            self.data[0] &= rhs as BigDigit;
+            self.data.drain(1..);
+        }
+    }
+}
+
+#[cfg(not(u64_digit))]
+impl BitAndAssign<u64> for BigUint {
+    fn bitand_assign(&mut self, rhs: u64) {
+        if !self.is_zero() {
+            self.data[0] &= rhs as BigDigit;
+            if self.data.len() > 1 {
+                self.data[1] &= (rhs >> big_digit::BITS) as BigDigit;
+                self.data.drain(2..);
+            }
+        }
+    }
+}
+
+impl BitAnd<u128> for BigUint {
+    type Output = BigUint;
+
+    fn bitand(mut self, rhs: u128) -> Self::Output {
+        self &= rhs;
+        self
+    }
+}
+
+#[cfg(u64_digit)]
+impl BitAndAssign<u128> for BigUint {
+    fn bitand_assign(&mut self, rhs: u128) {
+        if !self.is_zero() {
+            self.data[0] &= rhs as BigDigit;
+            if self.data.len() > 1 {
+                self.data[1] &= (rhs >> big_digit::BITS) as BigDigit;
+                self.data.drain(2..);
+            }
+        }
+    }
+}
+
+#[cfg(not(u64_digit))]
+impl BitAndAssign<u128> for BigUint {
+    fn bitand_assign(&mut self, rhs: u128) {
+        match self.data.len() {
+            0 => {}
+            1 => self.data[0] &= rhs as BigDigit,
+            2 => {
+                self.data[0] &= rhs as BigDigit;
+                self.data[1] &= (rhs >> big_digit::BITS) as BigDigit;
+            }
+            3 => {
+                self.data[0] &= rhs as BigDigit;
+                self.data[1] &= (rhs >> big_digit::BITS) as BigDigit;
+                self.data[2] &= (rhs >> (big_digit::BITS * 2)) as BigDigit;
+            }
+            _ => {
+                self.data[0] &= rhs as BigDigit;
+                self.data[1] &= (rhs >> big_digit::BITS) as BigDigit;
+                self.data[2] &= (rhs >> (big_digit::BITS * 2)) as BigDigit;
+                self.data[3] &= (rhs >> (big_digit::BITS * 3)) as BigDigit;
+                self.data.drain(4..);
+            }
+        }
+    }
+}
+
+// Implementation note: The signed bitwise variants work because `i* as u*`
+// produces numbers with identical bit patterns, thus bitwise operations will
+// return identical results. The only semantic difference lies in the leading
+// zeroes, which (conceptually) are all 0 if positive, and all one when
+// negative. As such, this will only truncate the leading bits when positive,
+// since x & 0 == 0.
+
+forward_all_scalar_binop_to_val_val_commutative!(impl BitAnd<i32> for BigUint, bitand);
+forward_all_scalar_binop_to_val_val_commutative!(impl BitAnd<i64> for BigUint, bitand);
+forward_all_scalar_binop_to_val_val_commutative!(impl BitAnd<i128> for BigUint, bitand);
+
+impl BitAnd<i32> for BigUint {
+    type Output = BigUint;
+
+    fn bitand(mut self, rhs: i32) -> Self::Output {
+        self &= rhs;
+        self
+    }
+}
+
+impl BitAndAssign<i32> for BigUint {
+    fn bitand_assign(&mut self, rhs: i32) {
+        if !self.is_zero() {
+            self.data[0] &= rhs as BigDigit;
+            if rhs >= 0 {
+                self.data.drain(1..);
+            }
+        }
+    }
+}
+
+impl BitAnd<i64> for BigUint {
+    type Output = BigUint;
+
+    fn bitand(mut self, rhs: i64) -> Self::Output {
+        self &= rhs;
+        self
+    }
+}
+
+#[cfg(u64_digit)]
+impl BitAndAssign<i64> for BigUint {
+    fn bitand_assign(&mut self, rhs: i64) {
+        if !self.is_zero() {
+            self.data[0] &= rhs as BigDigit;
+            if rhs >= 0 {
+                self.data.drain(1..);
+            }
+        }
+    }
+}
+
+#[cfg(not(u64_digit))]
+impl BitAndAssign<i64> for BigUint {
+    fn bitand_assign(&mut self, rhs: i64) {
+        if !self.is_zero() {
+            self.data[0] &= rhs as BigDigit;
+            if self.data.len() > 1 {
+                self.data[1] &= (rhs >> big_digit::BITS) as BigDigit;
+                if rhs >= 0 {
+                    self.data.drain(2..);
+                }
+            }
+        }
+    }
+}
+
+impl BitAnd<i128> for BigUint {
+    type Output = BigUint;
+
+    fn bitand(mut self, rhs: i128) -> Self::Output {
+        self &= rhs;
+        self
+    }
+}
+
+#[cfg(u64_digit)]
+impl BitAndAssign<i128> for BigUint {
+    fn bitand_assign(&mut self, rhs: i128) {
+        if !self.is_zero() {
+            self.data[0] &= rhs as BigDigit;
+            if self.data.len() > 1 {
+                self.data[1] &= (rhs >> big_digit::BITS) as BigDigit;
+                if rhs >= 0 {
+                    self.data.drain(2..);
+                }
+            }
+        }
+    }
+}
+
+#[cfg(not(u64_digit))]
+impl BitAndAssign<i128> for BigUint {
+    fn bitand_assign(&mut self, rhs: i128) {
+        match self.data.len() {
+            0 => {}
+            1 => self.data[0] &= rhs as BigDigit,
+            2 => {
+                self.data[0] &= rhs as BigDigit;
+                self.data[1] &= (rhs >> big_digit::BITS) as BigDigit;
+            }
+            3 => {
+                self.data[0] &= rhs as BigDigit;
+                self.data[1] &= (rhs >> big_digit::BITS) as BigDigit;
+                self.data[2] &= (rhs >> (big_digit::BITS * 2)) as BigDigit;
+            }
+            _ => {
+                self.data[0] &= rhs as BigDigit;
+                self.data[1] &= (rhs >> big_digit::BITS) as BigDigit;
+                self.data[2] &= (rhs >> (big_digit::BITS * 2)) as BigDigit;
+                self.data[3] &= (rhs >> (big_digit::BITS * 3)) as BigDigit;
+                if rhs >= 0 {
+                    self.data.drain(4..);
+                }
+            }
+        }
     }
 }

--- a/tests/bigint_bitwise.rs
+++ b/tests/bigint_bitwise.rs
@@ -176,3 +176,18 @@ fn test_bitwise_i64() {
         }
     }
 }
+
+#[test]
+fn test_bitwise_primitive() {
+    for &prim_a in I64_VALUES.iter() {
+        let a = prim_a.to_bigint().unwrap();
+        for &prim_b in I64_VALUES.iter() {
+            let and = (prim_a & prim_b).to_bigint().unwrap();
+            let or = (prim_a | prim_b).to_bigint().unwrap();
+            let xor = (prim_a ^ prim_b).to_bigint().unwrap();
+            assert_eq!(a.clone() & prim_b, and, "{:x} & {:x}", a, prim_b.to_bigint().unwrap());
+            assert_eq!(a.clone() | prim_b, or, "{:x} | {:x}", a, prim_b.to_bigint().unwrap());
+            assert_eq!(a.clone() ^ prim_b, xor, "{:x} ^ {:x}", a, prim_b.to_bigint().unwrap());
+        }
+    }
+}

--- a/tests/bigint_bitwise.rs
+++ b/tests/bigint_bitwise.rs
@@ -185,9 +185,27 @@ fn test_bitwise_primitive() {
             let and = (prim_a & prim_b).to_bigint().unwrap();
             let or = (prim_a | prim_b).to_bigint().unwrap();
             let xor = (prim_a ^ prim_b).to_bigint().unwrap();
-            assert_eq!(a.clone() & prim_b, and, "{:x} & {:x}", a, prim_b.to_bigint().unwrap());
-            assert_eq!(a.clone() | prim_b, or, "{:x} | {:x}", a, prim_b.to_bigint().unwrap());
-            assert_eq!(a.clone() ^ prim_b, xor, "{:x} ^ {:x}", a, prim_b.to_bigint().unwrap());
+            assert_eq!(
+                a.clone() & prim_b,
+                and,
+                "{:x} & {:x}",
+                a,
+                prim_b.to_bigint().unwrap()
+            );
+            assert_eq!(
+                a.clone() | prim_b,
+                or,
+                "{:x} | {:x}",
+                a,
+                prim_b.to_bigint().unwrap()
+            );
+            assert_eq!(
+                a.clone() ^ prim_b,
+                xor,
+                "{:x} ^ {:x}",
+                a,
+                prim_b.to_bigint().unwrap()
+            );
         }
     }
 }


### PR DESCRIPTION
Fixes #205.

This does not add bitwise-or and bitwise-xor operations between signed integers and BigUint, because there is no good way to represent negative numbers with a BigUint (see #184). Bitwise-and operations were added because the result of such an operation will always be positive.