### PR TITLE
Fixed incorrect formulas for coefficients.

### DIFF
--- a/src/biguint/multiplication.rs
+++ b/src/biguint/multiplication.rs
@@ -369,9 +369,9 @@ fn mac3(mut acc: &mut [BigDigit], mut b: &[BigDigit], mut c: &[BigDigit]) {
         // in terms of its coefficients:
         //
         // w0 = w(0)
-        // w1 = w(0)/2 + w(1)/3 - w(-1) + w(2)/6 - 2*w(inf)
+        // w1 = w(0)/2 + w(1)/3 - w(-1) + w(-2)/6 - 2*w(inf)
         // w2 = -w(0) + w(1)/2 + w(-1)/2 - w(inf)
-        // w3 = -w(0)/2 + w(1)/6 + w(-1)/2 - w(1)/6
+        // w3 = -w(0)/2 + w(1)/6 + w(-1)/2 - w(-2)/6 + 2*w(inf)
         // w4 = w(inf)
         //
         // This particular sequence is given by Bodrato and is an interpolation


### PR DESCRIPTION
This concerns only the comments for big integer multiplication where the formulas for the coefficients w0..w4 are explicitly listed. These were not completely correct. Please compare the formulas with https://en.wikipedia.org/wiki/Toom%E2%80%93Cook_multiplication#Interpolation. 