### PR TITLE
Carry only single word in multiplication

### DIFF
--- a/src/biguint/convert.rs
+++ b/src/biguint/convert.rs
@@ -2,7 +2,7 @@ use super::{biguint_from_vec, BigUint, ToBigUint};
 
 use super::addition::add2;
 use super::division::div_rem_digit;
-use super::multiplication::mac_with_carry;
+use super::multiplication::mul_with_carry;
 
 use crate::big_digit::{self, BigDigit};
 use crate::std_alloc::Vec;
@@ -132,7 +132,7 @@ fn from_radix_digits_be(v: &[u8], radix: u32) -> BigUint {
 
         let mut carry = 0;
         for d in data.iter_mut() {
-            *d = mac_with_carry(0, *d, base, &mut carry);
+            mul_with_carry(d, base, &mut carry);
         }
         debug_assert!(carry == 0);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -277,7 +277,7 @@ mod big_digit {
     }
     #[inline]
     fn get_lo(n: DoubleBigDigit) -> BigDigit {
-        (n & LO_MASK) as BigDigit
+        n as BigDigit
     }
 
     /// Split one `DoubleBigDigit` into two `BigDigit`s.


### PR DESCRIPTION
The carry from a multiply or a multiply-accumulate is a single word,
so update the functions to clarify that. Use a temporary double word for the
computation. And rename "acc" to "carry" to distinguish from the accumulator.

Also use multiply instead of multiply-accumulate for string conversions.

And remove an unnecessary mask in get_lo().