### PR TITLE
Avoid cloning inputs in sub and add

### DIFF
--- a/src/bigint/addition.rs
+++ b/src/bigint/addition.rs
@@ -14,8 +14,7 @@ use num_traits::{CheckedAdd, Zero};
 // We want to forward to BigUint::add, but it's not clear how that will go until
 // we compare both sign and magnitude.  So we call this function for every
 // val/ref combination, deferring that decision to BigUint's own forwarding.
-fn generic_add(a: Cow<'_, BigInt>, b: Cow<'_, BigInt>) -> BigInt {
-
+fn bigint_add(a: Cow<'_, BigInt>, b: Cow<'_, BigInt>) -> BigInt {
     match (a.sign, b.sign) {
         (_, NoSign) => match a {
             Cow::Borrowed(a) => a.clone(),
@@ -26,9 +25,7 @@ fn generic_add(a: Cow<'_, BigInt>, b: Cow<'_, BigInt>) -> BigInt {
             Cow::Owned(b) => b,
         },
         // same sign => keep the sign with the sum of magnitudes
-        (Plus, Plus) | (Minus, Minus) => {
-            BigInt::from_biguint(a.sign, &a.data + &b.data)
-        }
+        (Plus, Plus) | (Minus, Minus) => BigInt::from_biguint(a.sign, &a.data + &b.data),
         // opposite signs => keep the sign of the larger with the difference of magnitudes
         (Plus, Minus) | (Minus, Plus) => match &a.data.cmp(&b.data) {
             Less => BigInt::from_biguint(b.sign, &b.data - &a.data),
@@ -43,7 +40,7 @@ impl Add<&BigInt> for &BigInt {
 
     #[inline]
     fn add(self, other: &BigInt) -> BigInt {
-        generic_add(Cow::Borrowed(self), Cow::Borrowed(other))
+        bigint_add(Cow::Borrowed(self), Cow::Borrowed(other))
     }
 }
 
@@ -52,7 +49,7 @@ impl Add<BigInt> for &BigInt {
 
     #[inline]
     fn add(self, other: BigInt) -> BigInt {
-        generic_add(Cow::Borrowed(self), Cow::Owned(other))
+        bigint_add(Cow::Borrowed(self), Cow::Owned(other))
     }
 }
 
@@ -61,7 +58,7 @@ impl Add<&BigInt> for BigInt {
 
     #[inline]
     fn add(self, other: &BigInt) -> BigInt {
-        generic_add(Cow::Owned(self), Cow::Borrowed(other))
+        bigint_add(Cow::Owned(self), Cow::Borrowed(other))
     }
 }
 
@@ -70,7 +67,7 @@ impl Add<BigInt> for BigInt {
 
     #[inline]
     fn add(self, other: BigInt) -> BigInt {
-        generic_add(Cow::Owned(self), Cow::Owned(other))
+        bigint_add(Cow::Owned(self), Cow::Owned(other))
     }
 }
 

--- a/src/bigint/subtraction.rs
+++ b/src/bigint/subtraction.rs
@@ -1,6 +1,7 @@
 use super::CheckedUnsignedAbs::{Negative, Positive};
 use super::Sign::{Minus, NoSign, Plus};
 use super::{BigInt, UnsignedAbs};
+use std::borrow::Cow;
 
 use crate::{IsizePromotion, UsizePromotion};
 
@@ -10,23 +11,27 @@ use core::ops::{Sub, SubAssign};
 use num_traits::{CheckedSub, Zero};
 
 // We want to forward to BigUint::sub, but it's not clear how that will go until
-// we compare both sign and magnitude.  So we duplicate this body for every
+// we compare both sign and magnitude.  So we call this function for every
 // val/ref combination, deferring that decision to BigUint's own forwarding.
-macro_rules! bigint_sub {
-    ($a:expr, $a_owned:expr, $a_data:expr, $b:expr, $b_owned:expr, $b_data:expr) => {
-        match ($a.sign, $b.sign) {
-            (_, NoSign) => $a_owned,
-            (NoSign, _) => -$b_owned,
-            // opposite signs => keep the sign of the left with the sum of magnitudes
-            (Plus, Minus) | (Minus, Plus) => BigInt::from_biguint($a.sign, $a_data + $b_data),
-            // same sign => keep or toggle the sign of the left with the difference of magnitudes
-            (Plus, Plus) | (Minus, Minus) => match $a.data.cmp(&$b.data) {
-                Less => BigInt::from_biguint(-$a.sign, $b_data - $a_data),
-                Greater => BigInt::from_biguint($a.sign, $a_data - $b_data),
-                Equal => Zero::zero(),
-            },
-        }
-    };
+fn generic_sub(a: Cow<'_, BigInt>, b: Cow<'_, BigInt>) -> BigInt {
+    match (a.sign, b.sign) {
+        (_, NoSign) => match a {
+            Cow::Borrowed(a) => a.clone(),
+            Cow::Owned(a) => a,
+        },
+        (NoSign, _) => match b {
+            Cow::Borrowed(b) => -b.clone(),
+            Cow::Owned(b) => -b,
+        },
+        // opposite signs => keep the sign of the left with the sum of magnitudes
+        (Plus, Minus) | (Minus, Plus) => BigInt::from_biguint(a.sign, &a.data + &b.data),
+        // same sign => keep or toggle the sign of the left with the difference of magnitudes
+        (Plus, Plus) | (Minus, Minus) => match a.data.cmp(&b.data) {
+            Less => BigInt::from_biguint(-a.sign, &b.data - &a.data),
+            Greater => BigInt::from_biguint(a.sign, &a.data - &b.data),
+            Equal => Zero::zero(),
+        },
+    }
 }
 
 impl Sub<&BigInt> for &BigInt {
@@ -34,14 +39,7 @@ impl Sub<&BigInt> for &BigInt {
 
     #[inline]
     fn sub(self, other: &BigInt) -> BigInt {
-        bigint_sub!(
-            self,
-            self.clone(),
-            &self.data,
-            other,
-            other.clone(),
-            &other.data
-        )
+        generic_sub(Cow::Borrowed(self), Cow::Borrowed(other))
     }
 }
 
@@ -50,7 +48,7 @@ impl Sub<BigInt> for &BigInt {
 
     #[inline]
     fn sub(self, other: BigInt) -> BigInt {
-        bigint_sub!(self, self.clone(), &self.data, other, other, other.data)
+        generic_sub(Cow::Borrowed(self), Cow::Owned(other))
     }
 }
 
@@ -59,7 +57,7 @@ impl Sub<&BigInt> for BigInt {
 
     #[inline]
     fn sub(self, other: &BigInt) -> BigInt {
-        bigint_sub!(self, self, self.data, other, other.clone(), &other.data)
+        generic_sub(Cow::Owned(self), Cow::Borrowed(other))
     }
 }
 
@@ -68,7 +66,7 @@ impl Sub<BigInt> for BigInt {
 
     #[inline]
     fn sub(self, other: BigInt) -> BigInt {
-        bigint_sub!(self, self, self.data, other, other, other.data)
+        generic_sub(Cow::Owned(self), Cow::Owned(other))
     }
 }
 

--- a/src/bigint/subtraction.rs
+++ b/src/bigint/subtraction.rs
@@ -13,7 +13,7 @@ use num_traits::{CheckedSub, Zero};
 // We want to forward to BigUint::sub, but it's not clear how that will go until
 // we compare both sign and magnitude.  So we call this function for every
 // val/ref combination, deferring that decision to BigUint's own forwarding.
-fn generic_sub(a: Cow<'_, BigInt>, b: Cow<'_, BigInt>) -> BigInt {
+fn bigint_sub(a: Cow<'_, BigInt>, b: Cow<'_, BigInt>) -> BigInt {
     match (a.sign, b.sign) {
         (_, NoSign) => match a {
             Cow::Borrowed(a) => a.clone(),
@@ -39,7 +39,7 @@ impl Sub<&BigInt> for &BigInt {
 
     #[inline]
     fn sub(self, other: &BigInt) -> BigInt {
-        generic_sub(Cow::Borrowed(self), Cow::Borrowed(other))
+        bigint_sub(Cow::Borrowed(self), Cow::Borrowed(other))
     }
 }
 
@@ -48,7 +48,7 @@ impl Sub<BigInt> for &BigInt {
 
     #[inline]
     fn sub(self, other: BigInt) -> BigInt {
-        generic_sub(Cow::Borrowed(self), Cow::Owned(other))
+        bigint_sub(Cow::Borrowed(self), Cow::Owned(other))
     }
 }
 
@@ -57,7 +57,7 @@ impl Sub<&BigInt> for BigInt {
 
     #[inline]
     fn sub(self, other: &BigInt) -> BigInt {
-        generic_sub(Cow::Owned(self), Cow::Borrowed(other))
+        bigint_sub(Cow::Owned(self), Cow::Borrowed(other))
     }
 }
 
@@ -66,7 +66,7 @@ impl Sub<BigInt> for BigInt {
 
     #[inline]
     fn sub(self, other: BigInt) -> BigInt {
-        generic_sub(Cow::Owned(self), Cow::Owned(other))
+        bigint_sub(Cow::Owned(self), Cow::Owned(other))
     }
 }
 


### PR DESCRIPTION
Addition and subtraction with references currently clones inputs to use in the case that the other input is zero. For all other cases, the cloned value is not used.

This PR ensures that the clone is done lazily to avoid the performance penalty of the unnecessary clone.

The PR also uses a function instead of a macro, but this could be easily reverted.