### PR TITLE
Removed unnecessary lifetime annotations

### DIFF
--- a/src/bigint.rs
+++ b/src/bigint.rs
@@ -196,7 +196,7 @@ impl Not for BigInt {
     }
 }
 
-impl<'a> Not for &'a BigInt {
+impl Not for &BigInt {
     type Output = BigInt;
 
     fn not(self) -> BigInt {
@@ -342,7 +342,7 @@ impl Neg for BigInt {
     }
 }
 
-impl<'a> Neg for &'a BigInt {
+impl Neg for &BigInt {
     type Output = BigInt;
 
     #[inline]

--- a/src/bigint/addition.rs
+++ b/src/bigint/addition.rs
@@ -30,7 +30,7 @@ macro_rules! bigint_add {
     };
 }
 
-impl<'a, 'b> Add<&'b BigInt> for &'a BigInt {
+impl Add<&BigInt> for &BigInt {
     type Output = BigInt;
 
     #[inline]
@@ -46,7 +46,7 @@ impl<'a, 'b> Add<&'b BigInt> for &'a BigInt {
     }
 }
 
-impl<'a> Add<BigInt> for &'a BigInt {
+impl Add<BigInt> for &BigInt {
     type Output = BigInt;
 
     #[inline]
@@ -55,7 +55,7 @@ impl<'a> Add<BigInt> for &'a BigInt {
     }
 }
 
-impl<'a> Add<&'a BigInt> for BigInt {
+impl Add<&BigInt> for BigInt {
     type Output = BigInt;
 
     #[inline]
@@ -73,7 +73,7 @@ impl Add<BigInt> for BigInt {
     }
 }
 
-impl<'a> AddAssign<&'a BigInt> for BigInt {
+impl AddAssign<&BigInt> for BigInt {
     #[inline]
     fn add_assign(&mut self, other: &BigInt) {
         let n = mem::replace(self, BigInt::zero());

--- a/src/bigint/bits.rs
+++ b/src/bigint/bits.rs
@@ -108,7 +108,7 @@ forward_ref_val_binop!(impl BitAnd for BigInt, bitand);
 
 // do not use forward_ref_ref_binop_commutative! for bitand so that we can
 // clone as needed, avoiding over-allocation
-impl<'a, 'b> BitAnd<&'b BigInt> for &'a BigInt {
+impl BitAnd<&BigInt> for &BigInt {
     type Output = BigInt;
 
     #[inline]
@@ -130,7 +130,7 @@ impl<'a, 'b> BitAnd<&'b BigInt> for &'a BigInt {
     }
 }
 
-impl<'a> BitAnd<&'a BigInt> for BigInt {
+impl BitAnd<&BigInt> for BigInt {
     type Output = BigInt;
 
     #[inline]
@@ -142,7 +142,7 @@ impl<'a> BitAnd<&'a BigInt> for BigInt {
 
 forward_val_assign!(impl BitAndAssign for BigInt, bitand_assign);
 
-impl<'a> BitAndAssign<&'a BigInt> for BigInt {
+impl BitAndAssign<&BigInt> for BigInt {
     fn bitand_assign(&mut self, other: &BigInt) {
         match (self.sign, other.sign) {
             (NoSign, _) => {}
@@ -247,7 +247,7 @@ forward_ref_val_binop!(impl BitOr for BigInt, bitor);
 
 // do not use forward_ref_ref_binop_commutative! for bitor so that we can
 // clone as needed, avoiding over-allocation
-impl<'a, 'b> BitOr<&'b BigInt> for &'a BigInt {
+impl BitOr<&BigInt> for &BigInt {
     type Output = BigInt;
 
     #[inline]
@@ -270,7 +270,7 @@ impl<'a, 'b> BitOr<&'b BigInt> for &'a BigInt {
     }
 }
 
-impl<'a> BitOr<&'a BigInt> for BigInt {
+impl BitOr<&BigInt> for BigInt {
     type Output = BigInt;
 
     #[inline]
@@ -282,7 +282,7 @@ impl<'a> BitOr<&'a BigInt> for BigInt {
 
 forward_val_assign!(impl BitOrAssign for BigInt, bitor_assign);
 
-impl<'a> BitOrAssign<&'a BigInt> for BigInt {
+impl BitOrAssign<&BigInt> for BigInt {
     fn bitor_assign(&mut self, other: &BigInt) {
         match (self.sign, other.sign) {
             (_, NoSign) => {}
@@ -408,7 +408,7 @@ fn bitxor_neg_neg(a: &mut Vec<BigDigit>, b: &[BigDigit]) {
 
 forward_all_binop_to_val_ref_commutative!(impl BitXor for BigInt, bitxor);
 
-impl<'a> BitXor<&'a BigInt> for BigInt {
+impl BitXor<&BigInt> for BigInt {
     type Output = BigInt;
 
     #[inline]
@@ -420,7 +420,7 @@ impl<'a> BitXor<&'a BigInt> for BigInt {
 
 forward_val_assign!(impl BitXorAssign for BigInt, bitxor_assign);
 
-impl<'a> BitXorAssign<&'a BigInt> for BigInt {
+impl BitXorAssign<&BigInt> for BigInt {
     fn bitxor_assign(&mut self, other: &BigInt) {
         match (self.sign, other.sign) {
             (_, NoSign) => {}

--- a/src/bigint/division.rs
+++ b/src/bigint/division.rs
@@ -10,7 +10,7 @@ use num_traits::{CheckedDiv, ToPrimitive, Zero};
 
 forward_all_binop_to_ref_ref!(impl Div for BigInt, div);
 
-impl<'a, 'b> Div<&'b BigInt> for &'a BigInt {
+impl Div<&BigInt> for &BigInt {
     type Output = BigInt;
 
     #[inline]
@@ -20,7 +20,7 @@ impl<'a, 'b> Div<&'b BigInt> for &'a BigInt {
     }
 }
 
-impl<'a> DivAssign<&'a BigInt> for BigInt {
+impl DivAssign<&BigInt> for BigInt {
     #[inline]
     fn div_assign(&mut self, other: &BigInt) {
         *self = &*self / other;
@@ -235,7 +235,7 @@ impl Div<BigInt> for i128 {
 
 forward_all_binop_to_ref_ref!(impl Rem for BigInt, rem);
 
-impl<'a, 'b> Rem<&'b BigInt> for &'a BigInt {
+impl Rem<&BigInt> for &BigInt {
     type Output = BigInt;
 
     #[inline]
@@ -251,7 +251,7 @@ impl<'a, 'b> Rem<&'b BigInt> for &'a BigInt {
     }
 }
 
-impl<'a> RemAssign<&'a BigInt> for BigInt {
+impl RemAssign<&BigInt> for BigInt {
     #[inline]
     fn rem_assign(&mut self, other: &BigInt) {
         *self = &*self % other;

--- a/src/bigint/multiplication.rs
+++ b/src/bigint/multiplication.rs
@@ -22,8 +22,8 @@ impl Mul<Sign> for Sign {
 }
 
 macro_rules! impl_mul {
-    ($(impl<$($a:lifetime),*> Mul<$Other:ty> for $Self:ty;)*) => {$(
-        impl<$($a),*> Mul<$Other> for $Self {
+    ($(impl Mul<$Other:ty> for $Self:ty;)*) => {$(
+        impl Mul<$Other> for $Self {
             type Output = BigInt;
 
             #[inline]
@@ -37,15 +37,15 @@ macro_rules! impl_mul {
     )*}
 }
 impl_mul! {
-    impl<> Mul<BigInt> for BigInt;
-    impl<'b> Mul<&'b BigInt> for BigInt;
-    impl<'a> Mul<BigInt> for &'a BigInt;
-    impl<'a, 'b> Mul<&'b BigInt> for &'a BigInt;
+    impl Mul<BigInt> for BigInt;
+    impl Mul<BigInt> for &BigInt;
+    impl Mul<&BigInt> for BigInt;
+    impl Mul<&BigInt> for &BigInt;
 }
 
 macro_rules! impl_mul_assign {
-    ($(impl<$($a:lifetime),*> MulAssign<$Other:ty> for BigInt;)*) => {$(
-        impl<$($a),*> MulAssign<$Other> for BigInt {
+    ($(impl MulAssign<$Other:ty> for BigInt;)*) => {$(
+        impl MulAssign<$Other> for BigInt {
             #[inline]
             fn mul_assign(&mut self, other: $Other) {
                 // automatically match value/ref
@@ -61,8 +61,8 @@ macro_rules! impl_mul_assign {
     )*}
 }
 impl_mul_assign! {
-    impl<> MulAssign<BigInt> for BigInt;
-    impl<'a> MulAssign<&'a BigInt> for BigInt;
+    impl MulAssign<BigInt> for BigInt;
+    impl MulAssign<&BigInt> for BigInt;
 }
 
 promote_all_scalars!(impl Mul for BigInt, mul);

--- a/src/bigint/power.rs
+++ b/src/bigint/power.rs
@@ -31,7 +31,7 @@ macro_rules! pow_impl {
             }
         }
 
-        impl<'b> Pow<&'b $T> for BigInt {
+        impl Pow<&$T> for BigInt {
             type Output = BigInt;
 
             #[inline]
@@ -40,7 +40,7 @@ macro_rules! pow_impl {
             }
         }
 
-        impl<'a> Pow<$T> for &'a BigInt {
+        impl Pow<$T> for &BigInt {
             type Output = BigInt;
 
             #[inline]
@@ -49,7 +49,7 @@ macro_rules! pow_impl {
             }
         }
 
-        impl<'a, 'b> Pow<&'b $T> for &'a BigInt {
+        impl Pow<&$T> for &BigInt {
             type Output = BigInt;
 
             #[inline]

--- a/src/bigint/shift.rs
+++ b/src/bigint/shift.rs
@@ -6,25 +6,25 @@ use num_traits::{PrimInt, Signed, Zero};
 
 macro_rules! impl_shift {
     (@ref $Shx:ident :: $shx:ident, $ShxAssign:ident :: $shx_assign:ident, $rhs:ty) => {
-        impl<'b> $Shx<&'b $rhs> for BigInt {
+        impl $Shx<&$rhs> for BigInt {
             type Output = BigInt;
 
             #[inline]
-            fn $shx(self, rhs: &'b $rhs) -> BigInt {
+            fn $shx(self, rhs: &$rhs) -> BigInt {
                 $Shx::$shx(self, *rhs)
             }
         }
-        impl<'a, 'b> $Shx<&'b $rhs> for &'a BigInt {
+        impl $Shx<&$rhs> for &BigInt {
             type Output = BigInt;
 
             #[inline]
-            fn $shx(self, rhs: &'b $rhs) -> BigInt {
+            fn $shx(self, rhs: &$rhs) -> BigInt {
                 $Shx::$shx(self, *rhs)
             }
         }
-        impl<'b> $ShxAssign<&'b $rhs> for BigInt {
+        impl $ShxAssign<&$rhs> for BigInt {
             #[inline]
-            fn $shx_assign(&mut self, rhs: &'b $rhs) {
+            fn $shx_assign(&mut self, rhs: &$rhs) {
                 $ShxAssign::$shx_assign(self, *rhs);
             }
         }
@@ -38,7 +38,7 @@ macro_rules! impl_shift {
                 BigInt::from_biguint(self.sign, self.data << rhs)
             }
         }
-        impl<'a> Shl<$rhs> for &'a BigInt {
+        impl Shl<$rhs> for &BigInt {
             type Output = BigInt;
 
             #[inline]
@@ -65,7 +65,7 @@ macro_rules! impl_shift {
                 BigInt::from_biguint(self.sign, data)
             }
         }
-        impl<'a> Shr<$rhs> for &'a BigInt {
+        impl Shr<$rhs> for &BigInt {
             type Output = BigInt;
 
             #[inline]

--- a/src/bigint/subtraction.rs
+++ b/src/bigint/subtraction.rs
@@ -29,7 +29,7 @@ macro_rules! bigint_sub {
     };
 }
 
-impl<'a, 'b> Sub<&'b BigInt> for &'a BigInt {
+impl Sub<&BigInt> for &BigInt {
     type Output = BigInt;
 
     #[inline]
@@ -45,7 +45,7 @@ impl<'a, 'b> Sub<&'b BigInt> for &'a BigInt {
     }
 }
 
-impl<'a> Sub<BigInt> for &'a BigInt {
+impl Sub<BigInt> for &BigInt {
     type Output = BigInt;
 
     #[inline]
@@ -54,7 +54,7 @@ impl<'a> Sub<BigInt> for &'a BigInt {
     }
 }
 
-impl<'a> Sub<&'a BigInt> for BigInt {
+impl Sub<&BigInt> for BigInt {
     type Output = BigInt;
 
     #[inline]
@@ -72,7 +72,7 @@ impl Sub<BigInt> for BigInt {
     }
 }
 
-impl<'a> SubAssign<&'a BigInt> for BigInt {
+impl SubAssign<&BigInt> for BigInt {
     #[inline]
     fn sub_assign(&mut self, other: &BigInt) {
         let n = mem::replace(self, BigInt::zero());

--- a/src/biguint/addition.rs
+++ b/src/biguint/addition.rs
@@ -86,7 +86,7 @@ pub(super) fn add2(a: &mut [BigDigit], b: &[BigDigit]) {
 forward_all_binop_to_val_ref_commutative!(impl Add for BigUint, add);
 forward_val_assign!(impl AddAssign for BigUint, add_assign);
 
-impl<'a> Add<&'a BigUint> for BigUint {
+impl Add<&BigUint> for BigUint {
     type Output = BigUint;
 
     fn add(mut self, other: &BigUint) -> BigUint {
@@ -94,7 +94,7 @@ impl<'a> Add<&'a BigUint> for BigUint {
         self
     }
 }
-impl<'a> AddAssign<&'a BigUint> for BigUint {
+impl AddAssign<&BigUint> for BigUint {
     #[inline]
     fn add_assign(&mut self, other: &BigUint) {
         let self_len = self.data.len();

--- a/src/biguint/bits.rs
+++ b/src/biguint/bits.rs
@@ -7,7 +7,7 @@ forward_ref_val_binop!(impl BitAnd for BigUint, bitand);
 
 // do not use forward_ref_ref_binop_commutative! for bitand so that we can
 // clone the smaller value rather than the larger, avoiding over-allocation
-impl<'a, 'b> BitAnd<&'b BigUint> for &'a BigUint {
+impl BitAnd<&BigUint> for &BigUint {
     type Output = BigUint;
 
     #[inline]
@@ -23,7 +23,7 @@ impl<'a, 'b> BitAnd<&'b BigUint> for &'a BigUint {
 
 forward_val_assign!(impl BitAndAssign for BigUint, bitand_assign);
 
-impl<'a> BitAnd<&'a BigUint> for BigUint {
+impl BitAnd<&BigUint> for BigUint {
     type Output = BigUint;
 
     #[inline]
@@ -32,7 +32,7 @@ impl<'a> BitAnd<&'a BigUint> for BigUint {
         self
     }
 }
-impl<'a> BitAndAssign<&'a BigUint> for BigUint {
+impl BitAndAssign<&BigUint> for BigUint {
     #[inline]
     fn bitand_assign(&mut self, other: &BigUint) {
         for (ai, &bi) in self.data.iter_mut().zip(other.data.iter()) {
@@ -46,7 +46,7 @@ impl<'a> BitAndAssign<&'a BigUint> for BigUint {
 forward_all_binop_to_val_ref_commutative!(impl BitOr for BigUint, bitor);
 forward_val_assign!(impl BitOrAssign for BigUint, bitor_assign);
 
-impl<'a> BitOr<&'a BigUint> for BigUint {
+impl BitOr<&BigUint> for BigUint {
     type Output = BigUint;
 
     fn bitor(mut self, other: &BigUint) -> BigUint {
@@ -54,7 +54,7 @@ impl<'a> BitOr<&'a BigUint> for BigUint {
         self
     }
 }
-impl<'a> BitOrAssign<&'a BigUint> for BigUint {
+impl BitOrAssign<&BigUint> for BigUint {
     #[inline]
     fn bitor_assign(&mut self, other: &BigUint) {
         for (ai, &bi) in self.data.iter_mut().zip(other.data.iter()) {
@@ -70,7 +70,7 @@ impl<'a> BitOrAssign<&'a BigUint> for BigUint {
 forward_all_binop_to_val_ref_commutative!(impl BitXor for BigUint, bitxor);
 forward_val_assign!(impl BitXorAssign for BigUint, bitxor_assign);
 
-impl<'a> BitXor<&'a BigUint> for BigUint {
+impl BitXor<&BigUint> for BigUint {
     type Output = BigUint;
 
     fn bitxor(mut self, other: &BigUint) -> BigUint {
@@ -78,7 +78,7 @@ impl<'a> BitXor<&'a BigUint> for BigUint {
         self
     }
 }
-impl<'a> BitXorAssign<&'a BigUint> for BigUint {
+impl BitXorAssign<&BigUint> for BigUint {
     #[inline]
     fn bitxor_assign(&mut self, other: &BigUint) {
         for (ai, &bi) in self.data.iter_mut().zip(other.data.iter()) {

--- a/src/biguint/division.rs
+++ b/src/biguint/division.rs
@@ -314,7 +314,7 @@ impl Div<BigUint> for BigUint {
     }
 }
 
-impl<'a, 'b> Div<&'b BigUint> for &'a BigUint {
+impl Div<&BigUint> for &BigUint {
     type Output = BigUint;
 
     #[inline]
@@ -323,9 +323,9 @@ impl<'a, 'b> Div<&'b BigUint> for &'a BigUint {
         q
     }
 }
-impl<'a> DivAssign<&'a BigUint> for BigUint {
+impl DivAssign<&BigUint> for BigUint {
     #[inline]
-    fn div_assign(&mut self, other: &'a BigUint) {
+    fn div_assign(&mut self, other: &BigUint) {
         *self = &*self / other;
     }
 }
@@ -475,7 +475,7 @@ impl Rem<BigUint> for BigUint {
     }
 }
 
-impl<'a, 'b> Rem<&'b BigUint> for &'a BigUint {
+impl Rem<&BigUint> for &BigUint {
     type Output = BigUint;
 
     #[inline]
@@ -488,7 +488,7 @@ impl<'a, 'b> Rem<&'b BigUint> for &'a BigUint {
         }
     }
 }
-impl<'a> RemAssign<&'a BigUint> for BigUint {
+impl RemAssign<&BigUint> for BigUint {
     #[inline]
     fn rem_assign(&mut self, other: &BigUint) {
         *self = &*self % other;
@@ -501,7 +501,7 @@ forward_all_scalar_binop_to_ref_val!(impl Rem<u32> for BigUint, rem);
 forward_all_scalar_binop_to_val_val!(impl Rem<u64> for BigUint, rem);
 forward_all_scalar_binop_to_val_val!(impl Rem<u128> for BigUint, rem);
 
-impl<'a> Rem<u32> for &'a BigUint {
+impl Rem<u32> for &BigUint {
     type Output = BigUint;
 
     #[inline]
@@ -516,11 +516,11 @@ impl RemAssign<u32> for BigUint {
     }
 }
 
-impl<'a> Rem<&'a BigUint> for u32 {
+impl Rem<&BigUint> for u32 {
     type Output = BigUint;
 
     #[inline]
-    fn rem(mut self, other: &'a BigUint) -> BigUint {
+    fn rem(mut self, other: &BigUint) -> BigUint {
         self %= other;
         From::from(self)
     }
@@ -529,7 +529,7 @@ impl<'a> Rem<&'a BigUint> for u32 {
 macro_rules! impl_rem_assign_scalar {
     ($scalar:ty, $to_scalar:ident) => {
         forward_val_assign_scalar!(impl RemAssign for BigUint, $scalar, rem_assign);
-        impl<'a> RemAssign<&'a BigUint> for $scalar {
+        impl RemAssign<&BigUint> for $scalar {
             #[inline]
             fn rem_assign(&mut self, other: &BigUint) {
                 *self = match other.$to_scalar() {

--- a/src/biguint/multiplication.rs
+++ b/src/biguint/multiplication.rs
@@ -402,8 +402,8 @@ fn sub_sign(mut a: &[BigDigit], mut b: &[BigDigit]) -> (Sign, BigUint) {
 }
 
 macro_rules! impl_mul {
-    ($(impl<$($a:lifetime),*> Mul<$Other:ty> for $Self:ty;)*) => {$(
-        impl<$($a),*> Mul<$Other> for $Self {
+    ($(impl Mul<$Other:ty> for $Self:ty;)*) => {$(
+        impl Mul<$Other> for $Self {
             type Output = BigUint;
 
             #[inline]
@@ -422,15 +422,15 @@ macro_rules! impl_mul {
     )*}
 }
 impl_mul! {
-    impl<> Mul<BigUint> for BigUint;
-    impl<'b> Mul<&'b BigUint> for BigUint;
-    impl<'a> Mul<BigUint> for &'a BigUint;
-    impl<'a, 'b> Mul<&'b BigUint> for &'a BigUint;
+    impl Mul<BigUint> for BigUint;
+    impl Mul<BigUint> for &BigUint;
+    impl Mul<&BigUint> for BigUint;
+    impl Mul<&BigUint> for &BigUint;
 }
 
 macro_rules! impl_mul_assign {
-    ($(impl<$($a:lifetime),*> MulAssign<$Other:ty> for BigUint;)*) => {$(
-        impl<$($a),*> MulAssign<$Other> for BigUint {
+    ($(impl MulAssign<$Other:ty> for BigUint;)*) => {$(
+        impl MulAssign<$Other> for BigUint {
             #[inline]
             fn mul_assign(&mut self, other: $Other) {
                 match (&*self.data, &*other.data) {
@@ -448,8 +448,8 @@ macro_rules! impl_mul_assign {
     )*}
 }
 impl_mul_assign! {
-    impl<> MulAssign<BigUint> for BigUint;
-    impl<'a> MulAssign<&'a BigUint> for BigUint;
+    impl MulAssign<BigUint> for BigUint;
+    impl MulAssign<&BigUint> for BigUint;
 }
 
 promote_unsigned_scalars!(impl Mul for BigUint, mul);

--- a/src/biguint/power.rs
+++ b/src/biguint/power.rs
@@ -6,7 +6,7 @@ use crate::big_digit::{self, BigDigit};
 use num_integer::Integer;
 use num_traits::{One, Pow, ToPrimitive, Zero};
 
-impl<'b> Pow<&'b BigUint> for BigUint {
+impl Pow<&BigUint> for BigUint {
     type Output = BigUint;
 
     #[inline]
@@ -36,7 +36,7 @@ impl Pow<BigUint> for BigUint {
     }
 }
 
-impl<'a, 'b> Pow<&'b BigUint> for &'a BigUint {
+impl Pow<&BigUint> for &BigUint {
     type Output = BigUint;
 
     #[inline]
@@ -51,7 +51,7 @@ impl<'a, 'b> Pow<&'b BigUint> for &'a BigUint {
     }
 }
 
-impl<'a> Pow<BigUint> for &'a BigUint {
+impl Pow<BigUint> for &BigUint {
     type Output = BigUint;
 
     #[inline]
@@ -92,7 +92,7 @@ macro_rules! pow_impl {
             }
         }
 
-        impl<'b> Pow<&'b $T> for BigUint {
+        impl Pow<&$T> for BigUint {
             type Output = BigUint;
 
             #[inline]
@@ -101,7 +101,7 @@ macro_rules! pow_impl {
             }
         }
 
-        impl<'a> Pow<$T> for &'a BigUint {
+        impl Pow<$T> for &BigUint {
             type Output = BigUint;
 
             #[inline]
@@ -113,7 +113,7 @@ macro_rules! pow_impl {
             }
         }
 
-        impl<'a, 'b> Pow<&'b $T> for &'a BigUint {
+        impl Pow<&$T> for &BigUint {
             type Output = BigUint;
 
             #[inline]

--- a/src/biguint/shift.rs
+++ b/src/biguint/shift.rs
@@ -92,25 +92,25 @@ fn biguint_shr2(n: Cow<'_, BigUint>, digits: usize, shift: u8) -> BigUint {
 
 macro_rules! impl_shift {
     (@ref $Shx:ident :: $shx:ident, $ShxAssign:ident :: $shx_assign:ident, $rhs:ty) => {
-        impl<'b> $Shx<&'b $rhs> for BigUint {
+        impl $Shx<&$rhs> for BigUint {
             type Output = BigUint;
 
             #[inline]
-            fn $shx(self, rhs: &'b $rhs) -> BigUint {
+            fn $shx(self, rhs: &$rhs) -> BigUint {
                 $Shx::$shx(self, *rhs)
             }
         }
-        impl<'a, 'b> $Shx<&'b $rhs> for &'a BigUint {
+        impl $Shx<&$rhs> for &BigUint {
             type Output = BigUint;
 
             #[inline]
-            fn $shx(self, rhs: &'b $rhs) -> BigUint {
+            fn $shx(self, rhs: &$rhs) -> BigUint {
                 $Shx::$shx(self, *rhs)
             }
         }
-        impl<'b> $ShxAssign<&'b $rhs> for BigUint {
+        impl $ShxAssign<&$rhs> for BigUint {
             #[inline]
-            fn $shx_assign(&mut self, rhs: &'b $rhs) {
+            fn $shx_assign(&mut self, rhs: &$rhs) {
                 $ShxAssign::$shx_assign(self, *rhs);
             }
         }
@@ -124,7 +124,7 @@ macro_rules! impl_shift {
                 biguint_shl(Cow::Owned(self), rhs)
             }
         }
-        impl<'a> Shl<$rhs> for &'a BigUint {
+        impl Shl<$rhs> for &BigUint {
             type Output = BigUint;
 
             #[inline]
@@ -149,7 +149,7 @@ macro_rules! impl_shift {
                 biguint_shr(Cow::Owned(self), rhs)
             }
         }
-        impl<'a> Shr<$rhs> for &'a BigUint {
+        impl Shr<$rhs> for &BigUint {
             type Output = BigUint;
 
             #[inline]

--- a/src/biguint/subtraction.rs
+++ b/src/biguint/subtraction.rs
@@ -108,7 +108,7 @@ forward_val_val_binop!(impl Sub for BigUint, sub);
 forward_ref_ref_binop!(impl Sub for BigUint, sub);
 forward_val_assign!(impl SubAssign for BigUint, sub_assign);
 
-impl<'a> Sub<&'a BigUint> for BigUint {
+impl Sub<&BigUint> for BigUint {
     type Output = BigUint;
 
     fn sub(mut self, other: &BigUint) -> BigUint {
@@ -116,14 +116,14 @@ impl<'a> Sub<&'a BigUint> for BigUint {
         self
     }
 }
-impl<'a> SubAssign<&'a BigUint> for BigUint {
-    fn sub_assign(&mut self, other: &'a BigUint) {
+impl SubAssign<&BigUint> for BigUint {
+    fn sub_assign(&mut self, other: &BigUint) {
         sub2(&mut self.data[..], &other.data[..]);
         self.normalize();
     }
 }
 
-impl<'a> Sub<BigUint> for &'a BigUint {
+impl Sub<BigUint> for &BigUint {
     type Output = BigUint;
 
     fn sub(self, mut other: BigUint) -> BigUint {

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -34,7 +34,7 @@ macro_rules! forward_val_val_binop_commutative {
 
 macro_rules! forward_ref_val_binop {
     (impl $imp:ident for $res:ty, $method:ident) => {
-        impl<'a> $imp<$res> for &'a $res {
+        impl $imp<$res> for &$res {
             type Output = $res;
 
             #[inline]
@@ -48,7 +48,7 @@ macro_rules! forward_ref_val_binop {
 
 macro_rules! forward_ref_val_binop_commutative {
     (impl $imp:ident for $res:ty, $method:ident) => {
-        impl<'a> $imp<$res> for &'a $res {
+        impl $imp<$res> for &$res {
             type Output = $res;
 
             #[inline]
@@ -62,7 +62,7 @@ macro_rules! forward_ref_val_binop_commutative {
 
 macro_rules! forward_val_ref_binop {
     (impl $imp:ident for $res:ty, $method:ident) => {
-        impl<'a> $imp<&'a $res> for $res {
+        impl $imp<&$res> for $res {
             type Output = $res;
 
             #[inline]
@@ -76,7 +76,7 @@ macro_rules! forward_val_ref_binop {
 
 macro_rules! forward_ref_ref_binop {
     (impl $imp:ident for $res:ty, $method:ident) => {
-        impl<'a, 'b> $imp<&'b $res> for &'a $res {
+        impl $imp<&$res> for &$res {
             type Output = $res;
 
             #[inline]
@@ -90,7 +90,7 @@ macro_rules! forward_ref_ref_binop {
 
 macro_rules! forward_ref_ref_binop_commutative {
     (impl $imp:ident for $res:ty, $method:ident) => {
-        impl<'a, 'b> $imp<&'b $res> for &'a $res {
+        impl $imp<&$res> for &$res {
             type Output = $res;
 
             #[inline]
@@ -167,7 +167,7 @@ macro_rules! forward_scalar_val_val_binop_to_ref_val {
 
 macro_rules! forward_scalar_ref_ref_binop_to_ref_val {
     (impl $imp:ident<$scalar:ty> for $res:ty, $method:ident) => {
-        impl<'a, 'b> $imp<&'b $scalar> for &'a $res {
+        impl $imp<&$scalar> for &$res {
             type Output = $res;
 
             #[inline]
@@ -176,7 +176,7 @@ macro_rules! forward_scalar_ref_ref_binop_to_ref_val {
             }
         }
 
-        impl<'a, 'b> $imp<&'a $res> for &'b $scalar {
+        impl $imp<&$res> for &$scalar {
             type Output = $res;
 
             #[inline]
@@ -189,7 +189,7 @@ macro_rules! forward_scalar_ref_ref_binop_to_ref_val {
 
 macro_rules! forward_scalar_val_ref_binop_to_ref_val {
     (impl $imp:ident<$scalar:ty> for $res:ty, $method:ident) => {
-        impl<'a> $imp<&'a $scalar> for $res {
+        impl $imp<&$scalar> for $res {
             type Output = $res;
 
             #[inline]
@@ -198,7 +198,7 @@ macro_rules! forward_scalar_val_ref_binop_to_ref_val {
             }
         }
 
-        impl<'a> $imp<$res> for &'a $scalar {
+        impl $imp<$res> for &$scalar {
             type Output = $res;
 
             #[inline]
@@ -211,7 +211,7 @@ macro_rules! forward_scalar_val_ref_binop_to_ref_val {
 
 macro_rules! forward_scalar_val_ref_binop_to_val_val {
     (impl $imp:ident<$scalar:ty> for $res:ty, $method:ident) => {
-        impl<'a> $imp<&'a $scalar> for $res {
+        impl $imp<&$scalar> for $res {
             type Output = $res;
 
             #[inline]
@@ -220,7 +220,7 @@ macro_rules! forward_scalar_val_ref_binop_to_val_val {
             }
         }
 
-        impl<'a> $imp<$res> for &'a $scalar {
+        impl $imp<$res> for &$scalar {
             type Output = $res;
 
             #[inline]
@@ -233,7 +233,7 @@ macro_rules! forward_scalar_val_ref_binop_to_val_val {
 
 macro_rules! forward_scalar_ref_val_binop_to_val_val {
     (impl $imp:ident < $scalar:ty > for $res:ty, $method:ident) => {
-        impl<'a> $imp<$scalar> for &'a $res {
+        impl $imp<$scalar> for &$res {
             type Output = $res;
 
             #[inline]
@@ -242,7 +242,7 @@ macro_rules! forward_scalar_ref_val_binop_to_val_val {
             }
         }
 
-        impl<'a> $imp<&'a $res> for $scalar {
+        impl $imp<&$res> for $scalar {
             type Output = $res;
 
             #[inline]
@@ -255,7 +255,7 @@ macro_rules! forward_scalar_ref_val_binop_to_val_val {
 
 macro_rules! forward_scalar_ref_ref_binop_to_val_val {
     (impl $imp:ident<$scalar:ty> for $res:ty, $method:ident) => {
-        impl<'a, 'b> $imp<&'b $scalar> for &'a $res {
+        impl $imp<&$scalar> for &$res {
             type Output = $res;
 
             #[inline]
@@ -264,7 +264,7 @@ macro_rules! forward_scalar_ref_ref_binop_to_val_val {
             }
         }
 
-        impl<'a, 'b> $imp<&'a $res> for &'b $scalar {
+        impl $imp<&$res> for &$scalar {
             type Output = $res;
 
             #[inline]


### PR DESCRIPTION
Out of 110 lifetime generics in 20 files, only 23 in 4 files were necessary for compilation. This should make code more readable and not affect behavior in any way.

Hopefully this works. I tested it locally on both 1.31 and the latest version 1.59.