### PR TITLE
Implement number theoretic transform for large integer multiplication

### DIFF
--- a/benches/bigint.rs
+++ b/benches/bigint.rs
@@ -67,33 +67,48 @@ fn fib2(n: usize) -> BigUint {
 }
 
 #[bench]
-fn multiply_0(b: &mut Bencher) {
+fn multiply_8_8(b: &mut Bencher) {
     multiply_bench(b, 1 << 8, 1 << 8);
 }
 
 #[bench]
-fn multiply_1(b: &mut Bencher) {
+fn multiply_8_16(b: &mut Bencher) {
     multiply_bench(b, 1 << 8, 1 << 16);
 }
 
 #[bench]
-fn multiply_2(b: &mut Bencher) {
-    multiply_bench(b, 1 << 16, 1 << 16);
-}
-
-#[bench]
-fn multiply_3(b: &mut Bencher) {
-    multiply_bench(b, 1 << 16, 1 << 17);
-}
-
-#[bench]
-fn multiply_4(b: &mut Bencher) {
+fn multiply_12_13(b: &mut Bencher) {
     multiply_bench(b, 1 << 12, 1 << 13);
 }
 
 #[bench]
-fn multiply_5(b: &mut Bencher) {
+fn multiply_12_14(b: &mut Bencher) {
     multiply_bench(b, 1 << 12, 1 << 14);
+}
+
+#[bench]
+fn multiply_13_13(b: &mut Bencher) {
+    multiply_bench(b, 1 << 13, 1 << 13);
+}
+
+#[bench]
+fn multiply_14_14(b: &mut Bencher) {
+    multiply_bench(b, 1 << 14, 1 << 14);
+}
+
+#[bench]
+fn multiply_15_15(b: &mut Bencher) {
+    multiply_bench(b, 1 << 15, 1 << 15);
+}
+
+#[bench]
+fn multiply_16_16(b: &mut Bencher) {
+    multiply_bench(b, 1 << 16, 1 << 16);
+}
+
+#[bench]
+fn multiply_16_17(b: &mut Bencher) {
+    multiply_bench(b, 1 << 16, 1 << 17);
 }
 
 #[bench]

--- a/src/biguint.rs
+++ b/src/biguint.rs
@@ -24,6 +24,7 @@ mod bits;
 mod convert;
 mod iter;
 mod monty;
+mod ntt;
 mod power;
 mod serde;
 mod shift;

--- a/src/biguint/multiplication.rs
+++ b/src/biguint/multiplication.rs
@@ -420,7 +420,7 @@ fn mac3(mut acc: &mut [BigDigit], mut b: &[BigDigit], mut c: &[BigDigit]) {
         // NTT multiplies two integers by computing the convolution of the arrays
         // modulo a prime. Since the result may exceed the prime, we use two or three
         // distinct primes and combine the results using the Chinese Remainder
-        // Theroem (CRT).
+        // Theorem (CRT).
         ntt::mac3(acc, b, c);
     }
 }

--- a/src/biguint/multiplication.rs
+++ b/src/biguint/multiplication.rs
@@ -11,6 +11,8 @@ use core::iter::Product;
 use core::ops::{Mul, MulAssign};
 use num_traits::{CheckedMul, FromPrimitive, Zero};
 
+use super::ntt;
+
 #[inline]
 pub(super) fn mac_with_carry(
     a: BigDigit,
@@ -93,8 +95,9 @@ fn mac3(mut acc: &mut [BigDigit], mut b: &[BigDigit], mut c: &[BigDigit]) {
     // - If y is at least least twice as long as x, split using Half-Karatsuba.
     // - Next we use Karatsuba multiplication (Toom-2), which we have optimized
     //   to avoid unnecessary allocations for intermediate values.
-    // - For the largest inputs we use Toom-3, which better optimizes the
+    // - Next we use Toom-3, which better optimizes the
     //   number of operations, but uses more temporary allocations.
+    // - For the largest inputs we use number-theoretic transform (NTT).
     //
     // The thresholds are somewhat arbitrary, chosen by evaluating the results
     // of `cargo bench --bench bigint multiply`.
@@ -278,7 +281,11 @@ fn mac3(mut acc: &mut [BigDigit], mut b: &[BigDigit], mut c: &[BigDigit]) {
             }
             NoSign => (),
         }
-    } else {
+    } else if x.len() <= {
+        cfg_32!(let ntt_threshold = 2048;);
+        cfg_64!(let ntt_threshold = 512;);
+        ntt_threshold
+    } {
         // Toom-3 multiplication:
         //
         // Toom-3 is like Karatsuba above, but dividing the inputs into three parts.
@@ -407,6 +414,14 @@ fn mac3(mut acc: &mut [BigDigit], mut b: &[BigDigit], mut c: &[BigDigit]) {
                 NoSign => {}
             }
         }
+    } else {
+        // Number-theoretic transform (NTT) multiplication:
+        //
+        // NTT multiplies two integers by computing the convolution of the arrays
+        // modulo a prime. Since the result may exceed the prime, we use two or three
+        // distinct primes and combine the results using the Chinese Remainder
+        // Theroem (CRT).
+        ntt::mac3(acc, b, c);
     }
 }
 

--- a/src/biguint/multiplication.rs
+++ b/src/biguint/multiplication.rs
@@ -281,11 +281,7 @@ fn mac3(mut acc: &mut [BigDigit], mut b: &[BigDigit], mut c: &[BigDigit]) {
             }
             NoSign => (),
         }
-    } else if x.len() <= {
-        cfg_32!(let ntt_threshold = 2048;);
-        cfg_64!(let ntt_threshold = 512;);
-        ntt_threshold
-    } {
+    } else if x.len() <= 512 {
         // Toom-3 multiplication:
         //
         // Toom-3 is like Karatsuba above, but dividing the inputs into three parts.

--- a/src/biguint/ntt.rs
+++ b/src/biguint/ntt.rs
@@ -1,11 +1,4 @@
 #![forbid(unsafe_code)]
-#![allow(clippy::cast_sign_loss)]
-#![allow(clippy::cast_lossless)]
-#![allow(clippy::cast_possible_truncation)]
-#![allow(clippy::many_single_char_names)]
-#![allow(clippy::needless_range_loop)]
-#![allow(clippy::too_many_arguments)]
-#![allow(clippy::similar_names)]
 
 use super::Vec;
 
@@ -530,6 +523,7 @@ fn ntt4_single_block<const P: u64, const INV: bool, const TWIDDLE: bool>(px: &mu
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 const fn ntt5_kernel<const P: u64, const INV: bool, const TWIDDLE: bool>(
     w1: u64,
     w2: u64,
@@ -591,6 +585,7 @@ fn ntt5_single_block<const P: u64, const INV: bool, const TWIDDLE: bool>(px: &mu
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 const fn ntt6_kernel<const P: u64, const INV: bool, const TWIDDLE: bool>(
     w1: u64,
     w2: u64,

--- a/src/biguint/ntt.rs
+++ b/src/biguint/ntt.rs
@@ -418,10 +418,10 @@ impl<const P: u64, const INV: bool> NttKernelImpl<P, INV> {
 }
 
 const fn ntt2_kernel<const P: u64, const INV: bool, const TWIDDLE: bool>(
-    w1: u64,
     a: u64,
     mut b: u64,
-) -> (u64, u64) {
+    w1: u64,
+) -> [u64; 2] {
     if !INV && TWIDDLE {
         b = Arith::<P>::mmulmod(w1, b);
     }
@@ -430,7 +430,7 @@ const fn ntt2_kernel<const P: u64, const INV: bool, const TWIDDLE: bool>(
     if INV && TWIDDLE {
         out1 = Arith::<P>::mmulmod(w1, out1);
     }
-    (out0, out1)
+    [out0, out1]
 }
 
 fn ntt2_single_block<const P: u64, const INV: bool, const TWIDDLE: bool>(px: &mut [u64], w1: u64) {
@@ -438,17 +438,16 @@ fn ntt2_single_block<const P: u64, const INV: bool, const TWIDDLE: bool>(px: &mu
     let s1 = px.len() / 2;
     let (a, b) = px.split_at_mut(s1);
     for (a, b) in a.iter_mut().zip(b) {
-        (*a, *b) = ntt2_kernel::<P, INV, TWIDDLE>(w1, *a, *b);
+        [*a, *b] = ntt2_kernel::<P, INV, TWIDDLE>(*a, *b, w1);
     }
 }
 
 const fn ntt3_kernel<const P: u64, const INV: bool, const TWIDDLE: bool>(
-    w1: u64,
-    w2: u64,
     a: u64,
     mut b: u64,
     mut c: u64,
-) -> (u64, u64, u64) {
+    [w1, w2]: [u64; 2],
+) -> [u64; 3] {
     if !INV && TWIDDLE {
         b = Arith::<P>::mmulmod(w1, b);
         c = Arith::<P>::mmulmod(w2, c);
@@ -461,29 +460,31 @@ const fn ntt3_kernel<const P: u64, const INV: bool, const TWIDDLE: bool>(
         out1 = Arith::<P>::mmulmod(w1, out1);
         out2 = Arith::<P>::mmulmod(w2, out2);
     }
-    (out0, out1, out2)
+    [out0, out1, out2]
 }
 
 fn ntt3_single_block<const P: u64, const INV: bool, const TWIDDLE: bool>(px: &mut [u64], w1: u64) {
-    let w1 = if TWIDDLE { w1 } else { 0 };
-    let w2 = Arith::<P>::mmulmod(w1, w1);
+    let w = if TWIDDLE {
+        let w2 = Arith::<P>::mmulmod(w1, w1);
+        [w1, w2]
+    } else {
+        [0; 2]
+    };
     let s1 = px.len() / 3;
     let (a, rest) = px.split_at_mut(s1);
     let (b, c) = rest.split_at_mut(s1);
     for ((a, b), c) in a.iter_mut().zip(b).zip(c) {
-        (*a, *b, *c) = ntt3_kernel::<P, INV, TWIDDLE>(w1, w2, *a, *b, *c);
+        [*a, *b, *c] = ntt3_kernel::<P, INV, TWIDDLE>(*a, *b, *c, w);
     }
 }
 
 const fn ntt4_kernel<const P: u64, const INV: bool, const TWIDDLE: bool>(
-    w1: u64,
-    w2: u64,
-    w3: u64,
     a: u64,
     mut b: u64,
     mut c: u64,
     mut d: u64,
-) -> (u64, u64, u64, u64) {
+    [w1, w2, w3]: [u64; 3],
+) -> [u64; 4] {
     if !INV && TWIDDLE {
         b = Arith::<P>::mmulmod(w1, b);
         c = Arith::<P>::mmulmod(w2, c);
@@ -503,34 +504,34 @@ const fn ntt4_kernel<const P: u64, const INV: bool, const TWIDDLE: bool>(
         out2 = Arith::<P>::mmulmod(w2, out2);
         out3 = Arith::<P>::mmulmod(w3, out3);
     }
-    (out0, out1, out2, out3)
+    [out0, out1, out2, out3]
 }
 
 fn ntt4_single_block<const P: u64, const INV: bool, const TWIDDLE: bool>(px: &mut [u64], w1: u64) {
-    let w1 = if TWIDDLE { w1 } else { 0 };
-    let w2 = Arith::<P>::mmulmod(w1, w1);
-    let w3 = Arith::<P>::mmulmod(w1, w2);
+    let w = if TWIDDLE {
+        let w2 = Arith::<P>::mmulmod(w1, w1);
+        let w3 = Arith::<P>::mmulmod(w1, w2);
+        [w1, w2, w3]
+    } else {
+        [0; 3]
+    };
     let s1 = px.len() / 4;
     let (a, rest) = px.split_at_mut(s1);
     let (b, rest) = rest.split_at_mut(s1);
     let (c, d) = rest.split_at_mut(s1);
     for (((a, b), c), d) in a.iter_mut().zip(b).zip(c).zip(d) {
-        (*a, *b, *c, *d) = ntt4_kernel::<P, INV, TWIDDLE>(w1, w2, w3, *a, *b, *c, *d);
+        [*a, *b, *c, *d] = ntt4_kernel::<P, INV, TWIDDLE>(*a, *b, *c, *d, w);
     }
 }
 
-#[allow(clippy::too_many_arguments)]
 const fn ntt5_kernel<const P: u64, const INV: bool, const TWIDDLE: bool>(
-    w1: u64,
-    w2: u64,
-    w3: u64,
-    w4: u64,
     a: u64,
     mut b: u64,
     mut c: u64,
     mut d: u64,
     mut e: u64,
-) -> (u64, u64, u64, u64, u64) {
+    [w1, w2, w3, w4]: [u64; 4],
+) -> [u64; 5] {
     if !INV && TWIDDLE {
         b = Arith::<P>::mmulmod(w1, b);
         c = Arith::<P>::mmulmod(w2, c);
@@ -563,38 +564,37 @@ const fn ntt5_kernel<const P: u64, const INV: bool, const TWIDDLE: bool>(
         out3 = Arith::<P>::mmulmod(w3, out3);
         out4 = Arith::<P>::mmulmod(w4, out4);
     }
-    (out0, out1, out2, out3, out4)
+    [out0, out1, out2, out3, out4]
 }
 
 fn ntt5_single_block<const P: u64, const INV: bool, const TWIDDLE: bool>(px: &mut [u64], w1: u64) {
-    let w1 = if TWIDDLE { w1 } else { 0 };
-    let w2 = Arith::<P>::mmulmod(w1, w1);
-    let w3 = Arith::<P>::mmulmod(w1, w2);
-    let w4 = Arith::<P>::mmulmod(w2, w2);
+    let w = if TWIDDLE {
+        let w2 = Arith::<P>::mmulmod(w1, w1);
+        let w3 = Arith::<P>::mmulmod(w1, w2);
+        let w4 = Arith::<P>::mmulmod(w2, w2);
+        [w1, w2, w3, w4]
+    } else {
+        [0; 4]
+    };
     let s1 = px.len() / 5;
     let (a, rest) = px.split_at_mut(s1);
     let (b, rest) = rest.split_at_mut(s1);
     let (c, rest) = rest.split_at_mut(s1);
     let (d, e) = rest.split_at_mut(s1);
     for ((((a, b), c), d), e) in a.iter_mut().zip(b).zip(c).zip(d).zip(e) {
-        (*a, *b, *c, *d, *e) = ntt5_kernel::<P, INV, TWIDDLE>(w1, w2, w3, w4, *a, *b, *c, *d, *e);
+        [*a, *b, *c, *d, *e] = ntt5_kernel::<P, INV, TWIDDLE>(*a, *b, *c, *d, *e, w);
     }
 }
 
-#[allow(clippy::too_many_arguments)]
 const fn ntt6_kernel<const P: u64, const INV: bool, const TWIDDLE: bool>(
-    w1: u64,
-    w2: u64,
-    w3: u64,
-    w4: u64,
-    w5: u64,
     mut a: u64,
     mut b: u64,
     mut c: u64,
     mut d: u64,
     mut e: u64,
     mut f: u64,
-) -> (u64, u64, u64, u64, u64, u64) {
+    [w1, w2, w3, w4, w5]: [u64; 5],
+) -> [u64; 6] {
     if !INV && TWIDDLE {
         b = Arith::<P>::mmulmod(w1, b);
         c = Arith::<P>::mmulmod(w2, c);
@@ -620,15 +620,19 @@ const fn ntt6_kernel<const P: u64, const INV: bool, const TWIDDLE: bool>(
         out4 = Arith::<P>::mmulmod(w4, out4);
         out5 = Arith::<P>::mmulmod(w5, out5);
     }
-    (out0, out1, out2, out3, out4, out5)
+    [out0, out1, out2, out3, out4, out5]
 }
 
 fn ntt6_single_block<const P: u64, const INV: bool, const TWIDDLE: bool>(px: &mut [u64], w1: u64) {
-    let w1 = if TWIDDLE { w1 } else { 0 };
-    let w2 = Arith::<P>::mmulmod(w1, w1);
-    let w3 = Arith::<P>::mmulmod(w1, w2);
-    let w4 = Arith::<P>::mmulmod(w2, w2);
-    let w5 = Arith::<P>::mmulmod(w2, w3);
+    let w = if TWIDDLE {
+        let w2 = Arith::<P>::mmulmod(w1, w1);
+        let w3 = Arith::<P>::mmulmod(w1, w2);
+        let w4 = Arith::<P>::mmulmod(w2, w2);
+        let w5 = Arith::<P>::mmulmod(w2, w3);
+        [w1, w2, w3, w4, w5]
+    } else {
+        [0; 5]
+    };
     let s1 = px.len() / 6;
     let (a, rest) = px.split_at_mut(s1);
     let (b, rest) = rest.split_at_mut(s1);
@@ -636,8 +640,7 @@ fn ntt6_single_block<const P: u64, const INV: bool, const TWIDDLE: bool>(px: &mu
     let (d, rest) = rest.split_at_mut(s1);
     let (e, f) = rest.split_at_mut(s1);
     for (((((a, b), c), d), e), f) in a.iter_mut().zip(b).zip(c).zip(d).zip(e).zip(f) {
-        (*a, *b, *c, *d, *e, *f) =
-            ntt6_kernel::<P, INV, TWIDDLE>(w1, w2, w3, w4, w5, *a, *b, *c, *d, *e, *f);
+        [*a, *b, *c, *d, *e, *f] = ntt6_kernel::<P, INV, TWIDDLE>(*a, *b, *c, *d, *e, *f, w);
     }
 }
 

--- a/src/biguint/ntt.rs
+++ b/src/biguint/ntt.rs
@@ -208,11 +208,11 @@ impl<const P: u64> Arith<P> {
 }
 
 struct NttPlan {
-    pub n: usize, // n == g*m
-    pub g: usize, // g: size of the base case
-    pub m: usize, // m divides Arith::<P>::MAX_NTT_LEN
-    pub last_radix: usize,
-    pub s_list: Vec<(usize, usize)>,
+    n: usize, // n == g*m
+    g: usize, // g: size of the base case
+    m: usize, // m divides Arith::<P>::MAX_NTT_LEN
+    last_radix: usize,
+    s_list: Vec<(usize, usize)>,
 }
 
 impl NttPlan {

--- a/src/biguint/ntt.rs
+++ b/src/biguint/ntt.rs
@@ -7,7 +7,7 @@
 #![allow(clippy::too_many_arguments)]
 #![allow(clippy::similar_names)]
 
-use crate::biguint::Vec;
+use super::Vec;
 
 mod arith {
     // Extended Euclid algorithm:
@@ -141,8 +141,8 @@ impl<const P: u64> Arith<P> {
         }
         cur
     }
-    // Computes c as u128 * mreduce(v) as u128,
-    //   using d: u64 = mmulmod(P-1, c).
+    // Computes c as u128 * mreduce(v) as u128, using d: u64 = mmulmod(P-1, c).
+    //
     // It is caller's responsibility to ensure that d is correct.
     // Note that d can be computed by calling mreducelo(c).
     const fn mmulmod_noreduce(v: u128, c: u64, d: u64) -> u128 {
@@ -800,7 +800,7 @@ const P1P2_LO: u64 = (P1 as u128 * P2 as u128) as u64;
 const P1P2_HI: u64 = ((P1 as u128 * P2 as u128) >> 64) as u64;
 
 // Propagates carry from the beginning to the end of acc,
-//   and returns the resulting carry if it is nonzero.
+// and returns the resulting carry if it is nonzero.
 fn propagate_carry(acc: &mut [u64], mut carry: u64) -> u64 {
     for x in acc {
         let (v, overflow) = x.overflowing_add(carry);
@@ -908,7 +908,7 @@ fn mac3_two_primes(acc: &mut [u64], b: &[u64], c: &[u64], bits: u64) {
         }
     }
     // Process remaining carries. The addition carry_acc + bitbuf should not overflow
-    //   since bitbuf is underfilled and carry_acc is always 0 or 1.
+    // since bitbuf is underfilled and carry_acc is always 0 or 1.
     propagate_carry(&mut acc[j..], carry_acc + bitbuf);
 }
 

--- a/src/biguint/ntt.rs
+++ b/src/biguint/ntt.rs
@@ -118,18 +118,6 @@ impl<const P: u64> Arith<P> {
         Self::mreduce(a as u128 * b as u128)
     }
 
-    // Multiplication with Montgomery reduction:
-    //   a * b * R^-1 mod P
-    // This function only applies the multiplication when INV && TWIDDLE,
-    //   otherwise it just returns b.
-    const fn mmulmod_invtw<const INV: bool, const TWIDDLE: bool>(a: u64, b: u64) -> u64 {
-        if INV && TWIDDLE {
-            Self::mmulmod(a, b)
-        } else {
-            b
-        }
-    }
-
     // Fused-multiply-sub with Montgomery reduction:
     //   a * b * R^-1 - c mod P
     const fn mmulsubmod(a: u64, b: u64, c: u64) -> u64 {
@@ -438,7 +426,10 @@ const fn ntt2_kernel<const P: u64, const INV: bool, const TWIDDLE: bool>(
         b = Arith::<P>::mmulmod(w1, b);
     }
     let out0 = Arith::<P>::addmod(a, b);
-    let out1 = Arith::<P>::mmulmod_invtw::<INV, TWIDDLE>(w1, Arith::<P>::submod(a, b));
+    let mut out1 = Arith::<P>::submod(a, b);
+    if INV && TWIDDLE {
+        out1 = Arith::<P>::mmulmod(w1, out1);
+    }
     (out0, out1)
 }
 
@@ -464,14 +455,12 @@ const fn ntt3_kernel<const P: u64, const INV: bool, const TWIDDLE: bool>(
     }
     let kbmc = Arith::<P>::mmulmod(NttKernelImpl::<P, INV>::U3, Arith::<P>::submod(b, c));
     let out0 = Arith::<P>::addmod(a, Arith::<P>::addmod(b, c));
-    let out1 = Arith::<P>::mmulmod_invtw::<INV, TWIDDLE>(
-        w1,
-        Arith::<P>::submod(a, Arith::<P>::submod(c, kbmc)),
-    );
-    let out2 = Arith::<P>::mmulmod_invtw::<INV, TWIDDLE>(
-        w2,
-        Arith::<P>::submod(Arith::<P>::submod(a, b), kbmc),
-    );
+    let mut out1 = Arith::<P>::submod(a, Arith::<P>::submod(c, kbmc));
+    let mut out2 = Arith::<P>::submod(Arith::<P>::submod(a, b), kbmc);
+    if INV && TWIDDLE {
+        out1 = Arith::<P>::mmulmod(w1, out1);
+        out2 = Arith::<P>::mmulmod(w2, out2);
+    }
     (out0, out1, out2)
 }
 
@@ -506,12 +495,14 @@ const fn ntt4_kernel<const P: u64, const INV: bool, const TWIDDLE: bool>(
     let bmd = Arith::<P>::submod(b, d);
     let jbmd = Arith::<P>::mmulmod(NttKernelImpl::<P, INV>::U4, bmd);
     let out0 = Arith::<P>::addmod(apc, bpd);
-    let out1 = Arith::<P>::mmulmod_invtw::<INV, TWIDDLE>(
-        w1,
-        Arith::<P>::addmodopt_invtw::<INV, TWIDDLE>(amc, jbmd),
-    );
-    let out2 = Arith::<P>::mmulmod_invtw::<INV, TWIDDLE>(w2, Arith::<P>::submod(apc, bpd));
-    let out3 = Arith::<P>::mmulmod_invtw::<INV, TWIDDLE>(w3, Arith::<P>::submod(amc, jbmd));
+    let mut out1 = Arith::<P>::addmodopt_invtw::<INV, TWIDDLE>(amc, jbmd);
+    let mut out2 = Arith::<P>::submod(apc, bpd);
+    let mut out3 = Arith::<P>::submod(amc, jbmd);
+    if INV && TWIDDLE {
+        out1 = Arith::<P>::mmulmod(w1, out1);
+        out2 = Arith::<P>::mmulmod(w2, out2);
+        out3 = Arith::<P>::mmulmod(w3, out3);
+    }
     (out0, out1, out2, out3)
 }
 
@@ -562,16 +553,16 @@ const fn ntt5_kernel<const P: u64, const INV: bool, const TWIDDLE: bool>(
     let s1 = Arith::<P>::submod(m3, m2);
     let s2 = Arith::<P>::addmod(m2, m3);
     let out0 = m1;
-    let out1 = Arith::<P>::mmulmod_invtw::<INV, TWIDDLE>(w1, Arith::<P>::submod(s1, m5));
-    let out2 = Arith::<P>::mmulmod_invtw::<INV, TWIDDLE>(
-        w2,
-        Arith::<P>::submod(Arith::<P>::submod(0, s2), m6),
-    );
-    let out3 = Arith::<P>::mmulmod_invtw::<INV, TWIDDLE>(w3, Arith::<P>::submod(m6, s2));
-    let out4 = Arith::<P>::mmulmod_invtw::<INV, TWIDDLE>(
-        w4,
-        Arith::<P>::addmodopt_invtw::<INV, TWIDDLE>(s1, m5),
-    );
+    let mut out1 = Arith::<P>::submod(s1, m5);
+    let mut out2 = Arith::<P>::submod(Arith::<P>::submod(0, s2), m6);
+    let mut out3 = Arith::<P>::submod(m6, s2);
+    let mut out4 = Arith::<P>::addmodopt_invtw::<INV, TWIDDLE>(s1, m5);
+    if INV && TWIDDLE {
+        out1 = Arith::<P>::mmulmod(w1, out1);
+        out2 = Arith::<P>::mmulmod(w2, out2);
+        out3 = Arith::<P>::mmulmod(w3, out3);
+        out4 = Arith::<P>::mmulmod(w4, out4);
+    }
     (out0, out1, out2, out3, out4)
 }
 
@@ -616,27 +607,19 @@ const fn ntt6_kernel<const P: u64, const INV: bool, const TWIDDLE: bool>(
     (c, f) = (Arith::<P>::addmod(c, f), Arith::<P>::submod(c, f));
     let lbmc = Arith::<P>::mmulmod(NttKernelImpl::<P, INV>::U6, Arith::<P>::submod(b, c));
     let out0 = Arith::<P>::addmod(a, Arith::<P>::addmod(b, c));
-    let out2 = Arith::<P>::mmulmod_invtw::<INV, TWIDDLE>(
-        w2,
-        Arith::<P>::submod(a, Arith::<P>::submod(b, lbmc)),
-    );
-    let out4 = Arith::<P>::mmulmod_invtw::<INV, TWIDDLE>(
-        w4,
-        Arith::<P>::submod(Arith::<P>::submod(a, c), lbmc),
-    );
+    let mut out2 = Arith::<P>::submod(a, Arith::<P>::submod(b, lbmc));
+    let mut out4 = Arith::<P>::submod(Arith::<P>::submod(a, c), lbmc);
     let lepf = Arith::<P>::mmulmod(NttKernelImpl::<P, INV>::U6, Arith::<P>::addmod64(e, f));
-    let out1 = Arith::<P>::mmulmod_invtw::<INV, TWIDDLE>(
-        w1,
-        Arith::<P>::submod(d, Arith::<P>::submod(f, lepf)),
-    );
-    let out3 = Arith::<P>::mmulmod_invtw::<INV, TWIDDLE>(
-        w3,
-        Arith::<P>::submod(d, Arith::<P>::submod(e, f)),
-    );
-    let out5 = Arith::<P>::mmulmod_invtw::<INV, TWIDDLE>(
-        w5,
-        Arith::<P>::submod(d, Arith::<P>::submod(lepf, e)),
-    );
+    let mut out1 = Arith::<P>::submod(d, Arith::<P>::submod(f, lepf));
+    let mut out3 = Arith::<P>::submod(d, Arith::<P>::submod(e, f));
+    let mut out5 = Arith::<P>::submod(d, Arith::<P>::submod(lepf, e));
+    if INV && TWIDDLE {
+        out1 = Arith::<P>::mmulmod(w1, out1);
+        out2 = Arith::<P>::mmulmod(w2, out2);
+        out3 = Arith::<P>::mmulmod(w3, out3);
+        out4 = Arith::<P>::mmulmod(w4, out4);
+        out5 = Arith::<P>::mmulmod(w5, out5);
+    }
     (out0, out1, out2, out3, out4, out5)
 }
 

--- a/src/biguint/ntt.rs
+++ b/src/biguint/ntt.rs
@@ -29,6 +29,7 @@ mod arith {
             c = [c[1] - q * c[0], c[0], c[3] - q * c[2], c[2]];
         }
     }
+
     // Modular inverse: a^-1 mod modulus
     //   (m == 0 means m == 2^64)
     const fn invmod_inner(a: u64, modulus: u64) -> u64 {
@@ -45,11 +46,13 @@ mod arith {
         assert!(x > 0 && x < 1i128 << 64);
         x as u64
     }
+
     // Modular inverse: a^-1 mod modulus (modulus != 0)
     pub const fn invmod(a: u64, modulus: u64) -> u64 {
         assert!(modulus != 0);
         invmod_inner(a, modulus)
     }
+
     // Modular inverse: a^-1 mod 2^64
     pub const fn invmod_2pow64(a: u64) -> u64 {
         invmod_inner(a, 0)
@@ -64,12 +67,15 @@ mod arith {
 // 2^64 without a 129-bit addition, and supports the fused and delayed
 // reductions required by the NTT kernels.
 struct Arith<const P: u64> {}
+
 impl<const P: u64> Arith<P> {
     const R: u64 = ((1u128 << 64) % P as u128) as u64; // 2^64 mod P
     const R2: u64 = (Self::R as u128 * Self::R as u128 % P as u128) as u64; // R^2 mod P
     const PINV: u64 = arith::invmod_2pow64(P); // P^-1 mod 2^64
+
     const MAX_NTT_LEN: u64 =
         2u64.pow(Self::factors(2)) * 3u64.pow(Self::factors(3)) * 5u64.pow(Self::factors(5));
+
     const ROOTR: u64 = {
         // ROOT * R mod P (ROOT: MAX_NTT_LEN divides MultiplicativeOrder[ROOT, P])
         assert!(Self::MAX_NTT_LEN % 4050 == 0);
@@ -84,6 +90,7 @@ impl<const P: u64> Arith<P> {
             p = Self::addmod(p, Self::R);
         }
     };
+
     // Counts the number of `divisor` factors in P-1.
     const fn factors(divisor: u64) -> u32 {
         let (mut tmp, mut ans) = (P - 1, 0);
@@ -93,6 +100,7 @@ impl<const P: u64> Arith<P> {
         }
         ans
     }
+
     // Montgomery reduction:
     //   x * R^-1 mod P
     const fn mreduce(x: u128) -> u64 {
@@ -105,11 +113,13 @@ impl<const P: u64> Arith<P> {
             out
         }
     }
+
     // Multiplication with Montgomery reduction:
     //   a * b * R^-1 mod P
     const fn mmulmod(a: u64, b: u64) -> u64 {
         Self::mreduce(a as u128 * b as u128)
     }
+
     // Multiplication with Montgomery reduction:
     //   a * b * R^-1 mod P
     // This function only applies the multiplication when INV && TWIDDLE,
@@ -121,6 +131,7 @@ impl<const P: u64> Arith<P> {
             b
         }
     }
+
     // Fused-multiply-sub with Montgomery reduction:
     //   a * b * R^-1 - c mod P
     const fn mmulsubmod(a: u64, b: u64, c: u64) -> u64 {
@@ -129,6 +140,7 @@ impl<const P: u64> Arith<P> {
         let hi = Self::submod((x >> 64) as u64, c);
         Self::mreduce(lo as u128 | ((hi as u128) << 64))
     }
+
     // Computes base^exponent mod P with Montgomery reduction
     const fn mpowmod(mut base: u64, mut exponent: u64) -> u64 {
         let mut cur = Self::R;
@@ -141,6 +153,7 @@ impl<const P: u64> Arith<P> {
         }
         cur
     }
+
     // Computes c as u128 * mreduce(v) as u128, using d: u64 = mmulmod(P-1, c).
     //
     // It is caller's responsibility to ensure that d is correct.
@@ -155,15 +168,18 @@ impl<const P: u64> Arith<P> {
             w
         }
     }
+
     // Computes submod(0, mreduce(x as u128)) fast.
     const fn mreducelo(x: u64) -> u64 {
         let m = x.wrapping_mul(Self::PINV);
         ((m as u128 * P as u128) >> 64) as u64
     }
+
     // Computes a + b mod P, output range [0, P)
     const fn addmod(a: u64, b: u64) -> u64 {
         Self::submod(a, P.wrapping_sub(b))
     }
+
     // Computes a + b mod P, output range [0, 2^64)
     const fn addmod64(a: u64, b: u64) -> u64 {
         let (out, overflow) = a.overflowing_add(b);
@@ -173,6 +189,7 @@ impl<const P: u64> Arith<P> {
             out
         }
     }
+
     // Computes a + b mod P, selects addmod64 or addmod depending on INV && TWIDDLE
     const fn addmodopt_invtw<const INV: bool, const TWIDDLE: bool>(a: u64, b: u64) -> u64 {
         if INV && TWIDDLE {
@@ -181,6 +198,7 @@ impl<const P: u64> Arith<P> {
             Self::addmod(a, b)
         }
     }
+
     // Computes a - b mod P, output range [0, P)
     const fn submod(a: u64, b: u64) -> u64 {
         let (out, overflow) = a.overflowing_sub(b);
@@ -199,6 +217,7 @@ struct NttPlan {
     pub last_radix: usize,
     pub s_list: Vec<(usize, usize)>,
 }
+
 impl NttPlan {
     fn build<const P: u64>(min_len: usize) -> Self {
         assert!(min_len as u64 <= Arith::<P>::MAX_NTT_LEN);
@@ -210,11 +229,13 @@ impl NttPlan {
                     if len >= 2 * min_len as u64 {
                         break;
                     }
+
                     let (mut len, mut m2) = (len as usize, 0);
                     while len < min_len && m2 < Arith::<P>::factors(2) {
                         len *= 2;
                         m2 += 1;
                     }
+
                     if len >= min_len && len < len_max_cost {
                         let (mut tmp, mut cost) = (len, 0);
                         let mut g_new = 1;
@@ -246,6 +267,7 @@ impl NttPlan {
                         } else if len % 6 == 0 {
                             (g_new, tmp, cost) = (6, tmp / 6, cost + len * 91 / 100);
                         }
+
                         let (mut b6, mut b2) = (false, false);
                         while tmp % 6 == 0 {
                             (tmp, cost) = (tmp / 6, cost + len * radix6_weight / 100);
@@ -264,6 +286,7 @@ impl NttPlan {
                             (tmp, cost) = (tmp / 2, cost + len * radix2_weight / 100);
                             b2 = true;
                         }
+
                         if b6 && b2 {
                             // One radix-6 stage and the remaining radix-2 stage are
                             // executed as radix-4 and radix-3 stages.
@@ -272,6 +295,7 @@ impl NttPlan {
                             cost += len * radix4_weight / 100;
                             cost += len * radix3_weight / 100;
                         }
+
                         // Account for work that scales with transform length but is
                         // independent of the chosen stage decomposition.
                         cost += len * 4 / 100;
@@ -282,6 +306,7 @@ impl NttPlan {
                 }
             }
         }
+
         let (mut cnt6, mut cnt5, mut cnt4, mut cnt3, mut cnt2) = (0, 0, 0, 0, 0);
         let mut tmp = len_max / g;
         while tmp % 6 == 0 {
@@ -310,6 +335,7 @@ impl NttPlan {
             cnt4 += 1;
             cnt3 += 1;
         }
+
         let s_list = {
             let mut out = vec![];
             let mut tmp = len_max;
@@ -335,6 +361,7 @@ impl NttPlan {
             }
             out
         };
+
         Self {
             n: len_max,
             g,
@@ -344,6 +371,7 @@ impl NttPlan {
         }
     }
 }
+
 fn conv_base<const P: u64>(out: &mut [u64], x: &[u64], y: &[u64], c: u64) {
     assert_eq!(out.len(), x.len());
     assert_eq!(x.len(), y.len());
@@ -360,6 +388,7 @@ fn conv_base<const P: u64>(out: &mut [u64], x: &[u64], y: &[u64], c: u64) {
                 w
             };
         }
+
         v = Arith::<P>::mmulmod_noreduce(v, c, c2);
         for j in 0..=i {
             let (w, overflow) = v.overflowing_sub(x[j] as u128 * y[i - j] as u128);
@@ -369,20 +398,24 @@ fn conv_base<const P: u64>(out: &mut [u64], x: &[u64], y: &[u64], c: u64) {
                 w
             };
         }
+
         out[i] = Arith::<P>::mreduce(v);
     }
 }
 
 struct NttKernelImpl<const P: u64, const INV: bool>;
+
 impl<const P: u64, const INV: bool> NttKernelImpl<P, INV> {
     const ROOTR: u64 = Arith::<P>::mpowmod(
         Arith::<P>::ROOTR,
         if INV { Arith::<P>::MAX_NTT_LEN - 1 } else { 1 },
     );
+
     const U3: u64 = Arith::<P>::mpowmod(Self::ROOTR, Arith::<P>::MAX_NTT_LEN / 3);
     const U4: u64 = Arith::<P>::mpowmod(Self::ROOTR, Arith::<P>::MAX_NTT_LEN / 4);
     const U5: u64 = Arith::<P>::mpowmod(Self::ROOTR, Arith::<P>::MAX_NTT_LEN / 5);
     const U6: u64 = Arith::<P>::mpowmod(Self::ROOTR, Arith::<P>::MAX_NTT_LEN / 6);
+
     const C5: (u64, u64, u64, u64, u64, u64) = {
         let w = Self::U5;
         let w2 = Arith::<P>::mpowmod(w, 2);
@@ -397,6 +430,7 @@ impl<const P: u64, const INV: bool> NttKernelImpl<P, INV> {
         (0, c51, c52, c53, c54, c55)
     };
 }
+
 const fn ntt2_kernel<const P: u64, const INV: bool, const TWIDDLE: bool>(
     w1: u64,
     a: u64,
@@ -409,6 +443,7 @@ const fn ntt2_kernel<const P: u64, const INV: bool, const TWIDDLE: bool>(
     let out1 = Arith::<P>::mmulmod_invtw::<INV, TWIDDLE>(w1, Arith::<P>::submod(a, b));
     (out0, out1)
 }
+
 fn ntt2_single_block<const P: u64, const INV: bool, const TWIDDLE: bool>(px: &mut [u64], w1: u64) {
     let w1 = if TWIDDLE { w1 } else { 0 };
     let s1 = px.len() / 2;
@@ -417,6 +452,7 @@ fn ntt2_single_block<const P: u64, const INV: bool, const TWIDDLE: bool>(px: &mu
         (*a, *b) = ntt2_kernel::<P, INV, TWIDDLE>(w1, *a, *b);
     }
 }
+
 const fn ntt3_kernel<const P: u64, const INV: bool, const TWIDDLE: bool>(
     w1: u64,
     w2: u64,
@@ -440,6 +476,7 @@ const fn ntt3_kernel<const P: u64, const INV: bool, const TWIDDLE: bool>(
     );
     (out0, out1, out2)
 }
+
 fn ntt3_single_block<const P: u64, const INV: bool, const TWIDDLE: bool>(px: &mut [u64], w1: u64) {
     let w1 = if TWIDDLE { w1 } else { 0 };
     let w2 = Arith::<P>::mmulmod(w1, w1);
@@ -450,6 +487,7 @@ fn ntt3_single_block<const P: u64, const INV: bool, const TWIDDLE: bool>(px: &mu
         (*a, *b, *c) = ntt3_kernel::<P, INV, TWIDDLE>(w1, w2, *a, *b, *c);
     }
 }
+
 const fn ntt4_kernel<const P: u64, const INV: bool, const TWIDDLE: bool>(
     w1: u64,
     w2: u64,
@@ -478,6 +516,7 @@ const fn ntt4_kernel<const P: u64, const INV: bool, const TWIDDLE: bool>(
     let out3 = Arith::<P>::mmulmod_invtw::<INV, TWIDDLE>(w3, Arith::<P>::submod(amc, jbmd));
     (out0, out1, out2, out3)
 }
+
 fn ntt4_single_block<const P: u64, const INV: bool, const TWIDDLE: bool>(px: &mut [u64], w1: u64) {
     let w1 = if TWIDDLE { w1 } else { 0 };
     let w2 = Arith::<P>::mmulmod(w1, w1);
@@ -490,6 +529,7 @@ fn ntt4_single_block<const P: u64, const INV: bool, const TWIDDLE: bool>(px: &mu
         (*a, *b, *c, *d) = ntt4_kernel::<P, INV, TWIDDLE>(w1, w2, w3, *a, *b, *c, *d);
     }
 }
+
 const fn ntt5_kernel<const P: u64, const INV: bool, const TWIDDLE: bool>(
     w1: u64,
     w2: u64,
@@ -535,6 +575,7 @@ const fn ntt5_kernel<const P: u64, const INV: bool, const TWIDDLE: bool>(
     );
     (out0, out1, out2, out3, out4)
 }
+
 fn ntt5_single_block<const P: u64, const INV: bool, const TWIDDLE: bool>(px: &mut [u64], w1: u64) {
     let w1 = if TWIDDLE { w1 } else { 0 };
     let w2 = Arith::<P>::mmulmod(w1, w1);
@@ -549,6 +590,7 @@ fn ntt5_single_block<const P: u64, const INV: bool, const TWIDDLE: bool>(px: &mu
         (*a, *b, *c, *d, *e) = ntt5_kernel::<P, INV, TWIDDLE>(w1, w2, w3, w4, *a, *b, *c, *d, *e);
     }
 }
+
 const fn ntt6_kernel<const P: u64, const INV: bool, const TWIDDLE: bool>(
     w1: u64,
     w2: u64,
@@ -597,6 +639,7 @@ const fn ntt6_kernel<const P: u64, const INV: bool, const TWIDDLE: bool>(
     );
     (out0, out1, out2, out3, out4, out5)
 }
+
 fn ntt6_single_block<const P: u64, const INV: bool, const TWIDDLE: bool>(px: &mut [u64], w1: u64) {
     let w1 = if TWIDDLE { w1 } else { 0 };
     let w2 = Arith::<P>::mmulmod(w1, w1);
@@ -756,6 +799,7 @@ fn conv<const P: u64>(
         NttKernelImpl::<P, false>::ROOTR,
         Arith::<P>::MAX_NTT_LEN / last_radix,
     );
+
     while i < plan.n {
         // We accumulate the results just before `x_block` for cache friendliness.
         let (out_block, x_block) = x[i..i + 2 * g].split_at_mut(g);
@@ -791,11 +835,14 @@ const P2: u64 = 17_984_575_660_032_000_001; // Max NTT length = 2^19 * 3^17 * 5^
 const P3: u64 = 17_995_154_822_184_960_001; // Max NTT length = 2^17 * 3^22 * 5^4 = 2_570_736_403_169_280_000
 
 const P1INV_R_MOD_P2: u64 = Arith::<P2>::mmulmod(Arith::<P2>::R2, arith::invmod(P1, P2));
+
 const P1P2INV_R_MOD_P3: u64 = Arith::<P3>::mmulmod(
     Arith::<P3>::R2,
     arith::invmod((P1 as u128 * P2 as u128 % P3 as u128) as u64, P3),
 );
+
 const P1_R_MOD_P3: u64 = Arith::<P3>::mmulmod(Arith::<P3>::R2, P1);
+
 const P1P2_LO: u64 = (P1 as u128 * P2 as u128) as u64;
 const P1P2_HI: u64 = ((P1 as u128 * P2 as u128) >> 64) as u64;
 
@@ -856,8 +903,10 @@ fn mac3_two_primes(acc: &mut [u64], b: &[u64], c: &[u64], bits: u64) {
     let mut y = vec![0u64; plan_y.g + plan_y.n];
     let mut r = vec![0u64; plan_x.g + plan_x.n];
     let mut s = vec![0u64; plan_y.g + plan_y.n];
+
     pack_into(b, &mut x[plan_x.g..], &mut y[plan_y.g..], bits);
     pack_into(c, &mut r[plan_x.g..], &mut s[plan_y.g..], bits);
+
     conv::<P2>(
         &plan_x,
         &mut x,
@@ -866,6 +915,7 @@ fn mac3_two_primes(acc: &mut [u64], b: &[u64], c: &[u64], bits: u64) {
         c_len,
         arith::invmod(P3, P2),
     );
+
     conv::<P3>(
         &plan_y,
         &mut y,
@@ -907,6 +957,7 @@ fn mac3_two_primes(acc: &mut [u64], b: &[u64], c: &[u64], bits: u64) {
             bitbuf = out >> (bits - p);
         }
     }
+
     // Process remaining carries. The addition carry_acc + bitbuf should not overflow
     // since bitbuf is underfilled and carry_acc is always 0 or 1.
     propagate_carry(&mut acc[j..], carry_acc + bitbuf);
@@ -988,6 +1039,7 @@ fn mac3_three_primes(acc: &mut [u64], b: &[u64], c: &[u64]) {
         let u = Arith::<P2>::mmulmod(bma, P1INV_R_MOD_P2);
         let v = a as u128 + P1 as u128 * u as u128;
         let v_mod_p3 = Arith::<P3>::addmod(a, Arith::<P3>::mmulmod(P1_R_MOD_P3, u));
+
         // Now we have reduced the congruences into two:
         //     x === v mod P1P2,
         //     x === c mod P3.

--- a/src/biguint/ntt.rs
+++ b/src/biguint/ntt.rs
@@ -67,7 +67,7 @@ impl<const P: u64> Arith<P> {
     const PINV: u64 = arith::invmod_2pow64(P); // P^-1 mod 2^64
 
     const MAX_NTT_LEN: u64 =
-        2u64.pow(Self::factors(2)) * 3u64.pow(Self::factors(3)) * 5u64.pow(Self::factors(5));
+        2u64.pow(Self::FACTORS_2) * 3u64.pow(Self::FACTORS_3) * 5u64.pow(Self::FACTORS_5);
 
     const ROOTR: u64 = {
         // ROOT * R mod P (ROOT: MAX_NTT_LEN divides MultiplicativeOrder[ROOT, P])
@@ -83,6 +83,10 @@ impl<const P: u64> Arith<P> {
             p = Self::addmod(p, Self::R);
         }
     };
+
+    const FACTORS_2: u32 = Self::factors(2);
+    const FACTORS_3: u32 = Self::factors(3);
+    const FACTORS_5: u32 = Self::factors(5);
 
     // Counts the number of `divisor` factors in P-1.
     const fn factors(divisor: u64) -> u32 {
@@ -216,15 +220,15 @@ impl NttPlan {
         assert!(min_len as u64 <= Arith::<P>::MAX_NTT_LEN);
         let (mut len_max, mut len_max_cost, mut g) = (usize::MAX, usize::MAX, 1);
         for m7 in 0..=1 {
-            for m5 in 0..=Arith::<P>::factors(5) {
-                for m3 in 0..=Arith::<P>::factors(3) {
+            for m5 in 0..=Arith::<P>::FACTORS_5 {
+                for m3 in 0..=Arith::<P>::FACTORS_3 {
                     let len = 7u64.pow(m7) * 5u64.pow(m5) * 3u64.pow(m3);
                     if len >= 2 * min_len as u64 {
                         break;
                     }
 
                     let (mut len, mut m2) = (len as usize, 0);
-                    while len < min_len && m2 < Arith::<P>::factors(2) {
+                    while len < min_len && m2 < Arith::<P>::FACTORS_2 {
                         len *= 2;
                         m2 += 1;
                     }

--- a/src/biguint/ntt.rs
+++ b/src/biguint/ntt.rs
@@ -209,86 +209,81 @@ impl NttPlan {
     fn build<const P: u64>(min_len: usize) -> Self {
         assert!(min_len as u64 <= Arith::<P>::MAX_NTT_LEN);
         let (mut len_max, mut len_max_cost, mut g) = (usize::MAX, usize::MAX, 1);
-        for m7 in 0..=1 {
-            for m5 in 0..=Arith::<P>::FACTORS_5 {
-                for m3 in 0..=Arith::<P>::FACTORS_3 {
-                    let len = 7u64.pow(m7) * 5u64.pow(m5) * 3u64.pow(m3);
-                    if len >= 2 * min_len as u64 {
-                        break;
+        for m5 in 0..=Arith::<P>::FACTORS_5 {
+            for m3 in 0..=Arith::<P>::FACTORS_3 {
+                let len = 5u64.pow(m5) * 3u64.pow(m3);
+                if len >= 2 * min_len as u64 {
+                    break;
+                }
+
+                let (mut len, mut m2) = (len as usize, 0);
+                while len < min_len && m2 < Arith::<P>::FACTORS_2 {
+                    len *= 2;
+                    m2 += 1;
+                }
+
+                if len >= min_len && len < len_max_cost {
+                    let (mut tmp, mut cost) = (len, 0);
+                    let mut g_new = 1;
+
+                    // Length-dependent weights for cost estimation.
+                    let small_transform = len <= 1 << 20;
+                    let radix6_weight = if small_transform { 110 } else { 115 };
+                    let radix5_weight =
+                        156 + 30 * len.saturating_sub(5 << 14).min(1 << 16) / (1 << 16);
+                    let radix4_weight = if small_transform { 90 } else { 100 };
+                    let radix3_weight = 100;
+                    let radix2_weight = if small_transform { 85 } else { 100 };
+
+                    if len % 5 == 0 {
+                        (g_new, tmp, cost) = (5, tmp / 5, cost + len * 89 / 100);
+                    } else if m3 >= m2 + 2 {
+                        (g_new, tmp, cost) = (9, tmp / 9, cost + len * 180 / 100);
+                    } else if m2 >= m3 + 3 && (m2 - m3) % 2 == 1 {
+                        (g_new, tmp, cost) = (8, tmp / 8, cost + len * 130 / 100);
+                    } else if m2 >= m3 + 2 && m3 == 0 {
+                        (g_new, tmp, cost) = (4, tmp / 4, cost + len * 87 / 100);
+                    } else if m2 == 0 && m3 >= 1 {
+                        (g_new, tmp, cost) = (3, tmp / 3, cost + len * 86 / 100);
+                    } else if m3 == 0 && m2 >= 1 {
+                        (g_new, tmp, cost) = (2, tmp / 2, cost + len * 86 / 100);
+                    } else if len % 6 == 0 {
+                        (g_new, tmp, cost) = (6, tmp / 6, cost + len * 91 / 100);
                     }
 
-                    let (mut len, mut m2) = (len as usize, 0);
-                    while len < min_len && m2 < Arith::<P>::FACTORS_2 {
-                        len *= 2;
-                        m2 += 1;
+                    let (mut b6, mut b2) = (false, false);
+                    while tmp % 6 == 0 {
+                        (tmp, cost) = (tmp / 6, cost + len * radix6_weight / 100);
+                        b6 = true;
+                    }
+                    while tmp % 5 == 0 {
+                        (tmp, cost) = (tmp / 5, cost + len * radix5_weight / 100);
+                    }
+                    while tmp % 4 == 0 {
+                        (tmp, cost) = (tmp / 4, cost + len * radix4_weight / 100);
+                    }
+                    while tmp % 3 == 0 {
+                        (tmp, cost) = (tmp / 3, cost + len * radix3_weight / 100);
+                    }
+                    while tmp % 2 == 0 {
+                        (tmp, cost) = (tmp / 2, cost + len * radix2_weight / 100);
+                        b2 = true;
                     }
 
-                    if len >= min_len && len < len_max_cost {
-                        let (mut tmp, mut cost) = (len, 0);
-                        let mut g_new = 1;
+                    if b6 && b2 {
+                        // One radix-6 stage and the remaining radix-2 stage are
+                        // executed as radix-4 and radix-3 stages.
+                        cost -= len * radix6_weight / 100;
+                        cost -= len * radix2_weight / 100;
+                        cost += len * radix4_weight / 100;
+                        cost += len * radix3_weight / 100;
+                    }
 
-                        // Length-dependent weights for cost estimation.
-                        let small_transform = len <= 1 << 20;
-                        let g7_weight = if small_transform { 1113 } else { 1150 };
-                        let radix6_weight = if small_transform { 110 } else { 115 };
-                        let radix5_weight =
-                            156 + 30 * len.saturating_sub(5 << 14).min(1 << 16) / (1 << 16);
-                        let radix4_weight = if small_transform { 90 } else { 100 };
-                        let radix3_weight = 100;
-                        let radix2_weight = if small_transform { 85 } else { 100 };
-
-                        if len % 7 == 0 {
-                            (g_new, tmp, cost) = (7, tmp / 7, cost + len * g7_weight / 1000);
-                        } else if len % 5 == 0 {
-                            (g_new, tmp, cost) = (5, tmp / 5, cost + len * 89 / 100);
-                        } else if m3 >= m2 + 2 {
-                            (g_new, tmp, cost) = (9, tmp / 9, cost + len * 180 / 100);
-                        } else if m2 >= m3 + 3 && (m2 - m3) % 2 == 1 {
-                            (g_new, tmp, cost) = (8, tmp / 8, cost + len * 130 / 100);
-                        } else if m2 >= m3 + 2 && m3 == 0 {
-                            (g_new, tmp, cost) = (4, tmp / 4, cost + len * 87 / 100);
-                        } else if m2 == 0 && m3 >= 1 {
-                            (g_new, tmp, cost) = (3, tmp / 3, cost + len * 86 / 100);
-                        } else if m3 == 0 && m2 >= 1 {
-                            (g_new, tmp, cost) = (2, tmp / 2, cost + len * 86 / 100);
-                        } else if len % 6 == 0 {
-                            (g_new, tmp, cost) = (6, tmp / 6, cost + len * 91 / 100);
-                        }
-
-                        let (mut b6, mut b2) = (false, false);
-                        while tmp % 6 == 0 {
-                            (tmp, cost) = (tmp / 6, cost + len * radix6_weight / 100);
-                            b6 = true;
-                        }
-                        while tmp % 5 == 0 {
-                            (tmp, cost) = (tmp / 5, cost + len * radix5_weight / 100);
-                        }
-                        while tmp % 4 == 0 {
-                            (tmp, cost) = (tmp / 4, cost + len * radix4_weight / 100);
-                        }
-                        while tmp % 3 == 0 {
-                            (tmp, cost) = (tmp / 3, cost + len * radix3_weight / 100);
-                        }
-                        while tmp % 2 == 0 {
-                            (tmp, cost) = (tmp / 2, cost + len * radix2_weight / 100);
-                            b2 = true;
-                        }
-
-                        if b6 && b2 {
-                            // One radix-6 stage and the remaining radix-2 stage are
-                            // executed as radix-4 and radix-3 stages.
-                            cost -= len * radix6_weight / 100;
-                            cost -= len * radix2_weight / 100;
-                            cost += len * radix4_weight / 100;
-                            cost += len * radix3_weight / 100;
-                        }
-
-                        // Account for work that scales with transform length but is
-                        // independent of the chosen stage decomposition.
-                        cost += len * 4 / 100;
-                        if cost < len_max_cost {
-                            (len_max, len_max_cost, g) = (len, cost, g_new);
-                        }
+                    // Account for work that scales with transform length but is
+                    // independent of the chosen stage decomposition.
+                    cost += len * 4 / 100;
+                    if cost < len_max_cost {
+                        (len_max, len_max_cost, g) = (len, cost, g_new);
                     }
                 }
             }

--- a/src/biguint/ntt.rs
+++ b/src/biguint/ntt.rs
@@ -1,0 +1,1091 @@
+#![forbid(unsafe_code)]
+#![allow(clippy::cast_sign_loss)]
+#![allow(clippy::cast_lossless)]
+#![allow(clippy::cast_possible_truncation)]
+#![allow(clippy::many_single_char_names)]
+#![allow(clippy::needless_range_loop)]
+#![allow(clippy::too_many_arguments)]
+#![allow(clippy::similar_names)]
+
+use crate::biguint::Vec;
+
+mod arith {
+    // Extended Euclid algorithm:
+    //   (g, x, y) is a solution to ax + by = g, where g = gcd(a, b)
+    const fn egcd(mut a: i128, mut b: i128) -> (i128, i128, i128) {
+        assert!(a > 0 && b > 0);
+        let mut c = if a > b {
+            (a, b) = (b, a);
+            [0, 1, 1, 0]
+        } else {
+            [1, 0, 0, 1]
+        }; // treat as a row-major 2x2 matrix
+        loop {
+            if a == 0 {
+                break (b, c[1], c[3]);
+            }
+            let (q, r) = (b / a, b % a);
+            (a, b) = (r, a);
+            c = [c[1] - q * c[0], c[0], c[3] - q * c[2], c[2]];
+        }
+    }
+    // Modular inverse: a^-1 mod modulus
+    //   (m == 0 means m == 2^64)
+    const fn invmod_inner(a: u64, modulus: u64) -> u64 {
+        let m = if modulus == 0 {
+            1i128 << 64
+        } else {
+            modulus as i128
+        };
+        let (g, mut x, _y) = egcd(a as i128, m);
+        assert!(g == 1);
+        if x < 0 {
+            x += m;
+        }
+        assert!(x > 0 && x < 1i128 << 64);
+        x as u64
+    }
+    // Modular inverse: a^-1 mod modulus (modulus != 0)
+    pub const fn invmod(a: u64, modulus: u64) -> u64 {
+        assert!(modulus != 0);
+        invmod_inner(a, modulus)
+    }
+    // Modular inverse: a^-1 mod 2^64
+    pub const fn invmod_2pow64(a: u64) -> u64 {
+        invmod_inner(a, 0)
+    }
+}
+
+// NTT-local fixed-width modular arithmetic.
+//
+// Although this uses Montgomery reduction, it intentionally does not use
+// `biguint::monty`: P is a compile-time u64 modulus and R is 2^64. The
+// subtractive reduction remains const-evaluable, handles primes close to
+// 2^64 without a 129-bit addition, and supports the fused and delayed
+// reductions required by the NTT kernels.
+struct Arith<const P: u64> {}
+impl<const P: u64> Arith<P> {
+    const R: u64 = ((1u128 << 64) % P as u128) as u64; // 2^64 mod P
+    const R2: u64 = (Self::R as u128 * Self::R as u128 % P as u128) as u64; // R^2 mod P
+    const PINV: u64 = arith::invmod_2pow64(P); // P^-1 mod 2^64
+    const MAX_NTT_LEN: u64 =
+        2u64.pow(Self::factors(2)) * 3u64.pow(Self::factors(3)) * 5u64.pow(Self::factors(5));
+    const ROOTR: u64 = {
+        // ROOT * R mod P (ROOT: MAX_NTT_LEN divides MultiplicativeOrder[ROOT, P])
+        assert!(Self::MAX_NTT_LEN % 4050 == 0);
+        let mut p = Self::R;
+        loop {
+            if Self::mpowmod(p, P / 2) != Self::R
+                && Self::mpowmod(p, P / 3) != Self::R
+                && Self::mpowmod(p, P / 5) != Self::R
+            {
+                break Self::mpowmod(p, P / Self::MAX_NTT_LEN);
+            }
+            p = Self::addmod(p, Self::R);
+        }
+    };
+    // Counts the number of `divisor` factors in P-1.
+    const fn factors(divisor: u64) -> u32 {
+        let (mut tmp, mut ans) = (P - 1, 0);
+        while tmp % divisor == 0 {
+            tmp /= divisor;
+            ans += 1;
+        }
+        ans
+    }
+    // Montgomery reduction:
+    //   x * R^-1 mod P
+    const fn mreduce(x: u128) -> u64 {
+        let m = (x as u64).wrapping_mul(Self::PINV);
+        let y = ((m as u128 * P as u128) >> 64) as u64;
+        let (out, overflow) = ((x >> 64) as u64).overflowing_sub(y);
+        if overflow {
+            out.wrapping_add(P)
+        } else {
+            out
+        }
+    }
+    // Multiplication with Montgomery reduction:
+    //   a * b * R^-1 mod P
+    const fn mmulmod(a: u64, b: u64) -> u64 {
+        Self::mreduce(a as u128 * b as u128)
+    }
+    // Multiplication with Montgomery reduction:
+    //   a * b * R^-1 mod P
+    // This function only applies the multiplication when INV && TWIDDLE,
+    //   otherwise it just returns b.
+    const fn mmulmod_invtw<const INV: bool, const TWIDDLE: bool>(a: u64, b: u64) -> u64 {
+        if INV && TWIDDLE {
+            Self::mmulmod(a, b)
+        } else {
+            b
+        }
+    }
+    // Fused-multiply-sub with Montgomery reduction:
+    //   a * b * R^-1 - c mod P
+    const fn mmulsubmod(a: u64, b: u64, c: u64) -> u64 {
+        let x = a as u128 * b as u128;
+        let lo = x as u64;
+        let hi = Self::submod((x >> 64) as u64, c);
+        Self::mreduce(lo as u128 | ((hi as u128) << 64))
+    }
+    // Computes base^exponent mod P with Montgomery reduction
+    const fn mpowmod(mut base: u64, mut exponent: u64) -> u64 {
+        let mut cur = Self::R;
+        while exponent > 0 {
+            if exponent % 2 > 0 {
+                cur = Self::mmulmod(cur, base);
+            }
+            exponent /= 2;
+            base = Self::mmulmod(base, base);
+        }
+        cur
+    }
+    // Computes c as u128 * mreduce(v) as u128,
+    //   using d: u64 = mmulmod(P-1, c).
+    // It is caller's responsibility to ensure that d is correct.
+    // Note that d can be computed by calling mreducelo(c).
+    const fn mmulmod_noreduce(v: u128, c: u64, d: u64) -> u128 {
+        let a: u128 = c as u128 * (v >> 64);
+        let b: u128 = d as u128 * (v as u64 as u128);
+        let (w, overflow) = a.overflowing_sub(b);
+        if overflow {
+            w.wrapping_add((P as u128) << 64)
+        } else {
+            w
+        }
+    }
+    // Computes submod(0, mreduce(x as u128)) fast.
+    const fn mreducelo(x: u64) -> u64 {
+        let m = x.wrapping_mul(Self::PINV);
+        ((m as u128 * P as u128) >> 64) as u64
+    }
+    // Computes a + b mod P, output range [0, P)
+    const fn addmod(a: u64, b: u64) -> u64 {
+        Self::submod(a, P.wrapping_sub(b))
+    }
+    // Computes a + b mod P, output range [0, 2^64)
+    const fn addmod64(a: u64, b: u64) -> u64 {
+        let (out, overflow) = a.overflowing_add(b);
+        if overflow {
+            out.wrapping_sub(P)
+        } else {
+            out
+        }
+    }
+    // Computes a + b mod P, selects addmod64 or addmod depending on INV && TWIDDLE
+    const fn addmodopt_invtw<const INV: bool, const TWIDDLE: bool>(a: u64, b: u64) -> u64 {
+        if INV && TWIDDLE {
+            Self::addmod64(a, b)
+        } else {
+            Self::addmod(a, b)
+        }
+    }
+    // Computes a - b mod P, output range [0, P)
+    const fn submod(a: u64, b: u64) -> u64 {
+        let (out, overflow) = a.overflowing_sub(b);
+        if overflow {
+            out.wrapping_add(P)
+        } else {
+            out
+        }
+    }
+}
+
+struct NttPlan {
+    pub n: usize, // n == g*m
+    pub g: usize, // g: size of the base case
+    pub m: usize, // m divides Arith::<P>::MAX_NTT_LEN
+    pub last_radix: usize,
+    pub s_list: Vec<(usize, usize)>,
+}
+impl NttPlan {
+    fn build<const P: u64>(min_len: usize) -> Self {
+        assert!(min_len as u64 <= Arith::<P>::MAX_NTT_LEN);
+        let (mut len_max, mut len_max_cost, mut g) = (usize::MAX, usize::MAX, 1);
+        for m7 in 0..=1 {
+            for m5 in 0..=Arith::<P>::factors(5) {
+                for m3 in 0..=Arith::<P>::factors(3) {
+                    let len = 7u64.pow(m7) * 5u64.pow(m5) * 3u64.pow(m3);
+                    if len >= 2 * min_len as u64 {
+                        break;
+                    }
+                    let (mut len, mut m2) = (len as usize, 0);
+                    while len < min_len && m2 < Arith::<P>::factors(2) {
+                        len *= 2;
+                        m2 += 1;
+                    }
+                    if len >= min_len && len < len_max_cost {
+                        let (mut tmp, mut cost) = (len, 0);
+                        let mut g_new = 1;
+
+                        // Length-dependent weights for cost estimation.
+                        let small_transform = len <= 1 << 20;
+                        let g7_weight = if small_transform { 1113 } else { 1150 };
+                        let radix6_weight = if small_transform { 110 } else { 115 };
+                        let radix5_weight =
+                            156 + 30 * len.saturating_sub(5 << 14).min(1 << 16) / (1 << 16);
+                        let radix4_weight = if small_transform { 90 } else { 100 };
+                        let radix3_weight = 100;
+                        let radix2_weight = if small_transform { 85 } else { 100 };
+
+                        if len % 7 == 0 {
+                            (g_new, tmp, cost) = (7, tmp / 7, cost + len * g7_weight / 1000);
+                        } else if len % 5 == 0 {
+                            (g_new, tmp, cost) = (5, tmp / 5, cost + len * 89 / 100);
+                        } else if m3 >= m2 + 2 {
+                            (g_new, tmp, cost) = (9, tmp / 9, cost + len * 180 / 100);
+                        } else if m2 >= m3 + 3 && (m2 - m3) % 2 == 1 {
+                            (g_new, tmp, cost) = (8, tmp / 8, cost + len * 130 / 100);
+                        } else if m2 >= m3 + 2 && m3 == 0 {
+                            (g_new, tmp, cost) = (4, tmp / 4, cost + len * 87 / 100);
+                        } else if m2 == 0 && m3 >= 1 {
+                            (g_new, tmp, cost) = (3, tmp / 3, cost + len * 86 / 100);
+                        } else if m3 == 0 && m2 >= 1 {
+                            (g_new, tmp, cost) = (2, tmp / 2, cost + len * 86 / 100);
+                        } else if len % 6 == 0 {
+                            (g_new, tmp, cost) = (6, tmp / 6, cost + len * 91 / 100);
+                        }
+                        let (mut b6, mut b2) = (false, false);
+                        while tmp % 6 == 0 {
+                            (tmp, cost) = (tmp / 6, cost + len * radix6_weight / 100);
+                            b6 = true;
+                        }
+                        while tmp % 5 == 0 {
+                            (tmp, cost) = (tmp / 5, cost + len * radix5_weight / 100);
+                        }
+                        while tmp % 4 == 0 {
+                            (tmp, cost) = (tmp / 4, cost + len * radix4_weight / 100);
+                        }
+                        while tmp % 3 == 0 {
+                            (tmp, cost) = (tmp / 3, cost + len * radix3_weight / 100);
+                        }
+                        while tmp % 2 == 0 {
+                            (tmp, cost) = (tmp / 2, cost + len * radix2_weight / 100);
+                            b2 = true;
+                        }
+                        if b6 && b2 {
+                            // One radix-6 stage and the remaining radix-2 stage are
+                            // executed as radix-4 and radix-3 stages.
+                            cost -= len * radix6_weight / 100;
+                            cost -= len * radix2_weight / 100;
+                            cost += len * radix4_weight / 100;
+                            cost += len * radix3_weight / 100;
+                        }
+                        // Account for work that scales with transform length but is
+                        // independent of the chosen stage decomposition.
+                        cost += len * 4 / 100;
+                        if cost < len_max_cost {
+                            (len_max, len_max_cost, g) = (len, cost, g_new);
+                        }
+                    }
+                }
+            }
+        }
+        let (mut cnt6, mut cnt5, mut cnt4, mut cnt3, mut cnt2) = (0, 0, 0, 0, 0);
+        let mut tmp = len_max / g;
+        while tmp % 6 == 0 {
+            tmp /= 6;
+            cnt6 += 1;
+        }
+        while tmp % 5 == 0 {
+            tmp /= 5;
+            cnt5 += 1;
+        }
+        while tmp % 4 == 0 {
+            tmp /= 4;
+            cnt4 += 1;
+        }
+        while tmp % 3 == 0 {
+            tmp /= 3;
+            cnt3 += 1;
+        }
+        while tmp % 2 == 0 {
+            tmp /= 2;
+            cnt2 += 1;
+        }
+        while cnt6 > 0 && cnt2 > 0 {
+            cnt6 -= 1;
+            cnt2 -= 1;
+            cnt4 += 1;
+            cnt3 += 1;
+        }
+        let s_list = {
+            let mut out = vec![];
+            let mut tmp = len_max;
+            for _ in 0..cnt2 {
+                out.push((tmp, 2));
+                tmp /= 2;
+            }
+            for _ in 0..cnt3 {
+                out.push((tmp, 3));
+                tmp /= 3;
+            }
+            for _ in 0..cnt4 {
+                out.push((tmp, 4));
+                tmp /= 4;
+            }
+            for _ in 0..cnt5 {
+                out.push((tmp, 5));
+                tmp /= 5;
+            }
+            for _ in 0..cnt6 {
+                out.push((tmp, 6));
+                tmp /= 6;
+            }
+            out
+        };
+        Self {
+            n: len_max,
+            g,
+            m: len_max / g,
+            last_radix: s_list.last().unwrap_or(&(1, 1)).1,
+            s_list,
+        }
+    }
+}
+fn conv_base<const P: u64>(out: &mut [u64], x: &[u64], y: &[u64], c: u64) {
+    assert_eq!(out.len(), x.len());
+    assert_eq!(x.len(), y.len());
+
+    let n = out.len();
+    let c2 = Arith::<P>::mreducelo(c);
+    for i in 0..n {
+        let mut v: u128 = 0;
+        for j in i + 1..n {
+            let (w, overflow) = v.overflowing_sub(x[j] as u128 * y[i + n - j] as u128);
+            v = if overflow {
+                w.wrapping_add((P as u128) << 64)
+            } else {
+                w
+            };
+        }
+        v = Arith::<P>::mmulmod_noreduce(v, c, c2);
+        for j in 0..=i {
+            let (w, overflow) = v.overflowing_sub(x[j] as u128 * y[i - j] as u128);
+            v = if overflow {
+                w.wrapping_add((P as u128) << 64)
+            } else {
+                w
+            };
+        }
+        out[i] = Arith::<P>::mreduce(v);
+    }
+}
+
+struct NttKernelImpl<const P: u64, const INV: bool>;
+impl<const P: u64, const INV: bool> NttKernelImpl<P, INV> {
+    const ROOTR: u64 = Arith::<P>::mpowmod(
+        Arith::<P>::ROOTR,
+        if INV { Arith::<P>::MAX_NTT_LEN - 1 } else { 1 },
+    );
+    const U3: u64 = Arith::<P>::mpowmod(Self::ROOTR, Arith::<P>::MAX_NTT_LEN / 3);
+    const U4: u64 = Arith::<P>::mpowmod(Self::ROOTR, Arith::<P>::MAX_NTT_LEN / 4);
+    const U5: u64 = Arith::<P>::mpowmod(Self::ROOTR, Arith::<P>::MAX_NTT_LEN / 5);
+    const U6: u64 = Arith::<P>::mpowmod(Self::ROOTR, Arith::<P>::MAX_NTT_LEN / 6);
+    const C5: (u64, u64, u64, u64, u64, u64) = {
+        let w = Self::U5;
+        let w2 = Arith::<P>::mpowmod(w, 2);
+        let w4 = Arith::<P>::mpowmod(w, 4);
+        let inv2 = Arith::<P>::mmulmod(Arith::<P>::R2, arith::invmod(2, P));
+        let inv4 = Arith::<P>::mmulmod(Arith::<P>::R2, arith::invmod(4, P));
+        let c51 = Arith::<P>::addmod(Arith::<P>::R, inv4); // 1 + 4^-1 mod P
+        let c52 = Arith::<P>::addmod(Arith::<P>::mmulmod(inv2, Arith::<P>::addmod(w, w4)), inv4); // 4^-1 * (2*w + 2*w^4 + 1) mod P
+        let c53 = Arith::<P>::mmulmod(inv2, Arith::<P>::submod(w, w4)); // 2^-1 * (w - w^4) mod P
+        let c54 = Arith::<P>::addmod(Arith::<P>::addmod(w, w2), inv2); // 2^-1 * (2*w + 2*w^2 + 1) mod P
+        let c55 = Arith::<P>::addmod(Arith::<P>::addmod(w2, w4), inv2); // 2^-1 * (2*w^2 + 2*w^4 + 1) mod P
+        (0, c51, c52, c53, c54, c55)
+    };
+}
+const fn ntt2_kernel<const P: u64, const INV: bool, const TWIDDLE: bool>(
+    w1: u64,
+    a: u64,
+    mut b: u64,
+) -> (u64, u64) {
+    if !INV && TWIDDLE {
+        b = Arith::<P>::mmulmod(w1, b);
+    }
+    let out0 = Arith::<P>::addmod(a, b);
+    let out1 = Arith::<P>::mmulmod_invtw::<INV, TWIDDLE>(w1, Arith::<P>::submod(a, b));
+    (out0, out1)
+}
+fn ntt2_single_block<const P: u64, const INV: bool, const TWIDDLE: bool>(px: &mut [u64], w1: u64) {
+    let w1 = if TWIDDLE { w1 } else { 0 };
+    let s1 = px.len() / 2;
+    let (a, b) = px.split_at_mut(s1);
+    for (a, b) in a.iter_mut().zip(b) {
+        (*a, *b) = ntt2_kernel::<P, INV, TWIDDLE>(w1, *a, *b);
+    }
+}
+const fn ntt3_kernel<const P: u64, const INV: bool, const TWIDDLE: bool>(
+    w1: u64,
+    w2: u64,
+    a: u64,
+    mut b: u64,
+    mut c: u64,
+) -> (u64, u64, u64) {
+    if !INV && TWIDDLE {
+        b = Arith::<P>::mmulmod(w1, b);
+        c = Arith::<P>::mmulmod(w2, c);
+    }
+    let kbmc = Arith::<P>::mmulmod(NttKernelImpl::<P, INV>::U3, Arith::<P>::submod(b, c));
+    let out0 = Arith::<P>::addmod(a, Arith::<P>::addmod(b, c));
+    let out1 = Arith::<P>::mmulmod_invtw::<INV, TWIDDLE>(
+        w1,
+        Arith::<P>::submod(a, Arith::<P>::submod(c, kbmc)),
+    );
+    let out2 = Arith::<P>::mmulmod_invtw::<INV, TWIDDLE>(
+        w2,
+        Arith::<P>::submod(Arith::<P>::submod(a, b), kbmc),
+    );
+    (out0, out1, out2)
+}
+fn ntt3_single_block<const P: u64, const INV: bool, const TWIDDLE: bool>(px: &mut [u64], w1: u64) {
+    let w1 = if TWIDDLE { w1 } else { 0 };
+    let w2 = Arith::<P>::mmulmod(w1, w1);
+    let s1 = px.len() / 3;
+    let (a, rest) = px.split_at_mut(s1);
+    let (b, c) = rest.split_at_mut(s1);
+    for ((a, b), c) in a.iter_mut().zip(b).zip(c) {
+        (*a, *b, *c) = ntt3_kernel::<P, INV, TWIDDLE>(w1, w2, *a, *b, *c);
+    }
+}
+const fn ntt4_kernel<const P: u64, const INV: bool, const TWIDDLE: bool>(
+    w1: u64,
+    w2: u64,
+    w3: u64,
+    a: u64,
+    mut b: u64,
+    mut c: u64,
+    mut d: u64,
+) -> (u64, u64, u64, u64) {
+    if !INV && TWIDDLE {
+        b = Arith::<P>::mmulmod(w1, b);
+        c = Arith::<P>::mmulmod(w2, c);
+        d = Arith::<P>::mmulmod(w3, d);
+    }
+    let apc = Arith::<P>::addmod(a, c);
+    let amc = Arith::<P>::submod(a, c);
+    let bpd = Arith::<P>::addmod(b, d);
+    let bmd = Arith::<P>::submod(b, d);
+    let jbmd = Arith::<P>::mmulmod(NttKernelImpl::<P, INV>::U4, bmd);
+    let out0 = Arith::<P>::addmod(apc, bpd);
+    let out1 = Arith::<P>::mmulmod_invtw::<INV, TWIDDLE>(
+        w1,
+        Arith::<P>::addmodopt_invtw::<INV, TWIDDLE>(amc, jbmd),
+    );
+    let out2 = Arith::<P>::mmulmod_invtw::<INV, TWIDDLE>(w2, Arith::<P>::submod(apc, bpd));
+    let out3 = Arith::<P>::mmulmod_invtw::<INV, TWIDDLE>(w3, Arith::<P>::submod(amc, jbmd));
+    (out0, out1, out2, out3)
+}
+fn ntt4_single_block<const P: u64, const INV: bool, const TWIDDLE: bool>(px: &mut [u64], w1: u64) {
+    let w1 = if TWIDDLE { w1 } else { 0 };
+    let w2 = Arith::<P>::mmulmod(w1, w1);
+    let w3 = Arith::<P>::mmulmod(w1, w2);
+    let s1 = px.len() / 4;
+    let (a, rest) = px.split_at_mut(s1);
+    let (b, rest) = rest.split_at_mut(s1);
+    let (c, d) = rest.split_at_mut(s1);
+    for (((a, b), c), d) in a.iter_mut().zip(b).zip(c).zip(d) {
+        (*a, *b, *c, *d) = ntt4_kernel::<P, INV, TWIDDLE>(w1, w2, w3, *a, *b, *c, *d);
+    }
+}
+const fn ntt5_kernel<const P: u64, const INV: bool, const TWIDDLE: bool>(
+    w1: u64,
+    w2: u64,
+    w3: u64,
+    w4: u64,
+    a: u64,
+    mut b: u64,
+    mut c: u64,
+    mut d: u64,
+    mut e: u64,
+) -> (u64, u64, u64, u64, u64) {
+    if !INV && TWIDDLE {
+        b = Arith::<P>::mmulmod(w1, b);
+        c = Arith::<P>::mmulmod(w2, c);
+        d = Arith::<P>::mmulmod(w3, d);
+        e = Arith::<P>::mmulmod(w4, e);
+    }
+    let t1 = Arith::<P>::addmod(b, e);
+    let t2 = Arith::<P>::addmod(c, d);
+    let t3 = Arith::<P>::submod(b, e);
+    let t4 = Arith::<P>::submod(d, c);
+    let t5 = Arith::<P>::addmod(t1, t2);
+    let t6 = Arith::<P>::submod(t1, t2);
+    let t7 = Arith::<P>::addmod64(t3, t4);
+    let m1 = Arith::<P>::addmod(a, t5);
+    let m2 = Arith::<P>::mmulsubmod(NttKernelImpl::<P, INV>::C5.1, t5, m1);
+    let m3 = Arith::<P>::mmulmod(NttKernelImpl::<P, INV>::C5.2, t6);
+    let m4 = Arith::<P>::mmulmod(NttKernelImpl::<P, INV>::C5.3, t7);
+    let m5 = Arith::<P>::mmulsubmod(NttKernelImpl::<P, INV>::C5.4, t4, m4);
+    let m6 = Arith::<P>::mmulsubmod(P.wrapping_sub(NttKernelImpl::<P, INV>::C5.5), t3, m4);
+    let s1 = Arith::<P>::submod(m3, m2);
+    let s2 = Arith::<P>::addmod(m2, m3);
+    let out0 = m1;
+    let out1 = Arith::<P>::mmulmod_invtw::<INV, TWIDDLE>(w1, Arith::<P>::submod(s1, m5));
+    let out2 = Arith::<P>::mmulmod_invtw::<INV, TWIDDLE>(
+        w2,
+        Arith::<P>::submod(Arith::<P>::submod(0, s2), m6),
+    );
+    let out3 = Arith::<P>::mmulmod_invtw::<INV, TWIDDLE>(w3, Arith::<P>::submod(m6, s2));
+    let out4 = Arith::<P>::mmulmod_invtw::<INV, TWIDDLE>(
+        w4,
+        Arith::<P>::addmodopt_invtw::<INV, TWIDDLE>(s1, m5),
+    );
+    (out0, out1, out2, out3, out4)
+}
+fn ntt5_single_block<const P: u64, const INV: bool, const TWIDDLE: bool>(px: &mut [u64], w1: u64) {
+    let w1 = if TWIDDLE { w1 } else { 0 };
+    let w2 = Arith::<P>::mmulmod(w1, w1);
+    let w3 = Arith::<P>::mmulmod(w1, w2);
+    let w4 = Arith::<P>::mmulmod(w2, w2);
+    let s1 = px.len() / 5;
+    let (a, rest) = px.split_at_mut(s1);
+    let (b, rest) = rest.split_at_mut(s1);
+    let (c, rest) = rest.split_at_mut(s1);
+    let (d, e) = rest.split_at_mut(s1);
+    for ((((a, b), c), d), e) in a.iter_mut().zip(b).zip(c).zip(d).zip(e) {
+        (*a, *b, *c, *d, *e) = ntt5_kernel::<P, INV, TWIDDLE>(w1, w2, w3, w4, *a, *b, *c, *d, *e);
+    }
+}
+const fn ntt6_kernel<const P: u64, const INV: bool, const TWIDDLE: bool>(
+    w1: u64,
+    w2: u64,
+    w3: u64,
+    w4: u64,
+    w5: u64,
+    mut a: u64,
+    mut b: u64,
+    mut c: u64,
+    mut d: u64,
+    mut e: u64,
+    mut f: u64,
+) -> (u64, u64, u64, u64, u64, u64) {
+    if !INV && TWIDDLE {
+        b = Arith::<P>::mmulmod(w1, b);
+        c = Arith::<P>::mmulmod(w2, c);
+        d = Arith::<P>::mmulmod(w3, d);
+        e = Arith::<P>::mmulmod(w4, e);
+        f = Arith::<P>::mmulmod(w5, f);
+    }
+    (a, d) = (Arith::<P>::addmod(a, d), Arith::<P>::submod(a, d));
+    (b, e) = (Arith::<P>::addmod(b, e), Arith::<P>::submod(b, e));
+    (c, f) = (Arith::<P>::addmod(c, f), Arith::<P>::submod(c, f));
+    let lbmc = Arith::<P>::mmulmod(NttKernelImpl::<P, INV>::U6, Arith::<P>::submod(b, c));
+    let out0 = Arith::<P>::addmod(a, Arith::<P>::addmod(b, c));
+    let out2 = Arith::<P>::mmulmod_invtw::<INV, TWIDDLE>(
+        w2,
+        Arith::<P>::submod(a, Arith::<P>::submod(b, lbmc)),
+    );
+    let out4 = Arith::<P>::mmulmod_invtw::<INV, TWIDDLE>(
+        w4,
+        Arith::<P>::submod(Arith::<P>::submod(a, c), lbmc),
+    );
+    let lepf = Arith::<P>::mmulmod(NttKernelImpl::<P, INV>::U6, Arith::<P>::addmod64(e, f));
+    let out1 = Arith::<P>::mmulmod_invtw::<INV, TWIDDLE>(
+        w1,
+        Arith::<P>::submod(d, Arith::<P>::submod(f, lepf)),
+    );
+    let out3 = Arith::<P>::mmulmod_invtw::<INV, TWIDDLE>(
+        w3,
+        Arith::<P>::submod(d, Arith::<P>::submod(e, f)),
+    );
+    let out5 = Arith::<P>::mmulmod_invtw::<INV, TWIDDLE>(
+        w5,
+        Arith::<P>::submod(d, Arith::<P>::submod(lepf, e)),
+    );
+    (out0, out1, out2, out3, out4, out5)
+}
+fn ntt6_single_block<const P: u64, const INV: bool, const TWIDDLE: bool>(px: &mut [u64], w1: u64) {
+    let w1 = if TWIDDLE { w1 } else { 0 };
+    let w2 = Arith::<P>::mmulmod(w1, w1);
+    let w3 = Arith::<P>::mmulmod(w1, w2);
+    let w4 = Arith::<P>::mmulmod(w2, w2);
+    let w5 = Arith::<P>::mmulmod(w2, w3);
+    let s1 = px.len() / 6;
+    let (a, rest) = px.split_at_mut(s1);
+    let (b, rest) = rest.split_at_mut(s1);
+    let (c, rest) = rest.split_at_mut(s1);
+    let (d, rest) = rest.split_at_mut(s1);
+    let (e, f) = rest.split_at_mut(s1);
+    for (((((a, b), c), d), e), f) in a.iter_mut().zip(b).zip(c).zip(d).zip(e).zip(f) {
+        (*a, *b, *c, *d, *e, *f) =
+            ntt6_kernel::<P, INV, TWIDDLE>(w1, w2, w3, w4, w5, *a, *b, *c, *d, *e, *f);
+    }
+}
+
+fn ntt_dif_dit<const P: u64, const INV: bool>(plan: &NttPlan, x: &mut [u64], twiddles: &[u64]) {
+    let mut twiddle_index = 0;
+    for step in 0..plan.s_list.len() {
+        let i = if INV {
+            plan.s_list.len() - 1 - step
+        } else {
+            step
+        };
+        let (s, radix) = plan.s_list[i];
+        debug_assert_eq!(plan.n % s, 0);
+        debug_assert_eq!(s % radix, 0);
+
+        let mut x_iter = x[..plan.n].chunks_exact_mut(s);
+        match radix {
+            2 => {
+                ntt2_single_block::<P, INV, false>(x_iter.next().unwrap(), 0);
+                twiddle_index += 1;
+                for px in x_iter {
+                    ntt2_single_block::<P, INV, true>(px, twiddles[twiddle_index]);
+                    twiddle_index += 1;
+                }
+            }
+            3 => {
+                ntt3_single_block::<P, INV, false>(x_iter.next().unwrap(), 0);
+                twiddle_index += 1;
+                for px in x_iter {
+                    ntt3_single_block::<P, INV, true>(px, twiddles[twiddle_index]);
+                    twiddle_index += 1;
+                }
+            }
+            4 => {
+                ntt4_single_block::<P, INV, false>(x_iter.next().unwrap(), 0);
+                twiddle_index += 1;
+                for px in x_iter {
+                    ntt4_single_block::<P, INV, true>(px, twiddles[twiddle_index]);
+                    twiddle_index += 1;
+                }
+            }
+            5 => {
+                ntt5_single_block::<P, INV, false>(x_iter.next().unwrap(), 0);
+                twiddle_index += 1;
+                for px in x_iter {
+                    ntt5_single_block::<P, INV, true>(px, twiddles[twiddle_index]);
+                    twiddle_index += 1;
+                }
+            }
+            6 => {
+                ntt6_single_block::<P, INV, false>(x_iter.next().unwrap(), 0);
+                twiddle_index += 1;
+                for px in x_iter {
+                    ntt6_single_block::<P, INV, true>(px, twiddles[twiddle_index]);
+                    twiddle_index += 1;
+                }
+            }
+            _ => {
+                unreachable!()
+            }
+        }
+    }
+}
+
+fn calc_twiddle_factors<const P: u64, const INV: bool>(
+    s_list: &[(usize, usize)],
+    out: &mut [u64],
+) -> usize {
+    let mut p = 1;
+    out[0] = Arith::<P>::R;
+    for i in (1..s_list.len()).rev() {
+        let radix = s_list[i - 1].1;
+        let w = Arith::<P>::mpowmod(
+            NttKernelImpl::<P, INV>::ROOTR,
+            Arith::<P>::MAX_NTT_LEN / (p * radix * s_list.last().unwrap().1) as u64,
+        );
+        for j in p..radix * p {
+            out[j] = Arith::<P>::mmulmod(w, out[j - p]);
+        }
+        p *= radix;
+    }
+    p
+}
+
+// Performs (cyclic) integer convolution modulo P using NTT.
+// Modifies the input buffers in-place.
+// The output is saved in the slice `x`.
+// The input slices must have the same length.
+fn conv<const P: u64>(
+    plan: &NttPlan,
+    x: &mut [u64],
+    xlen: usize,
+    y: &mut [u64],
+    ylen: usize,
+    mut mult: u64,
+) {
+    assert!(!x.is_empty() && x.len() == y.len());
+    let (_n, g, m, last_radix) = (plan.n, plan.g, plan.m, plan.last_radix as u64);
+
+    /* multiply by a constant in advance */
+    mult = Arith::<P>::mmulmod(
+        Arith::<P>::mpowmod(Arith::<P>::R2, 3),
+        Arith::<P>::mmulmod(mult, (P - 1) / m as u64),
+    );
+    for v in if xlen < ylen {
+        &mut x[g..g + xlen]
+    } else {
+        &mut y[g..g + ylen]
+    } {
+        *v = Arith::<P>::mmulmod(*v, mult);
+    }
+
+    /* compute the total space needed for twiddle factors */
+    let (mut radix_prefix_product, mut twiddle_count) = (1, 2); // 2 extra slots
+    for &(_, radix) in &plan.s_list {
+        twiddle_count += radix_prefix_product;
+        radix_prefix_product *= radix;
+    }
+
+    /* build twiddle factors */
+    let mut twiddles = vec![0u64; twiddle_count];
+    let mut last_stage_twiddle_start = 0;
+    for i in 0..plan.s_list.len() {
+        let stage_twiddle_count = calc_twiddle_factors::<P, false>(
+            &plan.s_list[0..=i],
+            &mut twiddles[last_stage_twiddle_start..],
+        );
+        if i + 1 < plan.s_list.len() {
+            last_stage_twiddle_start += stage_twiddle_count;
+        }
+    }
+
+    /* dif fft */
+    ntt_dif_dit::<P, false>(plan, &mut x[g..], &twiddles);
+    ntt_dif_dit::<P, false>(plan, &mut y[g..], &twiddles);
+
+    /* naive multiplication */
+    let (mut i, mut last_stage_twiddle_index, mut position_in_last_radix) =
+        (0, last_stage_twiddle_start, 0);
+    let mut current_twiddle = Arith::<P>::R;
+    let twiddle_step = Arith::<P>::mpowmod(
+        NttKernelImpl::<P, false>::ROOTR,
+        Arith::<P>::MAX_NTT_LEN / last_radix,
+    );
+    while i < plan.n {
+        // We accumulate the results just before `x_block` for cache friendliness.
+        let (out_block, x_block) = x[i..i + 2 * g].split_at_mut(g);
+        let y_block = &y[i + g..i + 2 * g];
+        conv_base::<P>(out_block, x_block, y_block, current_twiddle);
+        i += g;
+        position_in_last_radix += 1;
+        if position_in_last_radix == last_radix {
+            last_stage_twiddle_index += 1;
+            position_in_last_radix = 0;
+            current_twiddle = twiddles[last_stage_twiddle_index];
+        } else {
+            current_twiddle = Arith::<P>::mmulmod(current_twiddle, twiddle_step);
+        }
+    }
+
+    /* dit fft */
+    let mut twiddle_offset = 0;
+    for i in (0..plan.s_list.len()).rev() {
+        twiddle_offset +=
+            calc_twiddle_factors::<P, true>(&plan.s_list[0..=i], &mut twiddles[twiddle_offset..]);
+    }
+    ntt_dif_dit::<P, true>(plan, x, &twiddles);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+use crate::big_digit::BigDigit;
+use core::cmp::max;
+
+const P1: u64 = 14_259_017_916_245_606_401; // Max NTT length = 2^22 * 3^21 * 5^2 = 1_096_847_532_018_892_800
+const P2: u64 = 17_984_575_660_032_000_001; // Max NTT length = 2^19 * 3^17 * 5^6 = 1_057_916_215_296_000_000
+const P3: u64 = 17_995_154_822_184_960_001; // Max NTT length = 2^17 * 3^22 * 5^4 = 2_570_736_403_169_280_000
+
+const P1INV_R_MOD_P2: u64 = Arith::<P2>::mmulmod(Arith::<P2>::R2, arith::invmod(P1, P2));
+const P1P2INV_R_MOD_P3: u64 = Arith::<P3>::mmulmod(
+    Arith::<P3>::R2,
+    arith::invmod((P1 as u128 * P2 as u128 % P3 as u128) as u64, P3),
+);
+const P1_R_MOD_P3: u64 = Arith::<P3>::mmulmod(Arith::<P3>::R2, P1);
+const P1P2_LO: u64 = (P1 as u128 * P2 as u128) as u64;
+const P1P2_HI: u64 = ((P1 as u128 * P2 as u128) >> 64) as u64;
+
+// Propagates carry from the beginning to the end of acc,
+//   and returns the resulting carry if it is nonzero.
+fn propagate_carry(acc: &mut [u64], mut carry: u64) -> u64 {
+    for x in acc {
+        let (v, overflow) = x.overflowing_add(carry);
+        (*x, carry) = (v, u64::from(overflow));
+        if !overflow {
+            break;
+        }
+    }
+    carry
+}
+
+fn mac3_two_primes(acc: &mut [u64], b: &[u64], c: &[u64], bits: u64) {
+    fn pack_into(src: &[u64], dst1: &mut [u64], dst2: &mut [u64], bits: u64) {
+        let mut p = 0u64;
+        let mut dst = dst1.iter_mut().zip(dst2);
+        let mut x = 0u64;
+        let mask = (1u64 << bits) - 1;
+        for v in src {
+            let mut k = 0;
+            while k < 64 {
+                x |= (v >> k) << p;
+                let q = 64 - k;
+                if p + q >= bits {
+                    let out = x & mask;
+                    let (pdst1, pdst2) = dst.next().unwrap();
+                    *pdst1 = out;
+                    *pdst2 = out;
+                    x = 0;
+                    k = k + bits - p;
+                    p = 0;
+                } else {
+                    p += q;
+                    break;
+                }
+            }
+        }
+        if p > 0 {
+            let out = x & mask;
+            let (pdst1, pdst2) = dst.next().unwrap();
+            *pdst1 = out;
+            *pdst2 = out;
+        }
+    }
+
+    assert!(bits < 63);
+    let b_len = ((64 * b.len() as u64 + bits - 1) / bits) as usize;
+    let c_len = ((64 * c.len() as u64 + bits - 1) / bits) as usize;
+    let min_len = b_len + c_len;
+    let plan_x = NttPlan::build::<P2>(min_len);
+    let plan_y = NttPlan::build::<P3>(min_len);
+
+    let mut x = vec![0u64; plan_x.g + plan_x.n];
+    let mut y = vec![0u64; plan_y.g + plan_y.n];
+    let mut r = vec![0u64; plan_x.g + plan_x.n];
+    let mut s = vec![0u64; plan_y.g + plan_y.n];
+    pack_into(b, &mut x[plan_x.g..], &mut y[plan_y.g..], bits);
+    pack_into(c, &mut r[plan_x.g..], &mut s[plan_y.g..], bits);
+    conv::<P2>(
+        &plan_x,
+        &mut x,
+        b_len,
+        &mut r[..plan_x.g + plan_x.n],
+        c_len,
+        arith::invmod(P3, P2),
+    );
+    conv::<P3>(
+        &plan_y,
+        &mut y,
+        b_len,
+        &mut s[..plan_y.g + plan_y.n],
+        c_len,
+        Arith::<P3>::submod(0, arith::invmod(P2, P3)),
+    );
+
+    /* merge the results in {x, y} into r (process carry along the way) */
+    let mask = (1u64 << bits) - 1;
+    let mut carry: u128 = 0;
+    let (mut j, mut p) = (0usize, 0u64);
+    let mut bitbuf: u64 = 0;
+    let mut carry_acc: u64 = 0;
+    for i in 0..min_len {
+        /* extract the convolution result */
+        let (a, b) = (x[i], y[i]);
+        let (mut v, overflow) =
+            (a as u128 * P3 as u128 + carry).overflowing_sub(b as u128 * P2 as u128);
+        if overflow {
+            v = v.wrapping_add(P2 as u128 * P3 as u128);
+        }
+        carry = v >> bits;
+
+        /* write to bitbuf */
+        let out = (v as u64) & mask;
+        bitbuf |= out << p;
+        p += bits;
+        if p >= 64 {
+            /* flush bitbuf to the output buffer */
+            let (w, overflow1) = bitbuf.overflowing_add(carry_acc);
+            let (w, overflow2) = acc[j].overflowing_add(w);
+            acc[j] = w;
+            carry_acc = u64::from(overflow1 || overflow2);
+
+            /* roll-over */
+            (j, p) = (j + 1, p - 64);
+            bitbuf = out >> (bits - p);
+        }
+    }
+    // Process remaining carries. The addition carry_acc + bitbuf should not overflow
+    //   since bitbuf is underfilled and carry_acc is always 0 or 1.
+    propagate_carry(&mut acc[j..], carry_acc + bitbuf);
+}
+
+fn mac3_three_primes(acc: &mut [u64], b: &[u64], c: &[u64]) {
+    let min_len = b.len() + c.len();
+    let plan_x = NttPlan::build::<P1>(min_len);
+    let plan_y = NttPlan::build::<P2>(min_len);
+    let plan_z = NttPlan::build::<P3>(min_len);
+    let mut x = vec![0u64; plan_x.g + plan_x.n];
+    let mut y = vec![0u64; plan_y.g + plan_y.n];
+    let mut z = vec![0u64; plan_z.g + plan_z.n];
+    let mut r = vec![0u64; max(x.len(), max(y.len(), z.len()))];
+
+    /* convolution with modulo P1 */
+    for i in 0..b.len() {
+        x[plan_x.g + i] = if b[i] >= P1 { b[i] - P1 } else { b[i] };
+    }
+    for i in 0..c.len() {
+        r[plan_x.g + i] = if c[i] >= P1 { c[i] - P1 } else { c[i] };
+    }
+    conv::<P1>(
+        &plan_x,
+        &mut x,
+        b.len(),
+        &mut r[..plan_x.g + plan_x.n],
+        c.len(),
+        1,
+    );
+
+    /* convolution with modulo P2 */
+    for i in 0..b.len() {
+        y[plan_y.g + i] = if b[i] >= P2 { b[i] - P2 } else { b[i] };
+    }
+    for i in 0..c.len() {
+        r[plan_y.g + i] = if c[i] >= P2 { c[i] - P2 } else { c[i] };
+    }
+    (&mut r[plan_y.g..])[c.len()..plan_y.n].fill(0u64);
+    conv::<P2>(
+        &plan_y,
+        &mut y,
+        b.len(),
+        &mut r[..plan_y.g + plan_y.n],
+        c.len(),
+        1,
+    );
+
+    /* convolution with modulo P3 */
+    for i in 0..b.len() {
+        z[plan_z.g + i] = if b[i] >= P3 { b[i] - P3 } else { b[i] };
+    }
+    for i in 0..c.len() {
+        r[plan_z.g + i] = if c[i] >= P3 { c[i] - P3 } else { c[i] };
+    }
+    (&mut r[plan_z.g..])[c.len()..plan_z.n].fill(0u64);
+    conv::<P3>(
+        &plan_z,
+        &mut z,
+        b.len(),
+        &mut r[..plan_z.g + plan_z.n],
+        c.len(),
+        1,
+    );
+
+    /* merge the results in {x, y, z} into acc (process carry along the way) */
+    let mut carry: u128 = 0;
+    for i in 0..min_len {
+        let (a, b, c) = (x[i], y[i], z[i]);
+        // We need to solve the following system of linear congruences:
+        //     x === a mod P1,
+        //     x === b mod P2,
+        //     x === c mod P3.
+        // The first two equations are equivalent to
+        //     x === a + P1 * (U * (b-a) mod P2) mod P1P2,
+        // where U is the solution to
+        //     P1 * U === 1 mod P2.
+        let bma = Arith::<P2>::submod(b, a);
+        let u = Arith::<P2>::mmulmod(bma, P1INV_R_MOD_P2);
+        let v = a as u128 + P1 as u128 * u as u128;
+        let v_mod_p3 = Arith::<P3>::addmod(a, Arith::<P3>::mmulmod(P1_R_MOD_P3, u));
+        // Now we have reduced the congruences into two:
+        //     x === v mod P1P2,
+        //     x === c mod P3.
+        // The solution is
+        //     x === v + P1P2 * (V * (c-v) mod P3) mod P1P2P3,
+        // where V is the solution to
+        //     P1P2 * V === 1 mod P3.
+        let cmv = Arith::<P3>::submod(c, v_mod_p3);
+        let vcmv = Arith::<P3>::mmulmod(cmv, P1P2INV_R_MOD_P3);
+        let (out_01, overflow) = carry.overflowing_add(v + P1P2_LO as u128 * vcmv as u128);
+        let out_0 = out_01 as u64;
+        let out_12 = P1P2_HI as u128 * vcmv as u128
+            + (out_01 >> 64)
+            + if overflow { 1u128 << 64 } else { 0 };
+
+        let (v, overflow) = acc[i].overflowing_add(out_0);
+        acc[i] = v;
+        carry = out_12 + u128::from(overflow);
+    }
+    propagate_carry(&mut acc[min_len..], carry as u64);
+}
+
+fn mac3_u64(acc: &mut [u64], b: &[u64], c: &[u64]) {
+    const fn compute_bits(l: u64) -> u64 {
+        let total_bits = l * 64;
+        let (mut lo, mut hi) = (42, 62);
+        while lo < hi {
+            let mid = (lo + hi + 1) / 2;
+            let single_digit_max_val = (1u64 << mid) - 1;
+            let l_corrected = (total_bits + mid - 1) / mid;
+            let (lhs, overflow) = (single_digit_max_val as u128)
+                .pow(2)
+                .overflowing_mul(l_corrected as u128);
+            if !overflow && lhs < P2 as u128 * P3 as u128 {
+                lo = mid;
+            } else {
+                hi = mid - 1;
+            }
+        }
+        lo
+    }
+
+    // We have two choices:
+    //     1. NTT with two primes.
+    //     2. NTT with three primes.
+    // Obviously we want to do only two passes for efficiency, not three.
+    // However, the number of bits per u64 we can pack for NTT
+    // depends on the length of the arrays being multiplied (convolved).
+    // If the arrays are too long, the resulting values may exceed the
+    // modulus range P2 * P3, which leads to incorrect results.
+    // Hence, we compute the number of bits required by the length of NTT,
+    // and use it to determine whether to use two-prime or three-prime.
+    // Since we can pack 64 bits per u64 in three-prime NTT, the effective
+    // number of bits in three-prime NTT is 64/3 = 21.3333..., which means
+    // two-prime NTT can only do better when at least 43 bits per u64 can
+    // be packed into each u64.
+    let max_cnt = max(b.len(), c.len()) as u64;
+    let bits = compute_bits(max_cnt);
+    if bits >= 43 {
+        /* can pack more effective bits per u64 with two primes than with three primes */
+        mac3_two_primes(acc, b, c, bits);
+    } else {
+        /* can pack at most 21 effective bits per u64, which is worse than
+        64/3 = 21.3333.. effective bits per u64 achieved with three primes */
+        mac3_three_primes(acc, b, c);
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+cfg_digit! {
+    pub fn mac3(acc: &mut [BigDigit], b: &[BigDigit], c: &[BigDigit]) {
+        fn bigdigit_to_u64(src: &[BigDigit], is_acc: bool) -> Vec<u64> {
+            let mut out = vec![0u64; (src.len() + 1) / 2 + is_acc as usize];
+            for i in 0..src.len()/2 {
+                out[i] = (src[2*i] as u64) | ((src[2*i+1] as u64) << 32);
+            }
+            if src.len() % 2 == 1 {
+                out[src.len()/2] = src[src.len()-1] as u64;
+            }
+            out
+        }
+        fn u64_to_bigdigit(src: &[u64], dst: &mut [BigDigit]) {
+            for i in 0..dst.len()/2 {
+                dst[2*i] = src[i] as BigDigit;
+                dst[2*i+1] = (src[i] >> 32) as BigDigit;
+            }
+            if dst.len() % 2 == 1 {
+                dst[dst.len()-1] = src[src.len()-1] as BigDigit;
+            }
+        }
+
+        /* convert to u64 => process => convert back to BigDigit (u32) */
+        let mut acc_u64 = bigdigit_to_u64(acc, true);
+        mac3_u64(&mut acc_u64, &bigdigit_to_u64(b, false), &bigdigit_to_u64(c, false));
+        u64_to_bigdigit(&acc_u64, acc);
+    }
+    pub fn mac3(acc: &mut [BigDigit], b: &[BigDigit], c: &[BigDigit]) {
+       mac3_u64(acc, b, c);
+    }
+}

--- a/src/biguint/ntt.rs
+++ b/src/biguint/ntt.rs
@@ -2,6 +2,7 @@
 
 use super::{BigDigit, Vec};
 use core::cmp::max;
+use core::iter::zip;
 
 mod arith {
     // Extended Euclid algorithm:
@@ -437,9 +438,9 @@ fn ntt2_single_block<const P: u64, const INV: bool, const TWIDDLE: bool>(px: &mu
     let w1 = if TWIDDLE { w1 } else { 0 };
     let s1 = px.len() / 2;
     let (a, b) = px.split_at_mut(s1);
-    for (a, b) in a.iter_mut().zip(b) {
+    zip(a, b).for_each(|(a, b)| {
         [*a, *b] = ntt2_kernel::<P, INV, TWIDDLE>(*a, *b, w1);
-    }
+    });
 }
 
 const fn ntt3_kernel<const P: u64, const INV: bool, const TWIDDLE: bool>(
@@ -473,9 +474,9 @@ fn ntt3_single_block<const P: u64, const INV: bool, const TWIDDLE: bool>(px: &mu
     let s1 = px.len() / 3;
     let (a, rest) = px.split_at_mut(s1);
     let (b, c) = rest.split_at_mut(s1);
-    for ((a, b), c) in a.iter_mut().zip(b).zip(c) {
+    zip(zip(a, b), c).for_each(|((a, b), c)| {
         [*a, *b, *c] = ntt3_kernel::<P, INV, TWIDDLE>(*a, *b, *c, w);
-    }
+    });
 }
 
 const fn ntt4_kernel<const P: u64, const INV: bool, const TWIDDLE: bool>(
@@ -519,9 +520,9 @@ fn ntt4_single_block<const P: u64, const INV: bool, const TWIDDLE: bool>(px: &mu
     let (a, rest) = px.split_at_mut(s1);
     let (b, rest) = rest.split_at_mut(s1);
     let (c, d) = rest.split_at_mut(s1);
-    for (((a, b), c), d) in a.iter_mut().zip(b).zip(c).zip(d) {
+    zip(zip(zip(a, b), c), d).for_each(|(((a, b), c), d)| {
         [*a, *b, *c, *d] = ntt4_kernel::<P, INV, TWIDDLE>(*a, *b, *c, *d, w);
-    }
+    });
 }
 
 const fn ntt5_kernel<const P: u64, const INV: bool, const TWIDDLE: bool>(
@@ -581,9 +582,9 @@ fn ntt5_single_block<const P: u64, const INV: bool, const TWIDDLE: bool>(px: &mu
     let (b, rest) = rest.split_at_mut(s1);
     let (c, rest) = rest.split_at_mut(s1);
     let (d, e) = rest.split_at_mut(s1);
-    for ((((a, b), c), d), e) in a.iter_mut().zip(b).zip(c).zip(d).zip(e) {
+    zip(zip(zip(zip(a, b), c), d), e).for_each(|((((a, b), c), d), e)| {
         [*a, *b, *c, *d, *e] = ntt5_kernel::<P, INV, TWIDDLE>(*a, *b, *c, *d, *e, w);
-    }
+    });
 }
 
 const fn ntt6_kernel<const P: u64, const INV: bool, const TWIDDLE: bool>(
@@ -639,9 +640,9 @@ fn ntt6_single_block<const P: u64, const INV: bool, const TWIDDLE: bool>(px: &mu
     let (c, rest) = rest.split_at_mut(s1);
     let (d, rest) = rest.split_at_mut(s1);
     let (e, f) = rest.split_at_mut(s1);
-    for (((((a, b), c), d), e), f) in a.iter_mut().zip(b).zip(c).zip(d).zip(e).zip(f) {
+    zip(zip(zip(zip(zip(a, b), c), d), e), f).for_each(|(((((a, b), c), d), e), f)| {
         [*a, *b, *c, *d, *e, *f] = ntt6_kernel::<P, INV, TWIDDLE>(*a, *b, *c, *d, *e, *f, w);
-    }
+    });
 }
 
 fn ntt_dif_dit<const P: u64, const INV: bool>(plan: &NttPlan, x: &mut [u64], twiddles: &[u64]) {
@@ -845,7 +846,7 @@ fn propagate_carry(acc: &mut [u64], mut carry: u64) -> u64 {
 fn mac3_two_primes(acc: &mut [u64], b: &[u64], c: &[u64], bits: u64) {
     fn pack_into(src: &[u64], dst1: &mut [u64], dst2: &mut [u64], bits: u64) {
         let mut p = 0u64;
-        let mut dst = dst1.iter_mut().zip(dst2);
+        let mut dst = zip(dst1, dst2);
         let mut x = 0u64;
         let mask = (1u64 << bits) - 1;
         for v in src {

--- a/src/biguint/ntt.rs
+++ b/src/biguint/ntt.rs
@@ -1,6 +1,7 @@
 #![forbid(unsafe_code)]
 
-use super::Vec;
+use super::{BigDigit, Vec};
+use core::cmp::max;
 
 mod arith {
     // Extended Euclid algorithm:
@@ -825,9 +826,6 @@ fn conv<const P: u64>(
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-
-use crate::big_digit::BigDigit;
-use core::cmp::max;
 
 const P1: u64 = 14_259_017_916_245_606_401; // Max NTT length = 2^22 * 3^21 * 5^2 = 1_096_847_532_018_892_800
 const P2: u64 = 17_984_575_660_032_000_001; // Max NTT length = 2^19 * 3^17 * 5^6 = 1_057_916_215_296_000_000

--- a/src/biguint/ntt.rs
+++ b/src/biguint/ntt.rs
@@ -711,7 +711,7 @@ fn conv<const P: u64>(
     assert!(!x.is_empty() && x.len() == y.len());
     let (_n, g, m, last_radix) = (plan.n, plan.g, plan.m, plan.last_radix as u64);
 
-    /* multiply by a constant in advance */
+    // multiply by a constant in advance
     mult = Arith::<P>::mmulmod(
         Arith::<P>::mpowmod(Arith::<P>::R2, 3),
         Arith::<P>::mmulmod(mult, (P - 1) / m as u64),
@@ -724,14 +724,14 @@ fn conv<const P: u64>(
         *v = Arith::<P>::mmulmod(*v, mult);
     }
 
-    /* compute the total space needed for twiddle factors */
+    // compute the total space needed for twiddle factors
     let (mut radix_prefix_product, mut twiddle_count) = (1, 2); // 2 extra slots
     for &(_, radix) in &plan.s_list {
         twiddle_count += radix_prefix_product;
         radix_prefix_product *= radix;
     }
 
-    /* build twiddle factors */
+    // build twiddle factors
     let mut twiddles = vec![0u64; twiddle_count];
     let mut last_stage_twiddle_start = 0;
     for i in 0..plan.s_list.len() {
@@ -744,11 +744,11 @@ fn conv<const P: u64>(
         }
     }
 
-    /* dif fft */
+    // dif fft
     ntt_dif_dit::<P, false>(plan, &mut x[g..], &twiddles);
     ntt_dif_dit::<P, false>(plan, &mut y[g..], &twiddles);
 
-    /* naive multiplication */
+    // naive multiplication
     let (mut i, mut last_stage_twiddle_index, mut position_in_last_radix) =
         (0, last_stage_twiddle_start, 0);
     let mut current_twiddle = Arith::<P>::R;
@@ -772,7 +772,7 @@ fn conv<const P: u64>(
         }
     }
 
-    /* dit fft */
+    // dit fft
     let mut twiddle_offset = 0;
     for i in (0..plan.s_list.len()).rev() {
         twiddle_offset +=
@@ -875,14 +875,14 @@ fn mac3_two_primes(acc: &mut [u64], b: &[u64], c: &[u64], bits: u64) {
         Arith::<P3>::submod(0, arith::invmod(P2, P3)),
     );
 
-    /* merge the results in {x, y} into r (process carry along the way) */
+    // merge the results in {x, y} into r (process carry along the way)
     let mask = (1u64 << bits) - 1;
     let mut carry: u128 = 0;
     let (mut j, mut p) = (0usize, 0u64);
     let mut bitbuf: u64 = 0;
     let mut carry_acc: u64 = 0;
     for i in 0..min_len {
-        /* extract the convolution result */
+        // extract the convolution result
         let (a, b) = (x[i], y[i]);
         let (mut v, overflow) =
             (a as u128 * P3 as u128 + carry).overflowing_sub(b as u128 * P2 as u128);
@@ -891,18 +891,18 @@ fn mac3_two_primes(acc: &mut [u64], b: &[u64], c: &[u64], bits: u64) {
         }
         carry = v >> bits;
 
-        /* write to bitbuf */
+        // write to bitbuf
         let out = (v as u64) & mask;
         bitbuf |= out << p;
         p += bits;
         if p >= 64 {
-            /* flush bitbuf to the output buffer */
+            // flush bitbuf to the output buffer
             let (w, overflow1) = bitbuf.overflowing_add(carry_acc);
             let (w, overflow2) = acc[j].overflowing_add(w);
             acc[j] = w;
             carry_acc = u64::from(overflow1 || overflow2);
 
-            /* roll-over */
+            // roll-over
             (j, p) = (j + 1, p - 64);
             bitbuf = out >> (bits - p);
         }
@@ -922,7 +922,7 @@ fn mac3_three_primes(acc: &mut [u64], b: &[u64], c: &[u64]) {
     let mut z = vec![0u64; plan_z.g + plan_z.n];
     let mut r = vec![0u64; max(x.len(), max(y.len(), z.len()))];
 
-    /* convolution with modulo P1 */
+    // convolution with modulo P1
     for i in 0..b.len() {
         x[plan_x.g + i] = if b[i] >= P1 { b[i] - P1 } else { b[i] };
     }
@@ -938,7 +938,7 @@ fn mac3_three_primes(acc: &mut [u64], b: &[u64], c: &[u64]) {
         1,
     );
 
-    /* convolution with modulo P2 */
+    // convolution with modulo P2
     for i in 0..b.len() {
         y[plan_y.g + i] = if b[i] >= P2 { b[i] - P2 } else { b[i] };
     }
@@ -955,7 +955,7 @@ fn mac3_three_primes(acc: &mut [u64], b: &[u64], c: &[u64]) {
         1,
     );
 
-    /* convolution with modulo P3 */
+    // convolution with modulo P3
     for i in 0..b.len() {
         z[plan_z.g + i] = if b[i] >= P3 { b[i] - P3 } else { b[i] };
     }
@@ -972,7 +972,7 @@ fn mac3_three_primes(acc: &mut [u64], b: &[u64], c: &[u64]) {
         1,
     );
 
-    /* merge the results in {x, y, z} into acc (process carry along the way) */
+    // merge the results in {x, y, z} into acc (process carry along the way)
     let mut carry: u128 = 0;
     for i in 0..min_len {
         let (a, b, c) = (x[i], y[i], z[i]);
@@ -1047,11 +1047,11 @@ fn mac3_u64(acc: &mut [u64], b: &[u64], c: &[u64]) {
     let max_cnt = max(b.len(), c.len()) as u64;
     let bits = compute_bits(max_cnt);
     if bits >= 43 {
-        /* can pack more effective bits per u64 with two primes than with three primes */
+        // can pack more effective bits per u64 with two primes than with three primes
         mac3_two_primes(acc, b, c, bits);
     } else {
-        /* can pack at most 21 effective bits per u64, which is worse than
-        64/3 = 21.3333.. effective bits per u64 achieved with three primes */
+        // can pack at most 21 effective bits per u64, which is worse than
+        // 64/3 = 21.3333.. effective bits per u64 achieved with three primes
         mac3_three_primes(acc, b, c);
     }
 }
@@ -1080,7 +1080,7 @@ cfg_digit! {
             }
         }
 
-        /* convert to u64 => process => convert back to BigDigit (u32) */
+        // convert to u64 => process => convert back to BigDigit (u32)
         let mut acc_u64 = bigdigit_to_u64(acc, true);
         mac3_u64(&mut acc_u64, &bigdigit_to_u64(b, false), &bigdigit_to_u64(c, false));
         u64_to_bigdigit(&acc_u64, acc);

--- a/src/biguint/ntt.rs
+++ b/src/biguint/ntt.rs
@@ -73,6 +73,20 @@ impl<const P: u64> Arith<P> {
 
     const ROOTR: u64 = {
         // ROOT * R mod P (ROOT: MAX_NTT_LEN divides MultiplicativeOrder[ROOT, P])
+        //
+        // Find an element p whose multiplicative order is a multiple of
+        // MAX_NTT_LEN, then compute ROOTR = p^((P-1)/MAX_NTT_LEN) to obtain
+        // an element of exact order MAX_NTT_LEN.
+        //
+        // We only test p^((P-1)/q) != 1 for q in {2, 3, 5} — the prime
+        // factors of MAX_NTT_LEN. This suffices because:
+        //   - FACTORS_2/3/5 extract all factors of 2, 3, 5 from P-1, so
+        //     R = (P-1)/MAX_NTT_LEN is coprime to MAX_NTT_LEN by construction.
+        //   - Any remaining prime factors of P-1 (e.g. 7, 13, 17 for the
+        //     current primes) are absorbed by the p^R exponentiation and
+        //     do not affect the order of ROOTR.
+        //
+        // P must be prime for Z/PZ to be a field; this is not checked here.
         assert!(Self::MAX_NTT_LEN % 4050 == 0);
         let mut p = Self::R;
         loop {
@@ -226,7 +240,22 @@ impl NttPlan {
                     let (mut tmp, mut cost) = (len, 0);
                     let mut g_new = 1;
 
-                    // Length-dependent weights for cost estimation.
+                    // Cost model for NTT length selection.
+                    //
+                    // Each radix-R stage processes N elements in N/R groups of R-point
+                    // butterflies. The per-stage cost is approximated as N * weight / 100,
+                    // where weight reflects the butterfly's arithmetic cost and cache
+                    // behavior, calibrated empirically:
+                    //   - radix-2: weight 85 (small) / 100 (large)
+                    //   - radix-3: weight 100 (reference)
+                    //   - radix-4: weight 90 (small) / 100 (large)
+                    //   - radix-5: weight 156-186 (length-dependent)
+                    //   - radix-6: weight 110 (small) / 115 (large)
+                    //
+                    // The small/large threshold (2^20 elements) approximates L2 cache
+                    // residency. Radix-5 has the highest weight due to its mul-heavy
+                    // butterfly (5 modular multiplications vs. 1 for radix-3/4).
+
                     let small_transform = len <= 1 << 20;
                     let radix6_weight = if small_transform { 110 } else { 115 };
                     let radix5_weight =


### PR DESCRIPTION
This commit implements [number theoretic transform (NTT)](https://en.wikipedia.org/wiki/Discrete_Fourier_transform_over_a_ring#Number-theoretic_transform) for large integer multiplication (issue #169).

* To simplify implementation the [Schönhage–Strassen algorithm](https://en.wikipedia.org/wiki/Sch%C3%B6nhage%E2%80%93Strassen_algorithm) was not used. Instead, three distinct 64-bit primes were carefully chosen to enable NTT up to ~10^18 64bit integers, which allows multiplication up to ~5 x 10^17 64bit integers. Depending on the input length either two or three primes are used, with the latter only used when the inputs consist of at least 2^40 64bit integers. The convolution results modulo primes are merged using the [Chinese Remainder Theorem](https://en.wikipedia.org/wiki/Chinese_remainder_theorem).
* To reduce padding and the number of cycles for NTT, multiple radices are used (radix-2, radix-3, radix-4, radix-5, radix-6). Radix-8 is desirable but actually slower, presumably due to register spill. Although manual SIMD coding may alleviate this issue, it was not used (i) for maximum portability and (ii) since 64bit SIMD multiply is not widely available even on x86/x64 platforms (AVX512). The prime moduli are carefully chosen to support these radices.
  * The NTT length is selected by exhaustively evaluating cost estimates for all allowed lengths within a factor of two.
* Single-word (u64) [Montgomery reduction](https://en.algorithmica.org/hpc/number-theory/montgomery/) is used for fast modular multiplication.
* 32bit digits are supported by repacking the digits into u64, running the u64 algorithm, and converting back to u32. This results in 32bit builds being about 3-5x slower compared to 64bit builds, which, however, still is an improvement upon the existing algorithms.
* Unbalanced multiplication is enabled when the cost estimates are favorable.
* Based on experimentation, the following thresholds are chosen:
  * For u64 digits, switch to NTT if the shorter integer has at least 512 digits.
  * For u32 digits, switch to NTT if the shorter integer has at least 2,048 digits.
* The three primes are as follows:
  * P1 = 10_237_243_632_176_332_801, Max NTT length = 2^24 * 3^20 * 5^2 = 1_462_463_376_025_190_400
  * P2 = 13_649_658_176_235_110_401, Max NTT length = 2^26 * 3^19 * 5^2 = 1_949_951_168_033_587_200
  * P3 = 14_259_017_916_245_606_401, Max NTT length = 2^22 * 3^21 * 5^2 = 1_096_847_532_018_892_800
  * P1 and P2 are used for the two-prime NTT, whereas the three-prime NTT uses all three.
* The following MIT-licensed projects are used as reference:
  * [http://wwwa.pikara.ne.jp/okojisan/otfft-en/index.html](http://wwwa.pikara.ne.jp/okojisan/otfft-en/index.html)
  * [https://github.com/Bubbler-4/cg263748](https://github.com/Bubbler-4/cg263748)

On Ryzen 7 2700X, 64bit, it takes about 15ms for 2.7Mbits x 2.7Mbits and 170ms for 27Mbits x 27Mbits multiplication. This seems comparable to GMP 6.2.1.

![benchmark-20230829](https://github.com/rust-num/num-bigint/assets/24885840/2b5a89dc-b61a-4afc-9e71-40b19a005b3a)