### PR TITLE
Add true_division: divides 2 big integers and returns a f64

### DIFF
--- a/src/bigint.rs
+++ b/src/bigint.rs
@@ -24,6 +24,7 @@ mod addition;
 mod division;
 mod multiplication;
 mod subtraction;
+mod true_division;
 
 mod bits;
 mod convert;

--- a/src/bigint/true_division.rs
+++ b/src/bigint/true_division.rs
@@ -1,0 +1,12 @@
+use crate::{BigInt, Sign::*};
+
+impl BigInt {
+    pub fn true_div(&self, other: &BigInt) -> f64 {
+        let d = self.data.true_div(&other.data);
+        match (self.sign, other.sign) {
+            (Plus, Plus) | (NoSign, Plus) | (Minus, Minus) => d,
+            (Plus, Minus) | (NoSign, Minus) | (Minus, Plus) => -d,
+            (_, NoSign) => unreachable!(),
+        }
+    }
+}

--- a/src/biguint.rs
+++ b/src/biguint.rs
@@ -17,6 +17,7 @@ mod addition;
 mod division;
 mod multiplication;
 mod subtraction;
+mod true_division;
 
 mod bits;
 mod convert;

--- a/src/biguint/true_division.rs
+++ b/src/biguint/true_division.rs
@@ -1,0 +1,42 @@
+use num_integer::Integer;
+use num_traits::ToPrimitive;
+
+use crate::BigUint;
+
+impl BigUint {
+    pub fn true_div(&self, other: &BigUint) -> f64 {
+        // Compute exponent, biased by 52 (or 53)
+        let mut exponent =
+            (self.bits() as i32) - (other.bits() as i32) - (f64::MANTISSA_DIGITS as i32);
+
+        // Actual division, where the rhs is shifted, so that
+        // the quotient must have 52 or 53 bits in length
+        let rhs = match exponent {
+            i if i > 0 => self >> i,
+            i if i < 0 => self << -i,
+            _ => self.clone(),
+        };
+        let (mut q, r) = rhs.div_rem(other);
+
+        // rounding
+        if r > (other >> 1) {
+            q += 1u32;
+        }
+
+        // Get the exact 53 bits of mantissa and actual exponent
+        let extra_bits = q.bits() as u32 - f64::MANTISSA_DIGITS;
+        q >>= extra_bits;
+        exponent += (f64::MANTISSA_DIGITS + extra_bits - 1) as i32;
+
+        // Handle overflow or underflow
+        if exponent > core::f64::MAX_EXP {
+            return f64::INFINITY;
+        } else if exponent < core::f64::MIN_EXP {
+            return 0f64;
+        }
+
+        // Get actual mantissa as float and apply exponent
+        let mantissa_as_float = q.to_f64().unwrap() * 2.0f64.powi(1 - f64::MANTISSA_DIGITS as i32);
+        mantissa_as_float * 2.0f64.powi(exponent)
+    }
+}

--- a/tests/bigint.rs
+++ b/tests/bigint.rs
@@ -1416,3 +1416,18 @@ fn test_set_bit() {
     x.set_bit(0, false);
     assert_eq!(x, BigInt::from_biguint(Minus, BigUint::one() << 200));
 }
+
+#[test]
+fn test_true_division() {
+    let n1: BigInt = "123456678890123345567789".parse().unwrap();
+    let n2: BigInt = "-12345667555".parse().unwrap();
+    let f = n1.true_div(&n2);
+    let true_div = -10000000270550.242f64;
+    assert_eq!(f, true_div);
+
+    let n2: BigInt = "-123456678890123345567789".parse().unwrap();
+    let n1: BigInt = "-12345667555".parse().unwrap();
+    let f = n1.true_div(&n2);
+    let true_div = 9.999999729449765e-14f64;
+    assert_eq!(f, true_div);
+}

--- a/tests/biguint.rs
+++ b/tests/biguint.rs
@@ -1874,3 +1874,42 @@ fn test_set_bit() {
     x.set_bit(1, false);
     assert_eq!(x, BigUint::zero());
 }
+
+#[test]
+fn test_true_division() {
+    let n1: BigUint = "123456678890123345567789".parse().unwrap();
+    let n2: BigUint = "12345667555".parse().unwrap();
+    let f = n1.true_div(&n2);
+    let true_div = 10000000270550.242f64;
+    assert_eq!(f, true_div);
+
+    let n1: BigUint = "123456678890123345567789".parse::<BigUint>().unwrap() << 15;
+    let n2: BigUint = "12345667555".parse().unwrap();
+    let f = n1.true_div(&n2);
+    let true_div = 3.2768000886539034e+17f64;
+    assert_eq!(f, true_div);
+
+    let n1: BigUint = "123456678890123345567789".parse::<BigUint>().unwrap() << 3030;
+    let n2: BigUint = "12345667555".parse().unwrap();
+    let f = n1.true_div(&n2);
+    let true_div = f64::INFINITY;
+    assert_eq!(f, true_div);
+
+    let n2: BigUint = "123456678890123345567789".parse().unwrap();
+    let n1: BigUint = "12345667555".parse().unwrap();
+    let f = n1.true_div(&n2);
+    let true_div = 9.999999729449765e-14f64;
+    assert_eq!(f, true_div);
+
+    let n2: BigUint = "12345667889012334556778900000000".parse().unwrap();
+    let n1: BigUint = "12345667555".parse().unwrap();
+    let f = n1.true_div(&n2);
+    let true_div = 9.999999729449765e-22f64;
+    assert_eq!(f, true_div);
+
+    let n1: BigUint = "12345667889012334556778900000000".parse().unwrap();
+    let n2: BigUint = "12345667555".parse().unwrap();
+    let f = n1.true_div(&n2);
+    let true_div = 1.0000000270550242e+21f64;
+    assert_eq!(f, true_div);
+}


### PR DESCRIPTION
Sometimes one would to divide 2 big integers to get a f64. Most of the time, one could convert them to f64 first and then dividing, but in some cases one can lose precision bits (and if they are really big they won't fit in a f64 at all, even though their quotient might).

This is achieved by shifting the rhs to be 53 bits longer than the lhs. The regular integer division is then guaranteed to be 53 or 54 bits long. Then final result packs this quotient as the mantissa, with the exponent.

I'm completely open to renaming/suggestions about how to make this better ! As a matter of fact, this might not be useful at all (I personally have not stumble upon a credible use case), but while building my own big integer library for fun (at github.com:twiby/bigint), I added it by symmetry with Python's `__truediv__`.

In fact, I've never contributed to open_source projects before, and I hope I'm not doing anything wrong in one way or another !