### PR TITLE
style: use strip_prefix instead of manual starts_with/slice

### DIFF
--- a/src/bigint/convert.rs
+++ b/src/bigint/convert.rs
@@ -25,8 +25,7 @@ impl Num for BigInt {
     /// Creates and initializes a [`BigInt`].
     #[inline]
     fn from_str_radix(mut s: &str, radix: u32) -> Result<BigInt, ParseBigIntError> {
-        let sign = if s.starts_with('-') {
-            let tail = &s[1..];
+        let sign = if let Some(tail) = s.strip_prefix('-') {
             if !tail.starts_with('+') {
                 s = tail
             }

--- a/src/biguint/convert.rs
+++ b/src/biguint/convert.rs
@@ -221,8 +221,7 @@ impl Num for BigUint {
     fn from_str_radix(s: &str, radix: u32) -> Result<BigUint, ParseBigIntError> {
         assert!(2 <= radix && radix <= 36, "The radix must be within 2...36");
         let mut s = s;
-        if s.starts_with('+') {
-            let tail = &s[1..];
+        if let Some(tail) = s.strip_prefix('+') {
             if !tail.starts_with('+') {
                 s = tail
             }


### PR DESCRIPTION
`strip_prefix` is stable [since 1.45.0](https://doc.rust-lang.org/nightly/std/primitive.str.html#method.strip_prefix), which is less than the MSRV (1.60) of this crate, and it generally [generates better code](https://rust.godbolt.org/z/nfcsv4Eb8).
