### PR TITLE
Optimise multiplication

### DIFF
--- a/benches/bigint.rs
+++ b/benches/bigint.rs
@@ -88,6 +88,16 @@ fn multiply_3(b: &mut Bencher) {
 }
 
 #[bench]
+fn multiply_4(b: &mut Bencher) {
+    multiply_bench(b, 1 << 12, 1 << 13);
+}
+
+#[bench]
+fn multiply_5(b: &mut Bencher) {
+    multiply_bench(b, 1 << 12, 1 << 14);
+}
+
+#[bench]
 fn divide_0(b: &mut Bencher) {
     divide_bench(b, 1 << 8, 1 << 6);
 }

--- a/src/biguint/multiplication.rs
+++ b/src/biguint/multiplication.rs
@@ -164,7 +164,6 @@ fn mac3(mut acc: &mut [BigDigit], mut b: &[BigDigit], mut c: &[BigDigit]) {
         // (x * high2) * NBASE ^ m2 + z0
         mac3(acc, x, low2);
         mac3(&mut acc[m2..], x, high2);
-
     } else if x.len() <= 256 {
         // Karatsuba multiplication:
         //

--- a/src/biguint/multiplication.rs
+++ b/src/biguint/multiplication.rs
@@ -161,30 +161,10 @@ fn mac3(mut acc: &mut [BigDigit], mut b: &[BigDigit], mut c: &[BigDigit]) {
         let m2 = y.len() / 2;
         let (low2, high2) = y.split_at(m2);
 
-        // We reuse the same BigUint for all the intermediate multiplies and have to size p
-        // appropriately here: x.len() and high2.len() could be different:
-        let len = x.len() + high2.len() + 1;
-        let mut p = BigUint { data: vec![0; len] };
+        // (x * high2) * NBASE ^ m2 + z0
+        mac3(acc, x, low2);
+        mac3(&mut acc[m2..], x, high2);
 
-        // z0 = x * low2
-        mac3(&mut p.data, x, low2);
-        p.normalize();
-
-        // Add z0 directly to the accumulator
-        add2(acc, &p.data);
-
-        // Zero out p before the next multiply:
-        p.data.truncate(0);
-        p.data.resize(len, 0);
-
-        // temp = x * high2
-        mac3(&mut p.data, x, high2);
-        p.normalize();
-
-        // Add temp shifted by m2 to the accumulator
-        // This simulates the effect of multiplying temp by b^m2.
-        // Add directly starting at index m2 in the accumulator.
-        add2(&mut acc[m2..], &p.data);
     } else if x.len() <= 256 {
         // Karatsuba multiplication:
         //


### PR DESCRIPTION
Hi maintainers of rust-num/num-bigint,

I've been hacking on PostgreSQL's numeric.c lately, implementing the Karatsuba algorithm [1].

During this work, I realised that when splitting by half the larger factor's size, then if the smaller factor is less than that, its high part will be zero. I realised that a variable that is zero usually means a formula can be simplified, so I tried to plug in the zero high1 in the formula, and voila, that eliminated a multiplication and most of the additions/subtractions, needing only one multiplication and an addition. This simplification felt too obvious to be novel, have looked around a bit but haven't found it so far. Should be mentioned on the Karatsuba Wikipedia or something I think.

I of course checked also Rust's implementation, and it also seems to benefit from this trick, hence this Pull Request.

Would be fun to know what you think.

Benchmark:

    -test multiply_0           ... bench:          42 ns/iter (+/- 0)
    +test multiply_0           ... bench:          42 ns/iter (+/- 0)

    -test multiply_1           ... bench:       4,271 ns/iter (+/- 68)
    +test multiply_1           ... bench:       4,242 ns/iter (+/- 164)

    -test multiply_2           ... bench:     289,339 ns/iter (+/- 10,532)
    +test multiply_2           ... bench:     288,857 ns/iter (+/- 8,715)

    -test multiply_3           ... bench:     663,387 ns/iter (+/- 17,381)
    +test multiply_3           ... bench:     583,635 ns/iter (+/- 14,997)

    -test multiply_4           ... bench:       7,474 ns/iter (+/- 384)
    +test multiply_4           ... bench:       6,649 ns/iter (+/- 164)

    -test multiply_5           ... bench:      16,376 ns/iter (+/- 254)
    +test multiply_5           ... bench:      13,922 ns/iter (+/- 323)

Thanks for great work!

/Joel

[1] https://www.postgresql.org/message-id/flat/7f95163f-2019-4416-a042-6e2141619e5d@app.fastmail.com