### PR TITLE
[0.1] Disable `rustc-serialize` derives for future compilers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,13 +5,12 @@ rust:
   - nightly
 matrix:
   include:
-    - rust: 1.8.0
+    - rust: 1.19.0
       before_script:
-        # rand 0.3.22 started depending on rand 0.4, which requires rustc 1.15
-        # manually hacking the lockfile due to the limitations of cargo#2773
         - cargo generate-lockfile
-        - sed -i -e 's/"rand 0.[34].[0-9]\+/"rand 0.3.20/' Cargo.lock
-        - sed -i -e '/^name = "rand"/,/^$/s/version = "0.3.[0-9]\+"/version = "0.3.20"/' Cargo.lock
+        - cargo update -p num-integer --precise 0.1.45
+        - cargo update -p num-traits --precise 0.2.15
+        - cargo update -p libc --precise 0.2.163
 sudo: false
 script:
   - cargo build --verbose

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,8 +8,9 @@ categories = [ "algorithms", "data-structures", "science" ]
 license = "MIT/Apache-2.0"
 name = "num-bigint"
 repository = "https://github.com/rust-num/num-bigint"
-version = "0.1.44"
+version = "0.1.45"
 readme = "README.md"
+build = "build.rs"
 
 [[bench]]
 name = "bigint"
@@ -52,3 +53,6 @@ version = ">= 0.3.14, < 0.5.0"
 
 [features]
 default = ["rand", "rustc-serialize"]
+
+[build-dependencies]
+autocfg = "1.4.0"

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![crate](https://img.shields.io/crates/v/num-bigint.svg)](https://crates.io/crates/num-bigint)
 [![documentation](https://docs.rs/num-bigint/badge.svg)](https://docs.rs/num-bigint)
-![minimum rustc 1.8](https://img.shields.io/badge/rustc-1.8+-red.svg)
+![minimum rustc 1.19](https://img.shields.io/badge/rustc-1.19+-red.svg)
 [![Travis status](https://travis-ci.org/rust-num/num-bigint.svg?branch=master)](https://travis-ci.org/rust-num/num-bigint)
 
 Big integer types for Rust, `BigInt` and `BigUint`.
@@ -28,7 +28,7 @@ Release notes are available in [RELEASES.md](RELEASES.md).
 
 ## Compatibility
 
-The `num-bigint` crate is tested for rustc 1.8 and greater.
+The `num-bigint` crate is tested for rustc 1.19 and greater.
 
 ## Alternatives
 
@@ -38,7 +38,7 @@ table offers a brief comparison to a few alternatives.
 
 | Crate            | License        | Min rustc | Implementation |
 | :--------------- | :------------- | :-------- | :------------- |
-| **`num-bigint`** | MIT/Apache-2.0 | 1.8       | pure rust |
+| **`num-bigint`** | MIT/Apache-2.0 | 1.19      | pure rust |
 | [`ramp`]         | Apache-2.0     | nightly   | rust and inline assembly |
 | [`rug`]          | LGPL-3.0+      | 1.18      | bundles [GMP] via [`gmp-mpfr-sys`] |
 | [`rust-gmp`]     | MIT            | stable?   | links to [GMP] |

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,3 +1,9 @@
+# Release 0.1.45
+
+- [Disable `rustc-serialize` derives for future compilers.][319]
+
+[319]: https://github.com/rust-num/num-bigint/pull/319
+
 # Release 0.1.44
 
 - [Division with single-digit divisors is now much faster.][42]

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,30 @@
+extern crate autocfg;
+
+fn main() {
+    autocfg::rerun_path("build.rs");
+    autocfg::emit_possibility(HAS_DERIVE);
+    if std::env::var_os("CARGO_FEATURE_RUSTC_SERIALIZE").is_some() {
+        let ac = autocfg::new();
+
+        // These built-in derives are being removed! (rust-lang/rust#134272)
+        //
+        // It's hard to directly probe for `derive(RustcDecodable, RustcEncodable)`, because that
+        // depends on the external `rustc-serialize` dependency. They're in `prelude::v1` where we
+        // can probe by path, but ironically only on relatively new versions, so we're also using
+        // *inaccessible* `rust_2024` as a proxy for older versions.
+        if ac.probe_raw(PRELUDE_DERIVE).is_ok() || !ac.probe_path(RUST_2024) {
+            autocfg::emit(HAS_DERIVE);
+        } else {
+            println!("cargo:warning=rustc-serialize is not supported by the current compiler");
+        }
+    }
+}
+
+const HAS_DERIVE: &str = "has_derive_rustc_serialize";
+
+const PRELUDE_DERIVE: &str = "
+#[allow(soft_unstable, deprecated)]
+pub use std::prelude::v1::{RustcDecodable, RustcEncodable};
+";
+
+const RUST_2024: &str = "std::prelude::rust_2024";

--- a/ci/rustup.sh
+++ b/ci/rustup.sh
@@ -1,18 +1,17 @@
 #!/bin/sh
 # Use rustup to locally run the same suite of tests as .travis.yml.
-# (You should first install/update 1.8.0, stable, beta, and nightly.)
+# (You should first install/update 1.19.0, stable, beta, and nightly.)
 
 set -ex
 
 export TRAVIS_RUST_VERSION
-for TRAVIS_RUST_VERSION in 1.8.0 stable beta nightly; do
+for TRAVIS_RUST_VERSION in 1.19.0 stable beta nightly; do
     run="rustup run $TRAVIS_RUST_VERSION"
-    if [ "$TRAVIS_RUST_VERSION" = 1.8.0 ]; then
-      # rand 0.3.22 started depending on rand 0.4, which requires rustc 1.15
-      # manually hacking the lockfile due to the limitations of cargo#2773
-      $run cargo generate-lockfile
-      $run sed -i -e 's/"rand 0.[34].[0-9]\+/"rand 0.3.20/' Cargo.lock
-      $run sed -i -e '/^name = "rand"/,/^$/s/version = "0.3.[0-9]\+"/version = "0.3.20"/' Cargo.lock
+    $run cargo generate-lockfile
+    if [ "$TRAVIS_RUST_VERSION" = 1.19.0 ]; then
+      $run cargo update -p num-integer --precise 0.1.45
+      $run cargo update -p num-traits --precise 0.2.15
+      $run cargo update -p libc --precise 0.2.163
     fi
     $run cargo build --verbose
     $run $PWD/ci/test_full.sh

--- a/src/bigint.rs
+++ b/src/bigint.rs
@@ -38,7 +38,7 @@ mod bigint_tests;
 
 /// A Sign is a `BigInt`'s composing element.
 #[derive(PartialEq, PartialOrd, Eq, Ord, Copy, Clone, Debug, Hash)]
-#[cfg_attr(feature = "rustc-serialize", derive(RustcEncodable, RustcDecodable))]
+#[cfg_attr(has_derive_rustc_serialize, derive(RustcEncodable, RustcDecodable))]
 pub enum Sign {
     Minus,
     NoSign,
@@ -104,7 +104,7 @@ impl serde::Deserialize for Sign {
 
 /// A big signed integer type.
 #[derive(Clone, Debug, Hash)]
-#[cfg_attr(feature = "rustc-serialize", derive(RustcEncodable, RustcDecodable))]
+#[cfg_attr(has_derive_rustc_serialize, derive(RustcEncodable, RustcDecodable))]
 pub struct BigInt {
     sign: Sign,
     data: BigUint,

--- a/src/biguint.rs
+++ b/src/biguint.rs
@@ -47,7 +47,7 @@ mod biguint_tests;
 /// A `BigUint`-typed value `BigUint { data: vec!(a, b, c) }` represents a number
 /// `(a + b * big_digit::BASE + c * big_digit::BASE^2)`.
 #[derive(Clone, Debug, Hash)]
-#[cfg_attr(feature = "rustc-serialize", derive(RustcEncodable, RustcDecodable))]
+#[cfg_attr(has_derive_rustc_serialize, derive(RustcEncodable, RustcDecodable))]
 pub struct BigUint {
     data: Vec<BigDigit>,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,9 +72,10 @@
 //!
 //! ## Compatibility
 //!
-//! The `num-bigint` crate is tested for rustc 1.8 and greater.
+//! The `num-bigint` crate is tested for rustc 1.19 and greater.
 
 #![doc(html_root_url = "https://docs.rs/num-bigint/0.1")]
+#![cfg_attr(has_derive_rustc_serialize, warn(soft_unstable))] // un-deny
 
 #[cfg(any(feature = "rand", test))]
 extern crate rand;


### PR DESCRIPTION
The built-in derives are being [removed], but crater showed problems
with crates depending on `num v0.1`, where this feature is enabled by
default. With this PR, we detect the missing built-ins and disable the
derives, adding a build-script warning about it. Cargo won't show such
warnings by default from non-path dependencies, unless the build fails.

[removed]: https://github.com/rust-lang/rust/pull/134272
