### PR TITLE
Use divide and conquer in to_radix_digits

### DIFF
--- a/benches/bigint.rs
+++ b/benches/bigint.rs
@@ -113,6 +113,11 @@ fn divide_2(b: &mut Bencher) {
 }
 
 #[bench]
+fn divide_3(b: &mut Bencher) {
+    divide_bench(b, 1 << 20, 1 << 16);
+}
+
+#[bench]
 fn divide_big_little(b: &mut Bencher) {
     divide_bench(b, 1 << 16, 1 << 4);
 }

--- a/benches/bigint.rs
+++ b/benches/bigint.rs
@@ -211,6 +211,16 @@ fn to_str_radix_10_2(b: &mut Bencher) {
 }
 
 #[bench]
+fn to_str_radix_10_3(b: &mut Bencher) {
+    to_str_radix_bench(b, 10, 100009);
+}
+
+#[bench]
+fn to_str_radix_10_4(b: &mut Bencher) {
+    to_str_radix_bench(b, 10, 1000009);
+}
+
+#[bench]
 fn to_str_radix_16(b: &mut Bencher) {
     to_str_radix_bench(b, 16, 1009);
 }

--- a/src/big_digit.rs
+++ b/src/big_digit.rs
@@ -208,6 +208,20 @@ impl BigDigits {
         }
     }
 
+    pub(crate) fn reserve(&mut self, additional: usize) {
+        match &mut *self {
+            BigDigits::Inline(opt_x) => {
+                let capacity = usize::from(opt_x.is_some()) + additional;
+                let mut vec = Vec::with_capacity(capacity);
+                if let Some(x) = *opt_x {
+                    vec.push(x);
+                }
+                *self = BigDigits::Heap(vec);
+            }
+            BigDigits::Heap(xs) => xs.reserve(additional),
+        }
+    }
+
     pub(crate) fn resize(&mut self, len: usize, value: BigDigit) {
         match &mut *self {
             BigDigits::Inline(x) => match len {

--- a/src/big_digit.rs
+++ b/src/big_digit.rs
@@ -212,11 +212,13 @@ impl BigDigits {
         match &mut *self {
             BigDigits::Inline(opt_x) => {
                 let capacity = usize::from(opt_x.is_some()) + additional;
-                let mut vec = Vec::with_capacity(capacity);
-                if let Some(x) = *opt_x {
-                    vec.push(x);
+                if capacity > 1 {
+                    let mut vec = Vec::with_capacity(capacity);
+                    if let Some(x) = *opt_x {
+                        vec.push(x);
+                    }
+                    *self = BigDigits::Heap(vec);
                 }
-                *self = BigDigits::Heap(vec);
             }
             BigDigits::Heap(xs) => xs.reserve(additional),
         }

--- a/src/bigint.rs
+++ b/src/bigint.rs
@@ -1004,7 +1004,7 @@ impl BigInt {
         self.data.bits()
     }
 
-    /// Converts this [`BigInt`] into a [`BigUint`], if it's not negative.
+    /// Converts this owned [`BigInt`] into a [`BigUint`], if it's not negative.
     #[inline]
     pub fn into_biguint(self) -> Option<BigUint> {
         match self.sign {
@@ -1014,7 +1014,7 @@ impl BigInt {
         }
     }
 
-    /// Converts this [`BigInt`] into a [`BigUint`], if it's not negative.
+    /// Converts this borrowed [`BigInt`] into a [`BigUint`], if it's not negative.
     #[inline]
     pub fn to_biguint(&self) -> Option<BigUint> {
         match self.sign {

--- a/src/bigint.rs
+++ b/src/bigint.rs
@@ -1013,7 +1013,7 @@ impl BigInt {
             Minus => None,
         }
     }
-    
+
     /// Converts this [`BigInt`] into a [`BigUint`], if it's not negative.
     #[inline]
     pub fn to_biguint(&self) -> Option<BigUint> {

--- a/src/bigint.rs
+++ b/src/bigint.rs
@@ -1006,6 +1006,16 @@ impl BigInt {
 
     /// Converts this [`BigInt`] into a [`BigUint`], if it's not negative.
     #[inline]
+    pub fn into_biguint(self) -> Option<BigUint> {
+        match self.sign {
+            Plus => Some(self.data),
+            NoSign => Some(BigUint::ZERO),
+            Minus => None,
+        }
+    }
+    
+    /// Converts this [`BigInt`] into a [`BigUint`], if it's not negative.
+    #[inline]
     pub fn to_biguint(&self) -> Option<BigUint> {
         match self.sign {
             Plus => Some(self.data.clone()),

--- a/src/biguint.rs
+++ b/src/biguint.rs
@@ -11,7 +11,7 @@ use core::mem;
 use core::str;
 
 use num_integer::{Integer, Roots};
-use num_traits::{ConstZero, Num, One, Pow, ToPrimitive, Unsigned, Zero};
+use num_traits::{ConstZero, Num, One, Pow, PrimInt, ToPrimitive, Unsigned, Zero};
 
 mod addition;
 mod division;
@@ -29,6 +29,17 @@ mod shift;
 
 pub(crate) use self::convert::to_str_radix_reversed;
 pub use self::iter::{U32Digits, U64Digits};
+
+/// Find last set bit
+/// fls(0) == 0, fls(u32::MAX) == 32
+fn fls<T: PrimInt>(v: T) -> u8 {
+    mem::size_of::<T>() as u8 * 8 - v.leading_zeros() as u8
+}
+
+// TODO(MSRV 1.67): change callers to inherent `ilog2` instead
+fn ilog2<T: PrimInt>(v: T) -> u8 {
+    fls(v) - 1
+}
 
 /// A big unsigned integer type.
 pub struct BigUint {

--- a/src/biguint/convert.rs
+++ b/src/biguint/convert.rs
@@ -1,7 +1,7 @@
 // This uses stdlib features higher than the MSRV
 #![allow(clippy::manual_range_contains)] // 1.35
 
-use super::{biguint_from_vec, BigUint, IntDigits, ToBigUint};
+use super::{biguint_from_vec, BigUint, ToBigUint};
 
 use super::addition::add2;
 use super::division::{div_rem_digit, FAST_DIV_WIDE};
@@ -16,7 +16,7 @@ use core::cmp::Ordering::{Equal, Greater, Less};
 use core::convert::TryFrom;
 use core::mem;
 use core::str::FromStr;
-use num_integer::{Integer, Roots};
+use num_integer::Integer;
 use num_traits::float::FloatCore;
 use num_traits::{FromPrimitive, Num, PrimInt, ToPrimitive, Zero};
 
@@ -702,7 +702,7 @@ pub(super) fn to_radix_digits_le(u: &BigUint, radix: u32) -> Vec<u8> {
     // Estimate how big the result will be, so we can pre-allocate it.
     let mut res = Vec::with_capacity(radix_digits.to_usize().unwrap_or(0));
 
-    let mut digits = u.clone();
+    let digits = u.clone();
 
     // X86 DIV can quickly divide by a full digit, otherwise we choose a divisor
     // that's suitable for `div_half` to avoid slow `DoubleBigDigit` division.

--- a/src/biguint/convert.rs
+++ b/src/biguint/convert.rs
@@ -1,7 +1,7 @@
 // This uses stdlib features higher than the MSRV
 #![allow(clippy::manual_range_contains)] // 1.35
 
-use super::{biguint_from_vec, BigUint, ToBigUint};
+use super::{biguint_from_vec, BigUint, IntDigits, ToBigUint};
 
 use super::addition::add2;
 use super::division::{div_rem_digit, FAST_DIV_WIDE};
@@ -718,34 +718,48 @@ pub(super) fn to_radix_digits_le(u: &BigUint, radix: u32) -> Vec<u8> {
     // The threshold for this was chosen by anecdotal performance measurements to
     // approximate where this starts to make a noticeable difference.
     if digits.data.len() >= 64 {
-        let mut big_base = BigUint::from(base);
-        let mut big_power = 1usize;
+        let mut big_bases = Vec::with_capacity(32);
+        big_bases.push((BigUint::from(base), power));
 
-        // Choose a target base length near √n.
-        let target_len = digits.data.len().sqrt();
-        while big_base.data.len() < target_len {
-            big_base = &big_base * &big_base;
-            big_power *= 2;
-        }
-
-        // This outer loop will run approximately √n times.
-        while digits > big_base {
-            // This is still the dominating factor, with n digits divided by √n digits.
-            let (q, mut big_r) = digits.div_rem(&big_base);
-            digits = q;
-
-            // This inner loop now has O(√n²)=O(n) behavior altogether.
-            for _ in 0..big_power {
-                let (q, mut r) = div_rem_digit(big_r, base);
-                big_r = q;
-                for _ in 0..power {
-                    res.push((r % radix) as u8);
-                    r /= radix;
-                }
+        loop {
+            let (big_base, power) = big_bases.last().unwrap();
+            if big_base.data.len() > digits.data.len() / 2 + 1 {
+                break;
             }
+            let next_big_base = big_base * big_base;
+            let next_power = *power * 2;
+            big_bases.push((next_big_base, next_power));
         }
+
+        to_radix_digits_le_divide_and_conquer(
+            digits,
+            base,
+            power,
+            &big_bases,
+            big_bases.len() - 1,
+            &mut res,
+            radix,
+        );
+        while res.last() == Some(&0) {
+            res.pop();
+        }
+        return res;
     }
 
+    to_radix_digits_le_small(digits, base, power, &mut res, radix);
+
+    res
+}
+
+// Extract little-endian radix digits for small numbers
+#[inline(always)] // forced inline to get const-prop for radix=10
+fn to_radix_digits_le_small(
+    mut digits: BigUint,
+    base: u64,
+    power: usize,
+    res: &mut Vec<u8>,
+    radix: u64,
+) {
     while digits.data.len() > 1 {
         let (q, mut r) = div_rem_digit(digits, base);
         for _ in 0..power {
@@ -760,8 +774,34 @@ pub(super) fn to_radix_digits_le(u: &BigUint, radix: u32) -> Vec<u8> {
         res.push((r % radix) as u8);
         r /= radix;
     }
+}
 
-    res
+fn to_radix_digits_le_divide_and_conquer(
+    number: BigUint,
+    base: u64,
+    power: usize,
+    big_bases: &[(BigUint, usize)],
+    k: usize,
+    res: &mut Vec<u8>,
+    radix: u64,
+) {
+    let &(ref big_base, result_len) = &big_bases[k];
+    if number.data.len() < 8 {
+        let prev_res_len = res.len();
+        if !number.is_zero() {
+            to_radix_digits_le_small(number, base, power, res, radix);
+        }
+        while res.len() < prev_res_len + result_len * 2 {
+            res.push(0);
+        }
+        return;
+    }
+    // number always has two digits in the big base
+    let (digit_1, digit_2) = number.div_rem(big_base);
+    assert!(&digit_1 < big_base);
+    assert!(&digit_2 < big_base);
+    to_radix_digits_le_divide_and_conquer(digit_2, base, power, big_bases, k - 1, res, radix);
+    to_radix_digits_le_divide_and_conquer(digit_1, base, power, big_bases, k - 1, res, radix);
 }
 
 pub(super) fn to_radix_le(u: &BigUint, radix: u32) -> Vec<u8> {

--- a/src/biguint/convert.rs
+++ b/src/biguint/convert.rs
@@ -744,10 +744,10 @@ pub(super) fn to_radix_digits_le(u: &BigUint, radix: u32) -> Vec<u8> {
 #[inline(always)] // forced inline to get const-prop for radix=10
 fn to_radix_digits_le_small(
     mut digits: BigUint,
-    base: u64,
+    base: BigDigit,
     power: usize,
     res: &mut Vec<u8>,
-    radix: u64,
+    radix: BigDigit,
 ) {
     while digits.data.len() > 1 {
         let (q, mut r) = div_rem_digit(digits, base);
@@ -767,12 +767,12 @@ fn to_radix_digits_le_small(
 
 fn to_radix_digits_le_divide_and_conquer(
     number: BigUint,
-    base: u64,
+    base: BigDigit,
     power: usize,
     big_bases: &[(BigUint, usize)],
     k: usize,
     res: &mut Vec<u8>,
-    radix: u64,
+    radix: BigDigit,
 ) {
     let &(ref big_base, result_len) = &big_bases[k];
     if number.data.len() < 8 {

--- a/src/biguint/convert.rs
+++ b/src/biguint/convert.rs
@@ -717,7 +717,7 @@ pub(super) fn to_radix_digits_le(u: &BigUint, radix: u32) -> Vec<u8> {
     // performance. We can mitigate this by dividing into chunks of a larger base first.
     // The threshold for this was chosen by anecdotal performance measurements to
     // approximate where this starts to make a noticeable difference.
-    if digits.data.len() >= 64 {
+    if digits.data.len() >= 32 {
         let mut big_bases = Vec::with_capacity(32);
         big_bases.push((BigUint::from(base), power));
 

--- a/src/biguint/convert.rs
+++ b/src/biguint/convert.rs
@@ -1,7 +1,7 @@
 // This uses stdlib features higher than the MSRV
 #![allow(clippy::manual_range_contains)] // 1.35
 
-use super::{biguint_from_vec, BigUint, ToBigUint};
+use super::{biguint_from_vec, fls, ilog2, BigUint, ToBigUint};
 
 use super::addition::add2;
 use super::division::{div_rem_digit, FAST_DIV_WIDE};
@@ -14,21 +14,10 @@ use crate::TryFromBigIntError;
 use alloc::vec::Vec;
 use core::cmp::Ordering::{Equal, Greater, Less};
 use core::convert::TryFrom;
-use core::mem;
 use core::str::FromStr;
 use num_integer::Integer;
 use num_traits::float::FloatCore;
-use num_traits::{FromPrimitive, Num, PrimInt, ToPrimitive, Zero};
-
-/// Find last set bit
-/// fls(0) == 0, fls(u32::MAX) == 32
-fn fls<T: PrimInt>(v: T) -> u8 {
-    mem::size_of::<T>() as u8 * 8 - v.leading_zeros() as u8
-}
-
-fn ilog2<T: PrimInt>(v: T) -> u8 {
-    fls(v) - 1
-}
+use num_traits::{FromPrimitive, Num, ToPrimitive, Zero};
 
 impl FromStr for BigUint {
     type Err = ParseBigIntError;

--- a/src/biguint/division.rs
+++ b/src/biguint/division.rs
@@ -1,6 +1,6 @@
 use super::addition::__add2;
 use super::shift::biguint_shl;
-use super::{cmp_slice, BigUint};
+use super::{cmp_slice, ilog2, BigUint};
 
 use crate::big_digit::{self, BigDigit, BigDigits, DoubleBigDigit, BITS};
 use crate::biguint::IntDigits;
@@ -238,7 +238,7 @@ fn div_rem_burnikel_ziegler(u: &BigUint, d: &BigUint) -> (BigUint, BigUint) {
     }
 
     fn normalizing_shift_amount(b: &BigUint, level: usize) -> usize {
-        (level - b.len() + 1) * BITS as usize - b.data.last().unwrap().ilog2() as usize - 1
+        (level - b.len() + 1) * BITS as usize - ilog2(*b.data.last().unwrap()) as usize - 1
     }
 
     fn concat_biguint(b1: &BigUint, b2: BigUint, level: usize) -> BigUint {
@@ -310,7 +310,7 @@ fn div_rem_burnikel_ziegler(u: &BigUint, d: &BigUint) -> (BigUint, BigUint) {
         (q, r.into_biguint().unwrap())
     }
 
-    let mut level = 1 << (u.data.len().ilog2());
+    let mut level = 1 << ilog2(u.data.len());
     if d.len() > level {
         level *= 2;
     }

--- a/src/biguint/division.rs
+++ b/src/biguint/division.rs
@@ -2,15 +2,16 @@ use super::addition::__add2;
 use super::shift::biguint_shl;
 use super::{cmp_slice, BigUint};
 
-use crate::big_digit::{self, BigDigit, BigDigits, DoubleBigDigit};
-use crate::UsizePromotion;
+use crate::big_digit::{self, BigDigit, BigDigits, DoubleBigDigit, BITS};
+use crate::biguint::IntDigits;
+use crate::{BigInt, UsizePromotion};
 
 use alloc::borrow::Cow;
 use core::cmp::Ordering::{Equal, Greater, Less};
 use core::mem;
 use core::ops::{Div, DivAssign, Rem, RemAssign};
 use num_integer::Integer;
-use num_traits::{CheckedDiv, CheckedEuclid, Euclid, ToPrimitive, Zero};
+use num_traits::{CheckedDiv, CheckedEuclid, Euclid, Signed, ToPrimitive, Zero};
 
 pub(super) const FAST_DIV_WIDE: bool = cfg!(any(target_arch = "x86", target_arch = "x86_64"));
 
@@ -203,19 +204,131 @@ fn div_rem_cow(u: Cow<'_, BigUint>, d: Cow<'_, BigUint>) -> (BigUint, BigUint) {
 
     if shift == 0 {
         // no need to clone d
-        div_rem_core(u.into_owned(), &d.data)
+        div_rem_core(u.into_owned(), &d)
     } else {
         let u = biguint_shl(u, shift);
         let d = biguint_shl(d, shift);
-        let (q, r) = div_rem_core(u, &d.data);
+        let (q, r) = div_rem_core(u, &d);
         // renormalize the remainder
         (q, r >> shift)
     }
 }
 
+const BURNIKEL_ZIEGLER_THRESHOLD: usize = 64;
+
+/// This algorithm is from Burnikel and Ziegler, "Fast Recursive Division", Algorithm 1.
+/// It is a recursive algorithm that divides the dividend and divisor into blocks of digits
+/// and uses a divide-and-conquer approach to find the quotient.
+///
+/// The algorithm is more complex than the base algorithm, but it is faster for large operands.
+///
+/// Time complexity of this algorithm is the same as the algorithm used for the multiplication.
+///
+/// link: https://pure.mpg.de/rest/items/item_1819444_4/component/file_2599480/content
+fn div_rem_burnikel_ziegler(u: &BigUint, d: &BigUint) -> (BigUint, BigUint) {
+    fn divide_biguint(mut b: BigUint, level: usize) -> (BigUint, BigUint) {
+        if b.len() <= level {
+            return (BigUint::ZERO, b);
+        }
+        let mut b1_data = BigDigits::from_slice(&b.data[level..]);
+        b1_data.normalize();
+        b.data.truncate(level);
+        b.data.normalize();
+        (BigUint { data: b1_data }, b)
+    }
+
+    fn normalizing_shift_amount(b: &BigUint, level: usize) -> usize {
+        (level - b.len() + 1) * BITS as usize - b.data.last().unwrap().ilog2() as usize - 1
+    }
+
+    fn concat_biguint(b1: &BigUint, b2: BigUint, level: usize) -> BigUint {
+        let mut data = b2.data;
+        data.reserve(level + b1.len() - data.len());
+        data.extend(std::iter::repeat(0).take(level - data.len()));
+        data.extend_from_slice(&b1.data);
+        BigUint { data }.normalized()
+    }
+
+    fn div_two_digit_by_one(
+        ah: BigUint,
+        al: BigUint,
+        b: BigUint,
+        level: usize,
+    ) -> (BigUint, BigUint) {
+        // A precondition of this function is that q fits into a single digit.
+        debug_assert!(ah < b);
+        if level <= BURNIKEL_ZIEGLER_THRESHOLD {
+            return div_rem(concat_biguint(&ah, al.clone(), level), b);
+        }
+        let shift = normalizing_shift_amount(&b, level);
+        if shift != 0 {
+            let b = b << shift;
+            let (ah, al) = divide_biguint(concat_biguint(&ah, al.clone(), level) << shift, level);
+            let (q, r) = div_two_digit_by_one_normalized(ah, al, b, level);
+            (q, r >> shift)
+        } else {
+            div_two_digit_by_one_normalized(ah, al, b, level)
+        }
+    }
+
+    fn div_two_digit_by_one_normalized(
+        ah: BigUint,
+        al: BigUint,
+        b: BigUint,
+        level: usize,
+    ) -> (BigUint, BigUint) {
+        let level = level / 2;
+        let (a1, a2) = divide_biguint(ah, level);
+        let (a3, a4) = divide_biguint(al, level);
+        let (b1, b2) = divide_biguint(b, level);
+        let (q1, r) = div_three_halves_by_two(a1, a2, a3, b1.clone(), b2.clone(), level);
+        let (r1, r2) = divide_biguint(r, level);
+        let (q2, s) = div_three_halves_by_two(r1, r2, a4, b1, b2, level);
+        (concat_biguint(&q1, q2, level), s)
+    }
+
+    fn div_three_halves_by_two(
+        a1: BigUint,
+        a2: BigUint,
+        a3: BigUint,
+        b1: BigUint,
+        b2: BigUint,
+        level: usize,
+    ) -> (BigUint, BigUint) {
+        let (mut q, c) = div_two_digit_by_one(a1, a2, b1.clone(), level);
+        let mut r = BigInt::from(concat_biguint(&c, a3, level)) - BigInt::from(&q * &b2);
+        let b = concat_biguint(&b1, b2, level);
+        if r.is_negative() {
+            q -= 1u32;
+            r += BigInt::from(b.clone());
+            if r.is_negative() {
+                q -= 1u32;
+                r += BigInt::from(b.clone());
+            }
+        }
+        (q, r.into_biguint().unwrap())
+    }
+
+    let mut level = 1 << (u.data.len().ilog2());
+    if d.len() > level {
+        level *= 2;
+    }
+    let (u1, u2) = divide_biguint(u.clone(), level);
+    if &u1 > d {
+        div_two_digit_by_one(BigUint::ZERO, u.clone(), d.clone(), level * 2)
+    } else {
+        div_two_digit_by_one(u1, u2, d.clone(), level)
+    }
+}
+
 /// An implementation of the base division algorithm.
 /// Knuth, TAOCP vol 2 section 4.3.1, algorithm D, with an improvement from exercises 19-21.
-fn div_rem_core(mut a: BigUint, b: &[BigDigit]) -> (BigUint, BigUint) {
+fn div_rem_core(mut a: BigUint, b: &BigUint) -> (BigUint, BigUint) {
+    if a.len() > BURNIKEL_ZIEGLER_THRESHOLD * 2 && b.len() > BURNIKEL_ZIEGLER_THRESHOLD {
+        return div_rem_burnikel_ziegler(&a, b);
+    }
+
+    let b = &*b.data;
     debug_assert!(a.data.len() >= b.len() && b.len() > 1);
     debug_assert!(b.last().unwrap().leading_zeros() == 0);
 

--- a/src/biguint/division.rs
+++ b/src/biguint/division.rs
@@ -204,11 +204,11 @@ fn div_rem_cow(u: Cow<'_, BigUint>, d: Cow<'_, BigUint>) -> (BigUint, BigUint) {
 
     if shift == 0 {
         // no need to clone d
-        div_rem_core(u.into_owned(), &d)
+        div_rem_core(u, &d)
     } else {
         let u = biguint_shl(u, shift);
         let d = biguint_shl(d, shift);
-        let (q, r) = div_rem_core(u, &d);
+        let (q, r) = div_rem_core(Cow::Owned(u), &d);
         // renormalize the remainder
         (q, r >> shift)
     }
@@ -325,11 +325,14 @@ fn div_rem_burnikel_ziegler(u: &BigUint, d: &BigUint) -> (BigUint, BigUint) {
 
 /// An implementation of the base division algorithm.
 /// Knuth, TAOCP vol 2 section 4.3.1, algorithm D, with an improvement from exercises 19-21.
-fn div_rem_core(mut a: BigUint, b: &BigUint) -> (BigUint, BigUint) {
-    if a.len() > BURNIKEL_ZIEGLER_THRESHOLD * 2 && b.len() > BURNIKEL_ZIEGLER_THRESHOLD {
+fn div_rem_core(a: Cow<'_, BigUint>, b: &BigUint) -> (BigUint, BigUint) {
+    if (a.data.len() > BURNIKEL_ZIEGLER_THRESHOLD * 2)
+        && (b.data.len() > BURNIKEL_ZIEGLER_THRESHOLD)
+    {
         return div_rem_burnikel_ziegler(&a, b);
     }
 
+    let mut a = a.into_owned();
     let b = &*b.data;
     debug_assert!(a.data.len() >= b.len() && b.len() > 1);
     debug_assert!(b.last().unwrap().leading_zeros() == 0);

--- a/src/biguint/division.rs
+++ b/src/biguint/division.rs
@@ -244,9 +244,10 @@ fn div_rem_burnikel_ziegler(u: &BigUint, d: &BigUint) -> (BigUint, BigUint) {
     fn concat_biguint(b1: &BigUint, b2: BigUint, level: usize) -> BigUint {
         let mut data = b2.data;
         data.reserve(level + b1.len() - data.len());
-        data.extend(std::iter::repeat(0).take(level - data.len()));
+        data.resize(level, 0);
         data.extend_from_slice(&b1.data);
-        BigUint { data }.normalized()
+        data.normalize();
+        BigUint { data }
     }
 
     fn div_two_digit_by_one(

--- a/src/biguint/division.rs
+++ b/src/biguint/division.rs
@@ -4,14 +4,14 @@ use super::{cmp_slice, ilog2, BigUint};
 
 use crate::big_digit::{self, BigDigit, BigDigits, DoubleBigDigit, BITS};
 use crate::biguint::IntDigits;
-use crate::{BigInt, UsizePromotion};
+use crate::UsizePromotion;
 
 use alloc::borrow::Cow;
 use core::cmp::Ordering::{Equal, Greater, Less};
 use core::mem;
 use core::ops::{Div, DivAssign, Rem, RemAssign};
 use num_integer::Integer;
-use num_traits::{CheckedDiv, CheckedEuclid, Euclid, Signed, ToPrimitive, Zero};
+use num_traits::{CheckedDiv, CheckedEuclid, Euclid, ToPrimitive, Zero};
 
 pub(super) const FAST_DIV_WIDE: bool = cfg!(any(target_arch = "x86", target_arch = "x86_64"));
 
@@ -297,17 +297,18 @@ fn div_rem_burnikel_ziegler(u: &BigUint, d: &BigUint) -> (BigUint, BigUint) {
         level: usize,
     ) -> (BigUint, BigUint) {
         let (mut q, c) = div_two_digit_by_one(a1, a2, b1.clone(), level);
-        let mut r = BigInt::from(concat_biguint(&c, a3, level)) - BigInt::from(&q * &b2);
-        let b = concat_biguint(&b1, b2, level);
-        if r.is_negative() {
+        let (mut r, rsub) = (concat_biguint(&c, a3, level), &q * &b2);
+        // The algorithm guarantees at most two corrections are needed.
+        if r < rsub {
+            let b = concat_biguint(&b1, b2, level);
             q -= 1u32;
-            r += BigInt::from(b.clone());
-            if r.is_negative() {
+            r += &b;
+            if r < rsub {
                 q -= 1u32;
-                r += BigInt::from(b);
+                r += &b;
             }
         }
-        (q, r.into_biguint().unwrap())
+        (q, r - rsub)
     }
 
     let mut level = 1 << ilog2(u.data.len());

--- a/src/biguint/division.rs
+++ b/src/biguint/division.rs
@@ -315,7 +315,7 @@ fn div_rem_burnikel_ziegler(u: &BigUint, d: &BigUint) -> (BigUint, BigUint) {
         level *= 2;
     }
     let (u1, u2) = divide_biguint(u.clone(), level);
-    if &u1 > d {
+    if &u1 >= d {
         div_two_digit_by_one(BigUint::ZERO, u.clone(), d.clone(), level * 2)
     } else {
         div_two_digit_by_one(u1, u2, d.clone(), level)

--- a/src/biguint/division.rs
+++ b/src/biguint/division.rs
@@ -3,7 +3,6 @@ use super::shift::biguint_shl;
 use super::{cmp_slice, ilog2, BigUint};
 
 use crate::big_digit::{self, BigDigit, BigDigits, DoubleBigDigit, BITS};
-use crate::biguint::IntDigits;
 use crate::UsizePromotion;
 
 use alloc::borrow::Cow;
@@ -227,7 +226,7 @@ const BURNIKEL_ZIEGLER_THRESHOLD: usize = 64;
 /// link: https://pure.mpg.de/rest/items/item_1819444_4/component/file_2599480/content
 fn div_rem_burnikel_ziegler(u: &BigUint, d: &BigUint) -> (BigUint, BigUint) {
     fn divide_biguint(mut b: BigUint, level: usize) -> (BigUint, BigUint) {
-        if b.len() <= level {
+        if b.data.len() <= level {
             return (BigUint::ZERO, b);
         }
         let mut b1_data = BigDigits::from_slice(&b.data[level..]);
@@ -312,7 +311,7 @@ fn div_rem_burnikel_ziegler(u: &BigUint, d: &BigUint) -> (BigUint, BigUint) {
     }
 
     let mut level = 1 << ilog2(u.data.len());
-    if d.len() > level {
+    if d.data.len() > level {
         level *= 2;
     }
     let (u1, u2) = divide_biguint(u.clone(), level);

--- a/src/biguint/division.rs
+++ b/src/biguint/division.rs
@@ -259,12 +259,12 @@ fn div_rem_burnikel_ziegler(u: &BigUint, d: &BigUint) -> (BigUint, BigUint) {
         // A precondition of this function is that q fits into a single digit.
         debug_assert!(ah < b);
         if level <= BURNIKEL_ZIEGLER_THRESHOLD {
-            return div_rem(concat_biguint(&ah, al.clone(), level), b);
+            return div_rem(concat_biguint(&ah, al, level), b);
         }
         let shift = normalizing_shift_amount(&b, level);
         if shift != 0 {
             let b = b << shift;
-            let (ah, al) = divide_biguint(concat_biguint(&ah, al.clone(), level) << shift, level);
+            let (ah, al) = divide_biguint(concat_biguint(&ah, al, level) << shift, level);
             let (q, r) = div_two_digit_by_one_normalized(ah, al, b, level);
             (q, r >> shift)
         } else {
@@ -304,7 +304,7 @@ fn div_rem_burnikel_ziegler(u: &BigUint, d: &BigUint) -> (BigUint, BigUint) {
             r += BigInt::from(b.clone());
             if r.is_negative() {
                 q -= 1u32;
-                r += BigInt::from(b.clone());
+                r += BigInt::from(b);
             }
         }
         (q, r.into_biguint().unwrap())

--- a/src/biguint/division.rs
+++ b/src/biguint/division.rs
@@ -237,13 +237,13 @@ fn div_rem_burnikel_ziegler(u: &BigUint, d: &BigUint) -> (BigUint, BigUint) {
         (BigUint { data: b1_data }, b)
     }
 
-    fn normalizing_shift_amount(b: &BigUint, level: usize) -> usize {
-        (level - b.len() + 1) * BITS as usize - ilog2(*b.data.last().unwrap()) as usize - 1
+    fn normalizing_shift_amount(b: &BigUint, level: usize) -> u64 {
+        (level as u64) * u64::from(BITS) - b.bits()
     }
 
     fn concat_biguint(b1: &BigUint, b2: BigUint, level: usize) -> BigUint {
         let mut data = b2.data;
-        data.reserve(level + b1.len() - data.len());
+        data.reserve(level + b1.data.len() - data.len());
         data.resize(level, 0);
         data.extend_from_slice(&b1.data);
         data.normalize();

--- a/tests/biguint.rs
+++ b/tests/biguint.rs
@@ -923,6 +923,30 @@ fn test_div_rem_big_multiple() {
 }
 
 #[test]
+fn test_div_rem_burnikel_ziegler_u1_equals_d() {
+    // Construct u and d such that the B-Z entry point sees u1 == d.
+    //
+    // d has 65 u64-digits (130 u32-digits) with MSB set, ensuring:
+    //   - d.len() > 64 (enters B-Z)
+    //   - no normalization shift (MSB already set)
+    //
+    // u = d << 8192 + 42, so u's high part (split at `level` digits) is exactly d.
+    //   For u64: u.len()=193, level=128, split gives u1=d
+    //   For u32: u.len()=386, level=256, split gives u1=d
+    //
+    // The entry point originally had `if &u1 > d` (should be >=), so the else branch was
+    // taken with u1==d, violating div_two_digit_by_one's precondition ah < b.
+    let d = (BigUint::one() << 4159usize) + BigUint::one();
+    let remainder = BigUint::from(42u32);
+    let u = (&d << 8192usize) + &remainder;
+
+    let expected_q = BigUint::one() << 8192usize;
+    let (q, r) = u.div_rem(&d);
+    assert_eq!(q, expected_q, "quotient should be 1 << 8192");
+    assert_eq!(r, remainder, "remainder should be 42");
+}
+
+#[test]
 fn test_div_ceil() {
     fn check(a: &BigUint, b: &BigUint, d: &BigUint, m: &BigUint) {
         if m.is_zero() {


### PR DESCRIPTION
This implements the algorithm mentioned in #315

Benchmark:
```
// prev
running 4 tests
test to_str_radix_10      ... bench:       4,242.41 ns/iter (+/- 712.43)
test to_str_radix_10_2    ... bench:      82,360.73 ns/iter (+/- 13,304.91)
test to_str_radix_10_3    ... bench:   3,929,829.90 ns/iter (+/- 514,647.85)
test to_str_radix_10_4    ... bench: 243,146,081.10 ns/iter (+/- 44,213,689.70)
// now
running 4 tests
test to_str_radix_10      ... bench:       4,261.38 ns/iter (+/- 522.98)
test to_str_radix_10_2    ... bench:      83,358.54 ns/iter (+/- 11,170.02)
test to_str_radix_10_3    ... bench:   2,623,301.20 ns/iter (+/- 279,505.89)
test to_str_radix_10_4    ... bench: 195,073,240.50 ns/iter (+/- 17,025,687.08)
```

Currently both grow with `O(n^2)`, to make things algorithmically faster we need a faster multiplication and division algorithm.