### PR TITLE
Update and simplify the CI workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -30,7 +30,7 @@ jobs:
           profile: minimal
           override: true
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Build
         uses: actions-rs/cargo@v1
         with:
@@ -54,7 +54,7 @@ jobs:
           profile: minimal
           override: true
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v3
       - name: Build
         uses: actions-rs/cargo@v1
         with:
@@ -75,7 +75,7 @@ jobs:
           override: true
           target: thumbv6m-none-eabi
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v3
       - name: Build
         uses: actions-rs/cargo@v1
         with:
@@ -94,7 +94,7 @@ jobs:
           override: true
           components: rustfmt
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Check formatting
         uses: actions-rs/cargo@v1
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,60 +23,45 @@ jobs:
           nightly
         ]
     steps:
-      - name: Rust install
-        uses: dtolnay/rust-toolchain@master
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.rust }}
-      - name: Checkout
-        uses: actions/checkout@v3
-      - name: Build
-        run: cargo build
-      - name: Test
-        run: ./ci/test_full.sh
+      - run: cargo build
+      - run: ./ci/test_full.sh
 
   # try a target with `BigDigit = u32`
   i686:
     name: Test (i686)
     runs-on: ubuntu-latest
     steps:
-      - name: System install
-        run: |
+      - run: |
           sudo apt-get update
           sudo apt-get install gcc-multilib
-      - name: Rust install
-        uses: dtolnay/rust-toolchain@master
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: stable-i686-unknown-linux-gnu
-      - name: Checkout
-        uses: actions/checkout@v3
-      - name: Build
-        run: cargo build
-      - name: Test
-        run: ./ci/test_full.sh
+      - run: cargo build
+      - run: ./ci/test_full.sh
 
   # try a target that doesn't have std at all, but does have alloc
   no_std:
     name: No Std
     runs-on: ubuntu-latest
     steps:
-      - name: Rust install
-        uses: dtolnay/rust-toolchain@stable
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@stable
         with:
           target: thumbv6m-none-eabi
-      - name: Checkout
-        uses: actions/checkout@v3
-      - name: Build
-        run: cargo build --target thumbv6m-none-eabi --no-default-features --features "serde rand"
+      - run: cargo build --target thumbv6m-none-eabi --no-default-features --features "serde rand"
 
   fmt:
     name: Format
     runs-on: ubuntu-latest
     steps:
-      - name: Rust install
-        uses: dtolnay/rust-toolchain@1.62.0
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@1.62.0
         with:
           components: rustfmt
-      - name: Checkout
-        uses: actions/checkout@v3
-      - name: Check formatting
-        run: cargo fmt --all --check
+      - run: cargo fmt --all --check

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -30,9 +30,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Build
-        uses: actions-rs/cargo@v1
-        with:
-          command: build
+        run: cargo build
       - name: Test
         run: ./ci/test_full.sh
 
@@ -52,9 +50,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Build
-        uses: actions-rs/cargo@v1
-        with:
-          command: build
+        run: cargo build
       - name: Test
         run: ./ci/test_full.sh
 
@@ -70,10 +66,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Build
-        uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --target thumbv6m-none-eabi --no-default-features --features "serde rand"
+        run: cargo build --target thumbv6m-none-eabi --no-default-features --features "serde rand"
 
   fmt:
     name: Format
@@ -86,7 +79,4 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Check formatting
-        uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --all --check
+        run: cargo fmt --all --check

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,11 +24,9 @@ jobs:
         ]
     steps:
       - name: Rust install
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.rust }}
-          profile: minimal
-          override: true
       - name: Checkout
         uses: actions/checkout@v3
       - name: Build
@@ -48,11 +46,9 @@ jobs:
           sudo apt-get update
           sudo apt-get install gcc-multilib
       - name: Rust install
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
           toolchain: stable-i686-unknown-linux-gnu
-          profile: minimal
-          override: true
       - name: Checkout
         uses: actions/checkout@v3
       - name: Build
@@ -68,11 +64,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Rust install
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: stable
-          profile: minimal
-          override: true
           target: thumbv6m-none-eabi
       - name: Checkout
         uses: actions/checkout@v3
@@ -87,11 +80,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Rust install
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@1.62.0
         with:
-          toolchain: 1.54.0
-          profile: minimal
-          override: true
           components: rustfmt
       - name: Checkout
         uses: actions/checkout@v3
@@ -99,4 +89,4 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: fmt
-          args: --all -- --check
+          args: --all --check

--- a/.github/workflows/master.yaml
+++ b/.github/workflows/master.yaml
@@ -22,7 +22,7 @@ jobs:
           profile: minimal
           override: true
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Build
         uses: actions-rs/cargo@v1
         with:

--- a/.github/workflows/master.yaml
+++ b/.github/workflows/master.yaml
@@ -22,8 +22,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Build
-        uses: actions-rs/cargo@v1
-        with:
-          command: build
+        run: cargo build
       - name: Test
         run: ./ci/test_full.sh

--- a/.github/workflows/master.yaml
+++ b/.github/workflows/master.yaml
@@ -15,13 +15,9 @@ jobs:
       matrix:
         rust: [1.31.0, stable]
     steps:
-      - name: Rust install
-        uses: dtolnay/rust-toolchain@master
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.rust }}
-      - name: Checkout
-        uses: actions/checkout@v3
-      - name: Build
-        run: cargo build
-      - name: Test
-        run: ./ci/test_full.sh
+      - run: cargo build
+      - run: ./ci/test_full.sh

--- a/.github/workflows/master.yaml
+++ b/.github/workflows/master.yaml
@@ -16,11 +16,9 @@ jobs:
         rust: [1.31.0, stable]
     steps:
       - name: Rust install
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.rust }}
-          profile: minimal
-          override: true
       - name: Checkout
         uses: actions/checkout@v3
       - name: Build

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -18,9 +18,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Build
-        uses: actions-rs/cargo@v1
-        with:
-          command: build
+        run: cargo build
       - name: Test
         run: ./ci/test_full.sh
 
@@ -35,7 +33,4 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Check formatting
-        uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --all --check
+        run: cargo fmt --all --check

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -18,7 +18,7 @@ jobs:
           profile: minimal
           override: true
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Build
         uses: actions-rs/cargo@v1
         with:
@@ -38,7 +38,7 @@ jobs:
           override: true
           components: rustfmt
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Check formatting
         uses: actions-rs/cargo@v1
         with:

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -11,26 +11,19 @@ jobs:
       matrix:
         rust: [1.31.0, stable]
     steps:
-      - name: Rust install
-        uses: dtolnay/rust-toolchain@master
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.rust }}
-      - name: Checkout
-        uses: actions/checkout@v3
-      - name: Build
-        run: cargo build
-      - name: Test
-        run: ./ci/test_full.sh
+      - run: cargo build
+      - run: ./ci/test_full.sh
 
   fmt:
     name: Format
     runs-on: ubuntu-latest
     steps:
-      - name: Rust install
-        uses: dtolnay/rust-toolchain@1.62.0
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@1.62.0
         with:
           components: rustfmt
-      - name: Checkout
-        uses: actions/checkout@v3
-      - name: Check formatting
-        run: cargo fmt --all --check
+      - run: cargo fmt --all --check

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -12,11 +12,9 @@ jobs:
         rust: [1.31.0, stable]
     steps:
       - name: Rust install
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.rust }}
-          profile: minimal
-          override: true
       - name: Checkout
         uses: actions/checkout@v3
       - name: Build
@@ -31,11 +29,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Rust install
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@1.62.0
         with:
-          toolchain: 1.54.0
-          profile: minimal
-          override: true
           components: rustfmt
       - name: Checkout
         uses: actions/checkout@v3
@@ -43,4 +38,4 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: fmt
-          args: --all -- --check
+          args: --all --check


### PR DESCRIPTION
- Update to actions/checkout@v3
- Switch from actions-rs/toolchain to dtolnay/rust-toolchain
- Switch from actions-rs/cargo to plain run
- Stop explicitly naming CI steps
