### PR TITLE
Add support for conversions to ICU4X FixedDecimal

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,9 +17,10 @@ edition = "2018"
 [features]
 default = ["std"]
 std = ["num-integer/std", "num-traits/std"]
+icu = ["fixed_decimal"]
 
 [package.metadata.docs.rs]
-features = ["std", "serde", "rand", "quickcheck", "arbitrary"]
+features = ["std", "serde", "rand", "quickcheck", "arbitrary", "icu"]
 
 [[bench]]
 name = "bigint"
@@ -67,6 +68,11 @@ default-features = false
 [dependencies.arbitrary]
 optional = true
 version = "1"
+default-features = false
+
+[dependencies.fixed_decimal]
+optional = true
+version = "0.5"
 default-features = false
 
 [build-dependencies]

--- a/tests/bigint.rs
+++ b/tests/bigint.rs
@@ -4,6 +4,8 @@ use num_bigint::{BigInt, ToBigInt};
 
 use std::cmp::Ordering::{Equal, Greater, Less};
 use std::collections::hash_map::RandomState;
+#[cfg(all(feature = "icu", has_try_from))]
+use std::convert::TryFrom;
 use std::hash::{BuildHasher, Hash, Hasher};
 use std::iter::repeat;
 use std::ops::Neg;
@@ -17,6 +19,9 @@ use num_traits::{pow, FromPrimitive, Num, One, Pow, Signed, ToPrimitive, Zero};
 
 mod consts;
 use crate::consts::*;
+
+#[cfg(all(feature = "icu", has_try_from))]
+use fixed_decimal::FixedDecimal;
 
 #[macro_use]
 mod macros;
@@ -650,6 +655,31 @@ fn test_convert_from_biguint() {
         BigInt::from(BigUint::from_slice(&[1, 2, 3])),
         BigInt::from_slice(Plus, &[1, 2, 3])
     );
+}
+
+#[test]
+#[cfg(all(feature = "icu", has_try_from))]
+fn test_convert_to_fixeddecimal() {
+    assert_eq!(
+        FixedDecimal::try_from(BigInt::zero()).unwrap(),
+        FixedDecimal::from(0)
+    );
+
+    assert_eq!(
+        FixedDecimal::try_from(BigInt::one()).unwrap(),
+        FixedDecimal::from(1)
+    );
+
+    assert_eq!(
+        FixedDecimal::try_from(-BigInt::one()).unwrap(),
+        FixedDecimal::from(-1)
+    );
+
+    let src_digits = "-387585729452378942174981728917891273198237198237123";
+    assert_eq!(
+        FixedDecimal::try_from(BigInt::from_str_radix(src_digits, 10).unwrap()).unwrap(),
+        src_digits.parse::<FixedDecimal>().unwrap()
+    )
 }
 
 #[test]

--- a/tests/biguint.rs
+++ b/tests/biguint.rs
@@ -5,6 +5,8 @@ use num_integer::Integer;
 
 use std::cmp::Ordering::{Equal, Greater, Less};
 use std::collections::hash_map::RandomState;
+#[cfg(all(feature = "icu", has_try_from))]
+use std::convert::TryFrom;
 use std::hash::{BuildHasher, Hash, Hasher};
 use std::i64;
 use std::iter::repeat;
@@ -17,6 +19,9 @@ use num_traits::{
     pow, CheckedAdd, CheckedDiv, CheckedMul, CheckedSub, FromPrimitive, Num, One, Pow, ToPrimitive,
     Zero,
 };
+
+#[cfg(all(feature = "icu", has_try_from))]
+use fixed_decimal::FixedDecimal;
 
 mod consts;
 use crate::consts::*;
@@ -769,6 +774,26 @@ fn test_convert_to_bigint() {
         BigUint::new(vec![1, 2, 3]),
         BigInt::from_biguint(Plus, BigUint::new(vec![1, 2, 3])),
     );
+}
+
+#[test]
+#[cfg(all(feature = "icu", has_try_from))]
+fn test_convert_to_fixeddecimal() {
+    assert_eq!(
+        FixedDecimal::try_from(BigUint::zero()).unwrap(),
+        FixedDecimal::from(0)
+    );
+
+    assert_eq!(
+        FixedDecimal::try_from(BigUint::one()).unwrap(),
+        FixedDecimal::from(1)
+    );
+
+    let src_digits = "387585729452378942174981728917891273198237198237123";
+    assert_eq!(
+        FixedDecimal::try_from(BigUint::from_str_radix(src_digits, 10).unwrap()).unwrap(),
+        src_digits.parse::<FixedDecimal>().unwrap()
+    )
 }
 
 #[test]


### PR DESCRIPTION
Feature-gated support for fallible conversion to the `FixedDecimal` type used with ICU4X, enabling localized formatting of `BigInt` and `BigUint`. I've used the `icu` feature as the gate here as I thought this would be friendlier than using `fixed_decimal` directly.