### PR TITLE
Clippy fixes

### DIFF
--- a/src/bigint/convert.rs
+++ b/src/bigint/convert.rs
@@ -389,7 +389,7 @@ pub(super) fn from_signed_bytes_be(digits: &[u8]) -> BigInt {
         // two's-complement the content to retrieve the magnitude
         let mut digits = Vec::from(digits);
         twos_complement_be(&mut digits);
-        BigInt::from_biguint(sign, BigUint::from_bytes_be(&*digits))
+        BigInt::from_biguint(sign, BigUint::from_bytes_be(&digits))
     } else {
         BigInt::from_biguint(sign, BigUint::from_bytes_be(digits))
     }
@@ -407,7 +407,7 @@ pub(super) fn from_signed_bytes_le(digits: &[u8]) -> BigInt {
         // two's-complement the content to retrieve the magnitude
         let mut digits = Vec::from(digits);
         twos_complement_le(&mut digits);
-        BigInt::from_biguint(sign, BigUint::from_bytes_le(&*digits))
+        BigInt::from_biguint(sign, BigUint::from_bytes_le(&digits))
     } else {
         BigInt::from_biguint(sign, BigUint::from_bytes_le(digits))
     }

--- a/src/biguint.rs
+++ b/src/biguint.rs
@@ -589,7 +589,7 @@ impl BigUint {
         } else {
             let mut v = bytes.to_vec();
             v.reverse();
-            BigUint::from_bytes_le(&*v)
+            BigUint::from_bytes_le(&v)
         }
     }
 

--- a/src/biguint/convert.rs
+++ b/src/biguint/convert.rs
@@ -1,3 +1,6 @@
+// This uses stdlib features higher than the MSRV
+#![allow(clippy::manual_range_contains)] // 1.35
+
 use super::{biguint_from_vec, BigUint, ToBigUint};
 
 use super::addition::add2;

--- a/src/biguint/monty.rs
+++ b/src/biguint/monty.rs
@@ -78,8 +78,8 @@ fn montgomery(x: &BigUint, y: &BigUint, m: &BigUint, k: BigDigit, n: usize) -> B
         z.data = z.data[n..].to_vec();
     } else {
         {
-            let (mut first, second) = z.data.split_at_mut(n);
-            sub_vv(&mut first, &second, &m.data);
+            let (first, second) = z.data.split_at_mut(n);
+            sub_vv(first, second, &m.data);
         }
         z.data = z.data[..n].to_vec();
     }

--- a/src/biguint/power.rs
+++ b/src/biguint/power.rs
@@ -225,27 +225,27 @@ fn test_plain_modpow() {
     let exp = vec![0, 0b1];
     assert_eq!(
         two.pow(0b1_00000000_u32) % &modulus,
-        plain_modpow(&two, &exp, &modulus)
+        plain_modpow(two, &exp, &modulus)
     );
     let exp = vec![0, 0b10];
     assert_eq!(
         two.pow(0b10_00000000_u32) % &modulus,
-        plain_modpow(&two, &exp, &modulus)
+        plain_modpow(two, &exp, &modulus)
     );
     let exp = vec![0, 0b110010];
     assert_eq!(
         two.pow(0b110010_00000000_u32) % &modulus,
-        plain_modpow(&two, &exp, &modulus)
+        plain_modpow(two, &exp, &modulus)
     );
     let exp = vec![0b1, 0b1];
     assert_eq!(
         two.pow(0b1_00000001_u32) % &modulus,
-        plain_modpow(&two, &exp, &modulus)
+        plain_modpow(two, &exp, &modulus)
     );
     let exp = vec![0b1100, 0, 0b1];
     assert_eq!(
         two.pow(0b1_00000000_00001100_u32) % &modulus,
-        plain_modpow(&two, &exp, &modulus)
+        plain_modpow(two, &exp, &modulus)
     );
 }
 

--- a/src/biguint/shift.rs
+++ b/src/biguint/shift.rs
@@ -35,7 +35,7 @@ fn biguint_shl2(n: Cow<'_, BigUint>, digits: usize, shift: u8) -> BigUint {
 
     if shift > 0 {
         let mut carry = 0;
-        let carry_shift = big_digit::BITS as u8 - shift;
+        let carry_shift = big_digit::BITS - shift;
         for elem in data[digits..].iter_mut() {
             let new_carry = *elem >> carry_shift;
             *elem = (*elem << shift) | carry;
@@ -79,7 +79,7 @@ fn biguint_shr2(n: Cow<'_, BigUint>, digits: usize, shift: u8) -> BigUint {
 
     if shift > 0 {
         let mut borrow = 0;
-        let borrow_shift = big_digit::BITS as u8 - shift;
+        let borrow_shift = big_digit::BITS - shift;
         for elem in data.iter_mut().rev() {
             let new_borrow = *elem << borrow_shift;
             *elem = (*elem >> shift) | borrow;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -94,7 +94,7 @@ extern crate std;
 #[cfg(feature = "std")]
 mod std_alloc {
     pub(crate) use std::borrow::Cow;
-    #[cfg(any(feature = "quickcheck"))]
+    #[cfg(feature = "quickcheck")]
     pub(crate) use std::boxed::Box;
     pub(crate) use std::string::String;
     pub(crate) use std::vec::Vec;
@@ -107,7 +107,7 @@ extern crate alloc;
 #[cfg(not(feature = "std"))]
 mod std_alloc {
     pub(crate) use alloc::borrow::Cow;
-    #[cfg(any(feature = "quickcheck"))]
+    #[cfg(feature = "quickcheck")]
     pub(crate) use alloc::boxed::Box;
     pub(crate) use alloc::string::String;
     pub(crate) use alloc::vec::Vec;

--- a/tests/bigint.rs
+++ b/tests/bigint.rs
@@ -187,7 +187,7 @@ fn test_signed_bytes_le_round_trip() {
 
 #[test]
 fn test_cmp() {
-    let vs: [&[u32]; 4] = [&[2 as u32], &[1, 1], &[2, 1], &[1, 1, 1]];
+    let vs: [&[u32]; 4] = [&[2_u32], &[1, 1], &[2, 1], &[1, 1, 1]];
     let mut nums = Vec::new();
     for s in vs.iter().rev() {
         nums.push(BigInt::from_slice(Minus, *s));

--- a/tests/modpow.rs
+++ b/tests/modpow.rs
@@ -120,7 +120,7 @@ mod bigint {
             let even_m = m << 1u8;
             let even_modpow = b.modpow(e, m);
             assert!(even_modpow.abs() < even_m.abs());
-            assert_eq!(&even_modpow.mod_floor(&m), r);
+            assert_eq!(&even_modpow.mod_floor(m), r);
 
             // the sign of the result follows the modulus like `mod_floor`, not `rem`
             assert_eq!(b.modpow(&BigInt::one(), m), b.mod_floor(m));


### PR DESCRIPTION
This fixes (or suppresses) all clippy warnings in the lib target. (It doesn't help for the test target.)