### PR TITLE
Implement ties-to-even for Big[U]Int::to_{f32,f64}

### DIFF
--- a/ci/big_quickcheck/src/lib.rs
+++ b/ci/big_quickcheck/src/lib.rs
@@ -8,7 +8,7 @@
 
 use num_bigint::{BigInt, BigUint};
 use num_integer::Integer;
-use num_traits::{Num, One, Signed, Zero};
+use num_traits::{Num, One, Signed, ToPrimitive, Zero};
 use quickcheck::{Gen, QuickCheck, TestResult};
 use quickcheck_macros::quickcheck;
 
@@ -356,4 +356,21 @@ fn quickcheck_modpow() {
     }
 
     qc.quickcheck(test_modpow as fn(i128, u128, i128) -> TestResult);
+}
+
+#[test]
+fn quickcheck_to_float_equals_i128_cast() {
+    let gen = Gen::new(usize::max_value());
+    let mut qc = QuickCheck::new().gen(gen).tests(1_000_000);
+
+    fn to_f32_equals_i128_cast(value: i128) -> bool {
+        BigInt::from(value).to_f32() == Some(value as f32)
+    }
+
+    fn to_f64_equals_i128_cast(value: i128) -> bool {
+        BigInt::from(value).to_f64() == Some(value as f64)
+    }
+
+    qc.quickcheck(to_f32_equals_i128_cast as fn(i128) -> bool);
+    qc.quickcheck(to_f64_equals_i128_cast as fn(i128) -> bool);
 }

--- a/tests/bigint.rs
+++ b/tests/bigint.rs
@@ -415,6 +415,13 @@ fn test_convert_f32() {
         b <<= 1;
     }
 
+    // test correct ties-to-even rounding
+    let weird: i128 = (1i128 << 100) + (1i128 << (100 - f32::MANTISSA_DIGITS));
+    assert_ne!(weird as f32, (weird + 1) as f32);
+
+    assert_eq!(BigInt::from(weird).to_f32(), Some(weird as f32));
+    assert_eq!(BigInt::from(weird + 1).to_f32(), Some((weird + 1) as f32));
+
     // rounding
     assert_eq!(
         BigInt::from_f32(-f32::consts::PI),
@@ -504,6 +511,13 @@ fn test_convert_f64() {
         f *= 2.0;
         b <<= 1;
     }
+
+    // test correct ties-to-even rounding
+    let weird: i128 = (1i128 << 100) + (1i128 << (100 - f64::MANTISSA_DIGITS));
+    assert_ne!(weird as f64, (weird + 1) as f64);
+
+    assert_eq!(BigInt::from(weird).to_f64(), Some(weird as f64));
+    assert_eq!(BigInt::from(weird + 1).to_f64(), Some((weird + 1) as f64));
 
     // rounding
     assert_eq!(

--- a/tests/biguint.rs
+++ b/tests/biguint.rs
@@ -646,6 +646,13 @@ fn test_convert_f32() {
         b <<= 1;
     }
 
+    // test correct ties-to-even rounding
+    let weird: i128 = (1i128 << 100) + (1i128 << (100 - f32::MANTISSA_DIGITS));
+    assert_ne!(weird as f32, (weird + 1) as f32);
+
+    assert_eq!(BigInt::from(weird).to_f32(), Some(weird as f32));
+    assert_eq!(BigInt::from(weird + 1).to_f32(), Some((weird + 1) as f32));
+
     // rounding
     assert_eq!(BigUint::from_f32(-1.0), None);
     assert_eq!(BigUint::from_f32(-0.99999), Some(BigUint::zero()));
@@ -721,6 +728,13 @@ fn test_convert_f64() {
         f *= 2.0;
         b <<= 1;
     }
+
+    // test correct ties-to-even rounding
+    let weird: i128 = (1i128 << 100) + (1i128 << (100 - f64::MANTISSA_DIGITS));
+    assert_ne!(weird as f64, (weird + 1) as f64);
+
+    assert_eq!(BigInt::from(weird).to_f64(), Some(weird as f64));
+    assert_eq!(BigInt::from(weird + 1).to_f64(), Some((weird + 1) as f64));
 
     // rounding
     assert_eq!(BigUint::from_f64(-1.0), None);


### PR DESCRIPTION
This makes the rounding consistent with primitive types, which, per IEEE-754, uses nearest-ties-to-even rounding.

See: https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&gist=a6ab9b18a4982f881cd594061f096f8c

```rust
#[test]
fn test() {
    use num::{BigInt, ToPrimitive};
    let a: i128 = (1 << 120) + (1 << (120 - 53));
    let b: i128 = 1 << (120 - 60);
    assert_ne!(a as f64, (a + 1) as f64);
    assert_eq!((a + b) as f64, (a + 1) as f64);

    assert_eq!(BigInt::from(a).to_f64().unwrap(), a as f64);
    
    // This works because the b is among the high 64 bits
    assert_eq!(BigInt::from(a + b).to_f64().unwrap(), (a + b) as f64);

    // This fails because 1 is just thrown away
    assert_eq!(BigInt::from(a + 1).to_f64().unwrap(), (a + 1) as f64);
}
```
