### PR TITLE
Update documentation to use Markdown links for `BigUint` and `BigInt` references for consistency.

### DIFF
--- a/ci/big_quickcheck/src/lib.rs
+++ b/ci/big_quickcheck/src/lib.rs
@@ -1,4 +1,4 @@
-//! Quickcheck of `BigUint` and `BigInt`
+//! Quickcheck of [`BigUint`] and [`BigInt`]
 //!
 //! This test is in a completely separate crate so we can use `quickcheck_macros` only when
 //! `quickcheck` is active. The main crate can't have optional dev-dependencies, and it's

--- a/ci/big_rand/src/lib.rs
+++ b/ci/big_rand/src/lib.rs
@@ -1,4 +1,4 @@
-//! Test randomization of `BigUint` and `BigInt`
+//! Test randomization of [`BigUint`] and [`BigInt`]
 //!
 //! This test is in a completely separate crate so `rand::thread_rng()`
 //! can be available without "infecting" the rest of the build with

--- a/ci/big_serde/src/lib.rs
+++ b/ci/big_serde/src/lib.rs
@@ -1,4 +1,4 @@
-//! Test serialization and deserialization of `BigUint` and `BigInt`
+//! Test serialization and deserialization of [`BigUint`] and [`BigInt`]
 //!
 //! The serialized formats should not change, even if we change our
 //! internal representation, because we want to preserve forward and

--- a/src/bigint.rs
+++ b/src/bigint.rs
@@ -1,4 +1,4 @@
-// `Add`/`Sub` ops may flip from `BigInt` to its `BigUint` magnitude
+// `Add`/`Sub` ops may flip from [`BigInt`] to its [`BigUint`] magnitude
 #![allow(clippy::suspicious_arithmetic_impl)]
 
 use alloc::string::String;
@@ -563,7 +563,7 @@ pub trait ToBigInt {
 }
 
 impl BigInt {
-    /// A constant `BigInt` with value 0, useful for static initialization.
+    /// A constant [`BigInt`] with value 0, useful for static initialization.
     pub const ZERO: Self = BigInt {
         sign: NoSign,
         data: BigUint::ZERO,

--- a/src/bigint.rs
+++ b/src/bigint.rs
@@ -1,4 +1,4 @@
-// `Add`/`Sub` ops may flip from `BigInt` to its `BigUint` magnitude
+// `Add`/`Sub` ops may flip from [`BigInt`] to its [`BigUint`] magnitude
 #![allow(clippy::suspicious_arithmetic_impl)]
 
 use alloc::string::String;
@@ -565,7 +565,7 @@ pub trait ToBigInt {
 }
 
 impl BigInt {
-    /// A constant `BigInt` with value 0, useful for static initialization.
+    /// A constant [`BigInt`] with value 0, useful for static initialization.
     pub const ZERO: Self = BigInt {
         sign: NoSign,
         data: BigUint::ZERO,

--- a/src/biguint.rs
+++ b/src/biguint.rs
@@ -528,7 +528,7 @@ pub(crate) fn biguint_from_vec(digits: Vec<BigDigit>) -> BigUint {
 }
 
 impl BigUint {
-    /// A constant `BigUint` with value 0, useful for static initialization.
+    /// A constant [`BigUint`] with value 0, useful for static initialization.
     pub const ZERO: Self = BigUint { data: Vec::new() };
 
     /// Creates and initializes a [`BigUint`].

--- a/src/biguint.rs
+++ b/src/biguint.rs
@@ -547,12 +547,12 @@ pub(crate) fn biguint_from_vec(digits: Vec<BigDigit>) -> BigUint {
 }
 
 impl BigUint {
-    /// A constant `BigUint` with value 0, useful for static initialization.
+    /// A constant [`BigUint`] with value 0, useful for static initialization.
     pub const ZERO: Self = BigUint {
         data: BigDigits::ZERO,
     };
 
-    /// A constant `BigUint` with value 1, useful for static initialization.
+    /// A constant [`BigUint`] with value 1, useful for static initialization.
     pub const ONE: Self = BigUint {
         data: BigDigits::ONE,
     };

--- a/src/biguint/convert.rs
+++ b/src/biguint/convert.rs
@@ -217,7 +217,7 @@ pub(super) fn from_radix_le(buf: &[u8], radix: u32) -> Option<BigUint> {
 impl Num for BigUint {
     type FromStrRadixErr = ParseBigIntError;
 
-    /// Creates and initializes a `BigUint`.
+    /// Creates and initializes a [`BigUint`].
     fn from_str_radix(s: &str, radix: u32) -> Result<BigUint, ParseBigIntError> {
         assert!(2 <= radix && radix <= 36, "The radix must be within 2...36");
         let mut s = s;
@@ -808,7 +808,7 @@ fn get_half_radix_base(radix: u32) -> (BigDigit, usize) {
 
 /// Generate tables of the greatest power of each radix that is less that the given maximum. These
 /// are returned from `get_radix_base` to batch the multiplication/division of radix conversions on
-/// full `BigUint` values, operating on primitive integers as much as possible.
+/// full [`BigUint`] values, operating on primitive integers as much as possible.
 ///
 /// e.g. BASES_16[3] = (59049, 10) // 3¹⁰ fits in u16, but 3¹¹ is too big
 ///      BASES_32[3] = (3486784401, 20)

--- a/src/biguint/convert.rs
+++ b/src/biguint/convert.rs
@@ -206,7 +206,7 @@ pub(super) fn from_radix_le(buf: &[u8], radix: u32) -> Option<BigUint> {
 impl Num for BigUint {
     type FromStrRadixErr = ParseBigIntError;
 
-    /// Creates and initializes a `BigUint`.
+    /// Creates and initializes a [`BigUint`].
     fn from_str_radix(s: &str, radix: u32) -> Result<BigUint, ParseBigIntError> {
         assert!(2 <= radix && radix <= 36, "The radix must be within 2...36");
         let mut s = s;
@@ -854,7 +854,7 @@ fn get_half_radix_base(radix: u32) -> (BigDigit, usize) {
 
 /// Generate tables of the greatest power of each radix that is less that the given maximum. These
 /// are returned from `get_radix_base` to batch the multiplication/division of radix conversions on
-/// full `BigUint` values, operating on primitive integers as much as possible.
+/// full [`BigUint`] values, operating on primitive integers as much as possible.
 ///
 /// e.g. BASES_16[3] = (59049, 10) // 3¹⁰ fits in u16, but 3¹¹ is too big
 ///      BASES_32[3] = (3486784401, 20)

--- a/src/biguint/iter.rs
+++ b/src/biguint/iter.rs
@@ -1,13 +1,13 @@
 use core::iter::FusedIterator;
 
 cfg_digit!(
-    /// An iterator of `u32` digits representation of a `BigUint` or `BigInt`,
+    /// An iterator of `u32` digits representation of a [`BigUint`](super::BigUint) or [`BigInt`](super::super::BigInt),
     /// ordered least significant digit first.
     pub struct U32Digits<'a> {
         it: core::slice::Iter<'a, u32>,
     }
 
-    /// An iterator of `u32` digits representation of a `BigUint` or `BigInt`,
+    /// An iterator of `u32` digits representation of a [`BigUint`](super::BigUint) or [`BigInt`](super::super::BigInt),
     /// ordered least significant digit first.
     pub struct U32Digits<'a> {
         data: &'a [u64],
@@ -170,13 +170,13 @@ cfg_digit!(
 impl FusedIterator for U32Digits<'_> {}
 
 cfg_digit!(
-    /// An iterator of `u64` digits representation of a `BigUint` or `BigInt`,
+    /// An iterator of `u64` digits representation of a [`BigUint`](super::BigUint) or [`BigInt`](super::super::BigInt),
     /// ordered least significant digit first.
     pub struct U64Digits<'a> {
         it: core::slice::Chunks<'a, u32>,
     }
 
-    /// An iterator of `u64` digits representation of a `BigUint` or `BigInt`,
+    /// An iterator of `u64` digits representation of a [`BigUint`](super::BigUint) or [`BigInt`](super::super::BigInt),
     /// ordered least significant digit first.
     pub struct U64Digits<'a> {
         it: core::slice::Iter<'a, u64>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,7 +63,7 @@
 //! The `std` crate feature is enabled by default, which enables [`std::error::Error`]
 //! implementations and some internal use of floating point approximations. This can be disabled by
 //! depending on `num-bigint` with `default-features = false`. Either way, the `alloc` crate is
-//! always required for heap allocation of the `BigInt`/`BigUint` digits.
+//! always required for heap allocation of the [`BigInt`]/[`BigUint`] digits.
 //!
 //! ### Random Generation
 //!
@@ -81,13 +81,13 @@
 //! ### Arbitrary Big Integers
 //!
 //! `num-bigint` supports `arbitrary` and `quickcheck` features to implement
-//! [`arbitrary::Arbitrary`] and [`quickcheck::Arbitrary`], respectively, for both `BigInt` and
-//! `BigUint`. These are useful for fuzzing and other forms of randomized testing.
+//! [`arbitrary::Arbitrary`] and [`quickcheck::Arbitrary`], respectively, for both [`BigInt`] and
+//! [`BigUint`]. These are useful for fuzzing and other forms of randomized testing.
 //!
 //! ### Serialization
 //!
 //! The `serde` feature adds implementations of [`Serialize`][serde::Serialize] and
-//! [`Deserialize`][serde::Deserialize] for both `BigInt` and `BigUint`. Their serialized data is
+//! [`Deserialize`][serde::Deserialize] for both [`BigInt`] and [`BigUint`]. Their serialized data is
 //! generated portably, regardless of platform differences like the internal digit size.
 //!
 //!


### PR DESCRIPTION
There are spots in the library that have these links and other spots that don't. I added them everywhere for consistency.

There were a few spots that had to use `super` refs, probably because they were used in macros and in a different module.

I tested the links with `cargo doc` and they work.