### PR TITLE
[docs] Use assignment instead of replace

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,7 +22,6 @@
 //! # fn main() {
 //! use num_bigint::BigUint;
 //! use num_traits::{Zero, One};
-//! use std::mem::replace;
 //!
 //! // Calculate large fibonacci numbers.
 //! fn fib(n: usize) -> BigUint {
@@ -30,8 +29,8 @@
 //!     let mut f1: BigUint = One::one();
 //!     for _ in 0..n {
 //!         let f2 = f0 + &f1;
-//!         // This is a low cost way of swapping f0 with f1 and f1 with f2.
-//!         f0 = replace(&mut f1, f2);
+//!         f0 = f1;
+//!         f1 = f2;
 //!     }
 //!     f0
 //! }


### PR DESCRIPTION
The line moves f2 into f1 using `replace` but that can be done with assignment

(I'm a beginner to rust so it's very likely I've missed something)