### PR TITLE
Documentation for GCD

### DIFF
--- a/src/bigint.rs
+++ b/src/bigint.rs
@@ -425,7 +425,7 @@ impl Integer for BigInt {
 
     /// Calculates the Greatest Common Divisor (GCD) of the number and `other`.
     ///
-    /// The result is always positive.
+    /// The result is always non-negative.
     #[inline]
     fn gcd(&self, other: &BigInt) -> BigInt {
         BigInt::from(self.data.gcd(&other.data))

--- a/src/biguint.rs
+++ b/src/biguint.rs
@@ -215,8 +215,6 @@ impl Integer for BigUint {
     }
 
     /// Calculates the Greatest Common Divisor (GCD) of the number and `other`.
-    ///
-    /// The result is always positive.
     #[inline]
     fn gcd(&self, other: &Self) -> Self {
         #[inline]


### PR DESCRIPTION
This pull request makes the wording consistent with the wording in the `num-integer` crate.  Note, `BigUint` does not need the statement since it can not be negative.

Related pull request: rust-num/num-integer#75