### PR TITLE
Optimize twos_complement and from_signed_bytes_be

### DIFF
--- a/src/bigint/convert.rs
+++ b/src/bigint/convert.rs
@@ -460,10 +460,8 @@ where
 {
     let mut carry = true;
     for d in digits {
-        *d = !*d;
-        if carry {
-            *d = d.wrapping_add(1);
-            carry = d.is_zero();
-        }
+        let (val, tmp_carry) = (!*d).overflowing_add(carry as u8);
+        *d = val;
+        carry = tmp_carry;
     }
 }

--- a/src/bigint/convert.rs
+++ b/src/bigint/convert.rs
@@ -377,9 +377,10 @@ pub(super) fn from_signed_bytes_be(digits: &[u8]) -> BigInt {
 
     if sign == Sign::Minus {
         // two's-complement the content to retrieve the magnitude
-        let mut digits = Vec::from(digits);
-        twos_complement_be(&mut digits);
-        BigInt::from_biguint(sign, BigUint::from_bytes_be(&*digits))
+        let mut digits = digits.to_vec();
+        digits.reverse();
+        twos_complement_le(&mut digits);
+        BigInt::from_biguint(sign, BigUint::from_bytes_le(&digits))
     } else {
         BigInt::from_biguint(sign, BigUint::from_bytes_be(digits))
     }
@@ -395,9 +396,9 @@ pub(super) fn from_signed_bytes_le(digits: &[u8]) -> BigInt {
 
     if sign == Sign::Minus {
         // two's-complement the content to retrieve the magnitude
-        let mut digits = Vec::from(digits);
+        let mut digits = digits.to_vec();
         twos_complement_le(&mut digits);
-        BigInt::from_biguint(sign, BigUint::from_bytes_le(&*digits))
+        BigInt::from_biguint(sign, BigUint::from_bytes_le(&digits))
     } else {
         BigInt::from_biguint(sign, BigUint::from_bytes_le(digits))
     }


### PR DESCRIPTION
from_signed_bytes_be with a 20 byte negative number | time
-----------|---------
Currently | 91 ns/iter (+/- 3)
Only twos_complement optimization | 88 ns/iter (+/- 2)
This PR | 78 ns/iter (+/- 5)