### PR TITLE
Commit to `alloc` as much as possible

### DIFF
--- a/src/bigint.rs
+++ b/src/bigint.rs
@@ -1,7 +1,8 @@
 // `Add`/`Sub` ops may flip from `BigInt` to its `BigUint` magnitude
 #![allow(clippy::suspicious_arithmetic_impl)]
 
-use crate::std_alloc::{String, Vec};
+use alloc::string::String;
+use alloc::vec::Vec;
 use core::cmp::Ordering::{self, Equal};
 use core::default::Default;
 use core::fmt;

--- a/src/bigint/arbitrary.rs
+++ b/src/bigint/arbitrary.rs
@@ -1,8 +1,8 @@
 use super::{BigInt, Sign};
+use crate::BigUint;
 
 #[cfg(feature = "quickcheck")]
-use crate::std_alloc::Box;
-use crate::BigUint;
+use alloc::boxed::Box;
 
 #[cfg(feature = "quickcheck")]
 impl quickcheck::Arbitrary for BigInt {

--- a/src/bigint/bits.rs
+++ b/src/bigint/bits.rs
@@ -3,8 +3,8 @@ use super::Sign::{Minus, NoSign, Plus};
 
 use crate::big_digit::{self, BigDigit, DoubleBigDigit};
 use crate::biguint::IntDigits;
-use crate::std_alloc::Vec;
 
+use alloc::vec::Vec;
 use core::cmp::Ordering::{Equal, Greater, Less};
 use core::ops::{BitAnd, BitAndAssign, BitOr, BitOrAssign, BitXor, BitXorAssign};
 use num_traits::{ToPrimitive, Zero};

--- a/src/bigint/convert.rs
+++ b/src/bigint/convert.rs
@@ -1,10 +1,10 @@
 use super::Sign::{self, Minus, NoSign, Plus};
 use super::{BigInt, ToBigInt};
 
-use crate::std_alloc::Vec;
 use crate::TryFromBigIntError;
 use crate::{BigUint, ParseBigIntError, ToBigUint};
 
+use alloc::vec::Vec;
 use core::cmp::Ordering::{Equal, Greater, Less};
 use core::convert::TryFrom;
 use core::str::{self, FromStr};

--- a/src/biguint.rs
+++ b/src/biguint.rs
@@ -1,6 +1,7 @@
 use crate::big_digit::{self, BigDigit};
-use crate::std_alloc::{String, Vec};
 
+use alloc::string::String;
+use alloc::vec::Vec;
 use core::cmp;
 use core::cmp::Ordering;
 use core::default::Default;

--- a/src/biguint/arbitrary.rs
+++ b/src/biguint/arbitrary.rs
@@ -2,8 +2,8 @@ use super::{biguint_from_vec, BigUint};
 
 use crate::big_digit::BigDigit;
 #[cfg(feature = "quickcheck")]
-use crate::std_alloc::Box;
-use crate::std_alloc::Vec;
+use alloc::boxed::Box;
+use alloc::vec::Vec;
 
 #[cfg(feature = "quickcheck")]
 impl quickcheck::Arbitrary for BigUint {

--- a/src/biguint/convert.rs
+++ b/src/biguint/convert.rs
@@ -8,10 +8,10 @@ use super::division::{div_rem_digit, FAST_DIV_WIDE};
 use super::multiplication::mac_with_carry;
 
 use crate::big_digit::{self, BigDigit};
-use crate::std_alloc::Vec;
 use crate::ParseBigIntError;
 use crate::TryFromBigIntError;
 
+use alloc::vec::Vec;
 use core::cmp::Ordering::{Equal, Greater, Less};
 use core::convert::TryFrom;
 use core::mem;

--- a/src/biguint/monty.rs
+++ b/src/biguint/monty.rs
@@ -1,4 +1,4 @@
-use crate::std_alloc::Vec;
+use alloc::vec::Vec;
 use core::mem;
 use core::ops::Shl;
 use num_traits::One;

--- a/src/biguint/serde.rs
+++ b/src/biguint/serde.rs
@@ -1,7 +1,6 @@
 use super::{biguint_from_vec, BigUint};
 
-use crate::std_alloc::Vec;
-
+use alloc::vec::Vec;
 use core::{cmp, fmt, mem};
 use serde::de::{SeqAccess, Visitor};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};

--- a/src/biguint/shift.rs
+++ b/src/biguint/shift.rs
@@ -1,8 +1,9 @@
 use super::{biguint_from_vec, BigUint};
 
 use crate::big_digit;
-use crate::std_alloc::{Cow, Vec};
 
+use alloc::borrow::Cow;
+use alloc::vec::Vec;
 use core::mem;
 use core::ops::{Shl, ShlAssign, Shr, ShrAssign};
 use num_traits::{PrimInt, Zero};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,10 +60,10 @@
 //!
 //! ## Features
 //!
-//! The `std` crate feature is enabled by default, and is mandatory before Rust
-//! 1.36 and the stabilized `alloc` crate.  If you depend on `num-bigint` with
-//! `default-features = false`, you must manually enable the `std` feature yourself
-//! if your compiler is not new enough.
+//! The `std` crate feature is enabled by default, which enables [`std::error::Error`]
+//! implementations and some internal use of floating point approximations. This can be disabled by
+//! depending on `num-bigint` with `default-features = false`. Either way, the `alloc` crate is
+//! always required for heap allocation of the `BigInt`/`BigUint` digits.
 //!
 //! ### Random Generation
 //!
@@ -87,35 +87,13 @@
 #![warn(rust_2018_idioms)]
 #![no_std]
 
-#[cfg(feature = "std")]
-#[macro_use]
-extern crate std;
-
-#[cfg(feature = "std")]
-mod std_alloc {
-    pub(crate) use std::borrow::Cow;
-    #[cfg(feature = "quickcheck")]
-    pub(crate) use std::boxed::Box;
-    pub(crate) use std::string::String;
-    pub(crate) use std::vec::Vec;
-}
-
-#[cfg(not(feature = "std"))]
 #[macro_use]
 extern crate alloc;
 
-#[cfg(not(feature = "std"))]
-mod std_alloc {
-    pub(crate) use alloc::borrow::Cow;
-    #[cfg(feature = "quickcheck")]
-    pub(crate) use alloc::boxed::Box;
-    pub(crate) use alloc::string::String;
-    pub(crate) use alloc::vec::Vec;
-}
+#[cfg(feature = "std")]
+extern crate std;
 
 use core::fmt;
-#[cfg(feature = "std")]
-use std::error::Error;
 
 #[macro_use]
 mod macros;
@@ -176,7 +154,7 @@ impl fmt::Display for ParseBigIntError {
 }
 
 #[cfg(feature = "std")]
-impl Error for ParseBigIntError {
+impl std::error::Error for ParseBigIntError {
     fn description(&self) -> &str {
         self.__description()
     }


### PR DESCRIPTION
Since our MSRV is 1.60, and `alloc` was stabilized way back in 1.36, we don't need to be conditional about using it anymore. There are still a few places where we use `std` functionality, like `std::error::Error`, so that feature flag is still useful, but less than it used to be.