### PR TITLE
Add From<bool> for BigInt and BigUint

### DIFF
--- a/src/bigint/convert.rs
+++ b/src/bigint/convert.rs
@@ -10,7 +10,7 @@ use core::cmp::Ordering::{Equal, Greater, Less};
 #[cfg(has_try_from)]
 use core::convert::TryFrom;
 use core::str::{self, FromStr};
-use num_traits::{FromPrimitive, Num, ToPrimitive, Zero};
+use num_traits::{FromPrimitive, Num, One, ToPrimitive, Zero};
 
 impl FromStr for BigInt {
     type Err = ParseBigIntError;
@@ -366,6 +366,16 @@ impl_to_bigint!(u128, FromPrimitive::from_u128);
 
 impl_to_bigint!(f32, FromPrimitive::from_f32);
 impl_to_bigint!(f64, FromPrimitive::from_f64);
+
+impl From<bool> for BigInt {
+    fn from(x: bool) -> Self {
+        if x {
+            One::one()
+        } else {
+            Zero::zero()
+        }
+    }
+}
 
 #[inline]
 pub(super) fn from_signed_bytes_be(digits: &[u8]) -> BigInt {

--- a/src/biguint/convert.rs
+++ b/src/biguint/convert.rs
@@ -17,7 +17,7 @@ use core::mem;
 use core::str::FromStr;
 use num_integer::{Integer, Roots};
 use num_traits::float::FloatCore;
-use num_traits::{FromPrimitive, Num, PrimInt, ToPrimitive, Zero};
+use num_traits::{FromPrimitive, Num, One, PrimInt, ToPrimitive, Zero};
 
 /// Find last set bit
 /// fls(0) == 0, fls(u32::MAX) == 32
@@ -571,6 +571,16 @@ impl_to_biguint!(u128, FromPrimitive::from_u128);
 
 impl_to_biguint!(f32, FromPrimitive::from_f32);
 impl_to_biguint!(f64, FromPrimitive::from_f64);
+
+impl From<bool> for BigUint {
+    fn from(x: bool) -> Self {
+        if x {
+            One::one()
+        } else {
+            Zero::zero()
+        }
+    }
+}
 
 // Extract bitwise digits that evenly divide BigDigit
 pub(super) fn to_bitwise_digits_le(u: &BigUint, bits: u8) -> Vec<u8> {


### PR DESCRIPTION
`From<bool> for {numeric}` has been around in `std` since 1.28, so it would make sense to have it for `BigInt` and `BigUint` too.