### PR TITLE
Update alternatives list

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,8 +53,8 @@ table offers a brief comparison to a few alternatives.
 | Crate             | License        | Min rustc | Implementation | Features |
 | :---------------  | :------------- | :-------- | :------------- | :------- |
 | **`num-bigint`**  | MIT/Apache-2.0 | 1.31      | pure rust | dynamic width, number theoretical functions |
-| [`rug`]           | LGPL-3.0+      | 1.37      | bundles [GMP] via [`gmp-mpfr-sys`] | all the features of GMP, MPFR, and MPC |
-| [`awint`]         | MIT/Apache-2.0 | 1.61      | pure rust | fixed width, heap or stack, concatenation macros |
+| [`rug`]           | LGPL-3.0+      | 1.65      | bundles [GMP] via [`gmp-mpfr-sys`] | all the features of GMP, MPFR, and MPC |
+| [`awint`]         | MIT/Apache-2.0 | 1.66      | pure rust | fixed width, heap or stack, concatenation macros |
 | [`bnum`]          | MIT/Apache-2.0 | 1.61      | pure rust | fixed width, parity with Rust primitives including floats |
 | [`ibig`]          | MIT/Apache-2.0 | 1.49      | pure rust | dynamic width, number theoretical functions |
 | [`crypto-bigint`] | MIT/Apache-2.0 | 1.57      | pure rust | fixed width, stack only |

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ table offers a brief comparison to a few alternatives.
 [`rug`]: https://crates.io/crates/rug
 [`awint`]: https://crates.io/crates/awint
 [`bnum`]: https://crates.io/crates/bnum
-[`ibig`]: https://github.com/tczajka/ibig-rs
+[`ibig`]: https://crates.io/crates/ibig
 [`crypto-bigint`]: https://crates.io/crates/crypto-bigint
 
 ## License

--- a/README.md
+++ b/README.md
@@ -50,20 +50,22 @@ While `num-bigint` strives for good performance in pure Rust code, other
 crates may offer better performance with different trade-offs.  The following
 table offers a brief comparison to a few alternatives.
 
-| Crate            | License        | Min rustc | Implementation |
-| :--------------- | :------------- | :-------- | :------------- |
-| **`num-bigint`** | MIT/Apache-2.0 | 1.31      | pure rust |
-| [`ramp`]         | Apache-2.0     | nightly   | rust and inline assembly (no longer maintained) |
-| [`rug`]          | LGPL-3.0+      | 1.37      | bundles [GMP] via [`gmp-mpfr-sys`] |
-| [`rust-gmp`]     | MIT            | stable?   | links to [GMP] |
-| [`apint`]        | MIT/Apache-2.0 | 1.26      | pure rust (unfinished) |
+| Crate             | License        | Min rustc | Implementation | Features |
+| :---------------  | :------------- | :-------- | :------------- | :------- |
+| **`num-bigint`**  | MIT/Apache-2.0 | 1.31      | pure rust | dynamic width, number theoretical functions |
+| [`rug`]           | LGPL-3.0+      | 1.37      | bundles [GMP] via [`gmp-mpfr-sys`] | all the features of GMP, MPFR, and MPC |
+| [`awint`]         | MIT/Apache-2.0 | 1.61      | pure rust | fixed width, heap or stack, concatenation macros |
+| [`bnum`]          | MIT/Apache-2.0 | 1.61      | pure rust | fixed width, parity with Rust primitives including floats |
+| [`ibig`]          | MIT/Apache-2.0 | 1.49      | pure rust | dynamic width, number theoretical functions |
+| [`crypto-bigint`] | MIT/Apache-2.0 | 1.57      | pure rust | fixed width, stack only |
 
 [GMP]: https://gmplib.org/
 [`gmp-mpfr-sys`]: https://crates.io/crates/gmp-mpfr-sys
 [`rug`]: https://crates.io/crates/rug
-[`rust-gmp`]: https://crates.io/crates/rust-gmp
-[`ramp`]: https://crates.io/crates/ramp
-[`apint`]: https://crates.io/crates/apint
+[`awint`]: https://crates.io/crates/awint
+[`bnum`]: https://crates.io/crates/bnum
+[`ibig`]: https://github.com/tczajka/ibig-rs
+[`crypto-bigint`]: https://crates.io/crates/crypto-bigint
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -53,19 +53,20 @@ table offers a brief comparison to a few alternatives.
 | Crate             | License        | Min rustc | Implementation | Features |
 | :---------------  | :------------- | :-------- | :------------- | :------- |
 | **`num-bigint`**  | MIT/Apache-2.0 | 1.31      | pure rust | dynamic width, number theoretical functions |
-| [`rug`]           | LGPL-3.0+      | 1.65      | bundles [GMP] via [`gmp-mpfr-sys`] | all the features of GMP, MPFR, and MPC |
 | [`awint`]         | MIT/Apache-2.0 | 1.66      | pure rust | fixed width, heap or stack, concatenation macros |
 | [`bnum`]          | MIT/Apache-2.0 | 1.61      | pure rust | fixed width, parity with Rust primitives including floats |
-| [`ibig`]          | MIT/Apache-2.0 | 1.49      | pure rust | dynamic width, number theoretical functions |
 | [`crypto-bigint`] | MIT/Apache-2.0 | 1.57      | pure rust | fixed width, stack only |
+| [`ibig`]          | MIT/Apache-2.0 | 1.49      | pure rust | dynamic width, number theoretical functions |
+| [`rug`]           | LGPL-3.0+      | 1.65      | bundles [GMP] via [`gmp-mpfr-sys`] | all the features of GMP, MPFR, and MPC |
+
+[`awint`]: https://crates.io/crates/awint
+[`bnum`]: https://crates.io/crates/bnum
+[`crypto-bigint`]: https://crates.io/crates/crypto-bigint
+[`ibig`]: https://crates.io/crates/ibig
+[`rug`]: https://crates.io/crates/rug
 
 [GMP]: https://gmplib.org/
 [`gmp-mpfr-sys`]: https://crates.io/crates/gmp-mpfr-sys
-[`rug`]: https://crates.io/crates/rug
-[`awint`]: https://crates.io/crates/awint
-[`bnum`]: https://crates.io/crates/bnum
-[`ibig`]: https://crates.io/crates/ibig
-[`crypto-bigint`]: https://crates.io/crates/crypto-bigint
 
 ## License
 


### PR DESCRIPTION
`rust-gmp`, `ramp`, and `apint` are all unmaintained so I removed them. I added a column for fundamental features the crates have and added some new rows.