### PR TITLE
addition/subtraction acceleration via inline assembly

### DIFF
--- a/src/biguint/addition.rs
+++ b/src/biguint/addition.rs
@@ -1,6 +1,8 @@
 use super::{BigUint, IntDigits};
 #[cfg(target_arch = "x86_64")]
-use std::arch::asm;
+cfg_64!(
+    use std::arch::asm;
+);
 
 use crate::big_digit::{self, BigDigit};
 use crate::UsizePromotion;

--- a/src/biguint/addition.rs
+++ b/src/biguint/addition.rs
@@ -1,4 +1,6 @@
 use super::{BigUint, IntDigits};
+#[cfg(target_arch = "x86_64")]
+use std::arch::asm;
 
 use crate::big_digit::{self, BigDigit};
 use crate::UsizePromotion;
@@ -45,6 +47,96 @@ fn adc(carry: u8, lhs: BigDigit, rhs: BigDigit, out: &mut BigDigit) -> u8 {
     u8::from(b || d)
 }
 
+/// Performs a part of the addition. Returns a tuple containing the carry state
+/// and the number of integers that were added
+///
+/// By using as many registers as possible, we treat digits 5 by 5
+#[cfg(target_arch = "x86_64")]
+unsafe fn schoolbook_add_assign_x86_64(
+    lhs: *mut u64,
+    rhs: *const u64,
+    mut size: usize,
+) -> (bool, usize) {
+    size /= 5;
+    if size == 0 {
+        return (false, 0);
+    }
+
+    let mut c: u8;
+    let mut idx = 0;
+
+    asm!(
+        // Clear the carry flag
+        "clc",
+
+        "3:",
+
+        // Copy a in registers
+        "mov {a_tmp1}, qword ptr [{a} + 8*{idx}]",
+        "mov {a_tmp2}, qword ptr [{a} + 8*{idx} + 8]",
+        "mov {a_tmp3}, qword ptr [{a} + 8*{idx} + 16]",
+        "mov {a_tmp4}, qword ptr [{a} + 8*{idx} + 24]",
+        "mov {a_tmp5}, qword ptr [{a} + 8*{idx} + 32]",
+
+        // Copy b in registers
+        "mov {b_tmp1}, qword ptr [{b} + 8*{idx}]",
+        "mov {b_tmp2}, qword ptr [{b} + 8*{idx} + 8]",
+        "mov {b_tmp3}, qword ptr [{b} + 8*{idx} + 16]",
+        "mov {b_tmp4}, qword ptr [{b} + 8*{idx} + 24]",
+        "mov {b_tmp5}, qword ptr [{b} + 8*{idx} + 32]",
+
+        // Perform the addition
+        "adc {a_tmp1}, {b_tmp1}",
+        "adc {a_tmp2}, {b_tmp2}",
+        "adc {a_tmp3}, {b_tmp3}",
+        "adc {a_tmp4}, {b_tmp4}",
+        "adc {a_tmp5}, {b_tmp5}",
+
+        // Copy the return values
+        "mov qword ptr [{a} + 8*{idx}], {a_tmp1}",
+        "mov qword ptr [{a} + 8*{idx} + 8], {a_tmp2}",
+        "mov qword ptr [{a} + 8*{idx} + 16], {a_tmp3}",
+        "mov qword ptr [{a} + 8*{idx} + 24], {a_tmp4}",
+        "mov qword ptr [{a} + 8*{idx} + 32], {a_tmp5}",
+
+        // Increment loop counter
+        // `inc` and `dec` aren't modifying carry flag
+        "inc {idx}",
+        "inc {idx}",
+        "inc {idx}",
+        "inc {idx}",
+        "inc {idx}",
+        "dec {size}",
+        "jnz 3b",
+
+        // Output carry flag and clear
+        "setc {c}",
+        "clc",
+
+        size = in(reg) size,
+        a = in(reg) lhs,
+        b = in(reg) rhs,
+        c = lateout(reg_byte) c,
+        idx = inout(reg) idx,
+
+        a_tmp1 = out(reg) _,
+        a_tmp2 = out(reg) _,
+        a_tmp3 = out(reg) _,
+        a_tmp4 = out(reg) _,
+        a_tmp5 = out(reg) _,
+
+        b_tmp1 = out(reg) _,
+        b_tmp2 = out(reg) _,
+        b_tmp3 = out(reg) _,
+        b_tmp4 = out(reg) _,
+        b_tmp5 = out(reg) _,
+
+        options(nostack),
+    );
+
+    (c > 0, idx)
+}
+
 /// Two argument addition of raw slices, `a += b`, returning the carry.
 ///
 /// This is used when the data `Vec` might need to resize to push a non-zero carry, so we perform
@@ -55,10 +147,17 @@ fn adc(carry: u8, lhs: BigDigit, rhs: BigDigit, out: &mut BigDigit) -> u8 {
 pub(super) fn __add2(a: &mut [BigDigit], b: &[BigDigit]) -> BigDigit {
     debug_assert!(a.len() >= b.len());
 
-    let mut carry = 0;
     let (a_lo, a_hi) = a.split_at_mut(b.len());
 
-    for (a, b) in a_lo.iter_mut().zip(b) {
+    // On x86_64 machine, perform most of the addition via inline assembly
+    #[cfg(target_arch = "x86_64")]
+    let (c, done) = unsafe { schoolbook_add_assign_x86_64(a_lo.as_mut_ptr(), b.as_ptr(), b.len()) };
+    #[cfg(not(target_arch = "x86_64"))]
+    let (c, done) = (false, 0);
+
+    let mut carry = c as u8;
+
+    for (a, b) in a_lo[done..].iter_mut().zip(b[done..].iter()) {
         carry = adc(carry, *a, *b, a);
     }
 

--- a/src/biguint/subtraction.rs
+++ b/src/biguint/subtraction.rs
@@ -1,6 +1,8 @@
 use super::BigUint;
 #[cfg(target_arch = "x86_64")]
-use std::arch::asm;
+cfg_64!(
+    use std::arch::asm;
+);
 
 use crate::big_digit::{self, BigDigit};
 use crate::UsizePromotion;

--- a/src/biguint/subtraction.rs
+++ b/src/biguint/subtraction.rs
@@ -47,105 +47,119 @@ fn sbb(borrow: u8, lhs: BigDigit, rhs: BigDigit, out: &mut BigDigit) -> u8 {
     u8::from(b || d)
 }
 
-/// Performs a part of the subtraction. Returns a tuple containing the carry state
-/// and the number of integers that were subtracted
-///
-/// By using as many registers as possible, we treat digits 5 by 5
 #[cfg(target_arch = "x86_64")]
-unsafe fn schoolbook_sub_assign_x86_64(
-    lhs: *mut u64,
-    rhs: *const u64,
-    mut size: usize,
-) -> (bool, usize) {
-    size /= 5;
-    if size == 0 {
-        return (false, 0);
+cfg_64!(
+    /// Performs a part of the subtraction. Returns a tuple containing the carry state
+    /// and the number of integers that were subtracted
+    ///
+    /// By using as many registers as possible, we treat digits 5 by 5
+    unsafe fn schoolbook_sub_assign_x86_64(
+        lhs: *mut u64,
+        rhs: *const u64,
+        mut size: usize,
+    ) -> (bool, usize) {
+        size /= 5;
+        if size == 0 {
+            return (false, 0);
+        }
+
+        let mut c: u8;
+        let mut idx = 0;
+
+        asm!(
+            // Clear carry flag
+            "clc",
+
+            "3:",
+
+            // Copy a in registers
+            "mov {a_tmp1}, qword ptr [{a} + 8*{idx}]",
+            "mov {a_tmp2}, qword ptr [{a} + 8*{idx} + 8]",
+            "mov {a_tmp3}, qword ptr [{a} + 8*{idx} + 16]",
+            "mov {a_tmp4}, qword ptr [{a} + 8*{idx} + 24]",
+            "mov {a_tmp5}, qword ptr [{a} + 8*{idx} + 32]",
+
+            // Copy b in registers
+            "mov {b_tmp1}, qword ptr [{b} + 8*{idx}]",
+            "mov {b_tmp2}, qword ptr [{b} + 8*{idx} + 8]",
+            "mov {b_tmp3}, qword ptr [{b} + 8*{idx} + 16]",
+            "mov {b_tmp4}, qword ptr [{b} + 8*{idx} + 24]",
+            "mov {b_tmp5}, qword ptr [{b} + 8*{idx} + 32]",
+
+            // Perform the subtraction
+            "sbb {a_tmp1}, {b_tmp1}",
+            "sbb {a_tmp2}, {b_tmp2}",
+            "sbb {a_tmp3}, {b_tmp3}",
+            "sbb {a_tmp4}, {b_tmp4}",
+            "sbb {a_tmp5}, {b_tmp5}",
+
+            // Copy the return values
+            "mov qword ptr [{a} + 8*{idx}], {a_tmp1}",
+            "mov qword ptr [{a} + 8*{idx} + 8], {a_tmp2}",
+            "mov qword ptr [{a} + 8*{idx} + 16], {a_tmp3}",
+            "mov qword ptr [{a} + 8*{idx} + 24], {a_tmp4}",
+            "mov qword ptr [{a} + 8*{idx} + 32], {a_tmp5}",
+
+            // Increment loop counter
+            // `inc` and `dec` aren't modifying carry flag
+            "inc {idx}",
+            "inc {idx}",
+            "inc {idx}",
+            "inc {idx}",
+            "inc {idx}",
+            "dec {size}",
+            "jnz 3b",
+
+            // Output carry flag and clear
+            "setc {c}",
+            "clc",
+
+            size = in(reg) size,
+            a = in(reg) lhs,
+            b = in(reg) rhs,
+            c = lateout(reg_byte) c,
+            idx = inout(reg) idx,
+
+            a_tmp1 = out(reg) _,
+            a_tmp2 = out(reg) _,
+            a_tmp3 = out(reg) _,
+            a_tmp4 = out(reg) _,
+            a_tmp5 = out(reg) _,
+
+            b_tmp1 = out(reg) _,
+            b_tmp2 = out(reg) _,
+            b_tmp3 = out(reg) _,
+            b_tmp4 = out(reg) _,
+            b_tmp5 = out(reg) _,
+
+            options(nostack),
+        );
+
+        (c > 0, idx)
     }
+);
 
-    let mut c: u8;
-    let mut idx = 0;
-
-    asm!(
-        // Clear carry flag
-        "clc",
-
-        "3:",
-
-        // Copy a in registers
-        "mov {a_tmp1}, qword ptr [{a} + 8*{idx}]",
-        "mov {a_tmp2}, qword ptr [{a} + 8*{idx} + 8]",
-        "mov {a_tmp3}, qword ptr [{a} + 8*{idx} + 16]",
-        "mov {a_tmp4}, qword ptr [{a} + 8*{idx} + 24]",
-        "mov {a_tmp5}, qword ptr [{a} + 8*{idx} + 32]",
-
-        // Copy b in registers
-        "mov {b_tmp1}, qword ptr [{b} + 8*{idx}]",
-        "mov {b_tmp2}, qword ptr [{b} + 8*{idx} + 8]",
-        "mov {b_tmp3}, qword ptr [{b} + 8*{idx} + 16]",
-        "mov {b_tmp4}, qword ptr [{b} + 8*{idx} + 24]",
-        "mov {b_tmp5}, qword ptr [{b} + 8*{idx} + 32]",
-
-        // Perform the subtraction
-        "sbb {a_tmp1}, {b_tmp1}",
-        "sbb {a_tmp2}, {b_tmp2}",
-        "sbb {a_tmp3}, {b_tmp3}",
-        "sbb {a_tmp4}, {b_tmp4}",
-        "sbb {a_tmp5}, {b_tmp5}",
-
-        // Copy the return values
-        "mov qword ptr [{a} + 8*{idx}], {a_tmp1}",
-        "mov qword ptr [{a} + 8*{idx} + 8], {a_tmp2}",
-        "mov qword ptr [{a} + 8*{idx} + 16], {a_tmp3}",
-        "mov qword ptr [{a} + 8*{idx} + 24], {a_tmp4}",
-        "mov qword ptr [{a} + 8*{idx} + 32], {a_tmp5}",
-
-        // Increment loop counter
-        // `inc` and `dec` aren't modifying carry flag
-        "inc {idx}",
-        "inc {idx}",
-        "inc {idx}",
-        "inc {idx}",
-        "inc {idx}",
-        "dec {size}",
-        "jnz 3b",
-
-        // Output carry flag and clear
-        "setc {c}",
-        "clc",
-
-        size = in(reg) size,
-        a = in(reg) lhs,
-        b = in(reg) rhs,
-        c = lateout(reg_byte) c,
-        idx = inout(reg) idx,
-
-        a_tmp1 = out(reg) _,
-        a_tmp2 = out(reg) _,
-        a_tmp3 = out(reg) _,
-        a_tmp4 = out(reg) _,
-        a_tmp5 = out(reg) _,
-
-        b_tmp1 = out(reg) _,
-        b_tmp2 = out(reg) _,
-        b_tmp3 = out(reg) _,
-        b_tmp4 = out(reg) _,
-        b_tmp5 = out(reg) _,
-
-        options(nostack),
-    );
-
-    (c > 0, idx)
-}
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+cfg_32!(
+    /// TODO: The same trick as above can be applied to 32 bit targets
+    unsafe fn schoolbook_sub_assign_x86_64(
+        _lhs: *mut u32,
+        _rhs: *const u32,
+        _size: usize,
+    ) -> (bool, usize) {
+        (false, 0)
+    }
+);
 
 pub(super) fn sub2(a: &mut [BigDigit], b: &[BigDigit]) {
     let len = Ord::min(a.len(), b.len());
     let (a_lo, a_hi) = a.split_at_mut(len);
     let (b_lo, b_hi) = b.split_at(len);
 
-    // On x86_64 machine, perform most of the subtraction via inline assembly
-    #[cfg(target_arch = "x86_64")]
+    // On x86 machine, perform most of the subtraction via inline assembly
+    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     let (b, done) = unsafe { schoolbook_sub_assign_x86_64(a_lo.as_mut_ptr(), b_lo.as_ptr(), len) };
-    #[cfg(not(target_arch = "x86_64"))]
+    #[cfg(not(any(target_arch = "x86", target_arch = "x86_64")))]
     let (b, done) = (false, 0);
 
     let mut borrow = b as u8;

--- a/src/biguint/subtraction.rs
+++ b/src/biguint/subtraction.rs
@@ -1,4 +1,6 @@
 use super::BigUint;
+#[cfg(target_arch = "x86_64")]
+use std::arch::asm;
 
 use crate::big_digit::{self, BigDigit};
 use crate::UsizePromotion;
@@ -45,14 +47,110 @@ fn sbb(borrow: u8, lhs: BigDigit, rhs: BigDigit, out: &mut BigDigit) -> u8 {
     u8::from(b || d)
 }
 
-pub(super) fn sub2(a: &mut [BigDigit], b: &[BigDigit]) {
-    let mut borrow = 0;
+/// Performs a part of the subtraction. Returns a tuple containing the carry state
+/// and the number of integers that were subtracted
+///
+/// By using as many registers as possible, we treat digits 5 by 5
+#[cfg(target_arch = "x86_64")]
+unsafe fn schoolbook_sub_assign_x86_64(
+    lhs: *mut u64,
+    rhs: *const u64,
+    mut size: usize,
+) -> (bool, usize) {
+    size /= 5;
+    if size == 0 {
+        return (false, 0);
+    }
 
+    let mut c: u8;
+    let mut idx = 0;
+
+    asm!(
+        // Clear carry flag
+        "clc",
+
+        "3:",
+
+        // Copy a in registers
+        "mov {a_tmp1}, qword ptr [{a} + 8*{idx}]",
+        "mov {a_tmp2}, qword ptr [{a} + 8*{idx} + 8]",
+        "mov {a_tmp3}, qword ptr [{a} + 8*{idx} + 16]",
+        "mov {a_tmp4}, qword ptr [{a} + 8*{idx} + 24]",
+        "mov {a_tmp5}, qword ptr [{a} + 8*{idx} + 32]",
+
+        // Copy b in registers
+        "mov {b_tmp1}, qword ptr [{b} + 8*{idx}]",
+        "mov {b_tmp2}, qword ptr [{b} + 8*{idx} + 8]",
+        "mov {b_tmp3}, qword ptr [{b} + 8*{idx} + 16]",
+        "mov {b_tmp4}, qword ptr [{b} + 8*{idx} + 24]",
+        "mov {b_tmp5}, qword ptr [{b} + 8*{idx} + 32]",
+
+        // Perform the subtraction
+        "sbb {a_tmp1}, {b_tmp1}",
+        "sbb {a_tmp2}, {b_tmp2}",
+        "sbb {a_tmp3}, {b_tmp3}",
+        "sbb {a_tmp4}, {b_tmp4}",
+        "sbb {a_tmp5}, {b_tmp5}",
+
+        // Copy the return values
+        "mov qword ptr [{a} + 8*{idx}], {a_tmp1}",
+        "mov qword ptr [{a} + 8*{idx} + 8], {a_tmp2}",
+        "mov qword ptr [{a} + 8*{idx} + 16], {a_tmp3}",
+        "mov qword ptr [{a} + 8*{idx} + 24], {a_tmp4}",
+        "mov qword ptr [{a} + 8*{idx} + 32], {a_tmp5}",
+
+        // Increment loop counter
+        // `inc` and `dec` aren't modifying carry flag
+        "inc {idx}",
+        "inc {idx}",
+        "inc {idx}",
+        "inc {idx}",
+        "inc {idx}",
+        "dec {size}",
+        "jnz 3b",
+
+        // Output carry flag and clear
+        "setc {c}",
+        "clc",
+
+        size = in(reg) size,
+        a = in(reg) lhs,
+        b = in(reg) rhs,
+        c = lateout(reg_byte) c,
+        idx = inout(reg) idx,
+
+        a_tmp1 = out(reg) _,
+        a_tmp2 = out(reg) _,
+        a_tmp3 = out(reg) _,
+        a_tmp4 = out(reg) _,
+        a_tmp5 = out(reg) _,
+
+        b_tmp1 = out(reg) _,
+        b_tmp2 = out(reg) _,
+        b_tmp3 = out(reg) _,
+        b_tmp4 = out(reg) _,
+        b_tmp5 = out(reg) _,
+
+        options(nostack),
+    );
+
+    (c > 0, idx)
+}
+
+pub(super) fn sub2(a: &mut [BigDigit], b: &[BigDigit]) {
     let len = Ord::min(a.len(), b.len());
     let (a_lo, a_hi) = a.split_at_mut(len);
     let (b_lo, b_hi) = b.split_at(len);
 
-    for (a, b) in a_lo.iter_mut().zip(b_lo) {
+    // On x86_64 machine, perform most of the subtraction via inline assembly
+    #[cfg(target_arch = "x86_64")]
+    let (b, done) = unsafe { schoolbook_sub_assign_x86_64(a_lo.as_mut_ptr(), b_lo.as_ptr(), len) };
+    #[cfg(not(target_arch = "x86_64"))]
+    let (b, done) = (false, 0);
+
+    let mut borrow = b as u8;
+
+    for (a, b) in a_lo[done..].iter_mut().zip(b_lo[done..].iter()) {
         borrow = sbb(borrow, *a, *b, a);
     }
 


### PR DESCRIPTION
During the addition/subtraction loops, there is performance to be gained by specifying the exact assembly instructions. The performance gain start to be felt after 1,000bit integers, and are maximal around 10,000bits, where we are near 2x performance.

Documentation for assembly instructions can be found [here](https://www.felixcloutier.com/x86/)

# Added assembly
### Principle
The main idea is to avoid any instruction that are modifying the carry flags, except for `adc` and `sbb` of course, so that the carry is propagated through the whole loop. This is doable if we use a decreasing index for the loop counter and a `jnz` instruction. The indices we use have to be updated using `inc` and`dec` instructions (those instructions aren't modifying the carry flag).

### Batching
To avoid overhead by looping digits one by one, we fill the 16 registers as much as possible. This enables us to treat digits 5 by 5 in one step (enabling efficient CPU pipelining).

A consequence of this is that a number of digits is still not added after the inline assembly code is run (the number is strictly less than 5). So we keep the existing code to handle the remaining digits.

### Safety
Obviously this is very much unsafe. On my personal project, where I want to let people the option to rely on `safe` Rust, I put these functions behind a feature gate. If necessary, I can take a similar approach here.

# Performance
I've measured performance by using the `criterion` crate, and adding 2 BigUint of different sizes. The results are below. On some scales, this gives close a 2x gain ! To me the performance gain is clear enough to be non-ambiguous, though I'm not a benchmarking expert, and I'm sure a finer evaluation could be interesting.

![Figure_1](https://github.com/rust-num/num-bigint/assets/61565340/77610a53-6691-4d67-ac16-22b468e9eaf2)
 
### Style
For easy review, the 2 added functions are in the files `addition` and `subtraction`, but I'd argue in the end, it'd be better to put them in a dedicated sub-module, they look far too different.

Also I'm notoriously average at naming things, so suggestions are welcome ^^