### PR TITLE
Remove an unreachable endianness bug in `mac_digit`

### DIFF
--- a/ci/big_quickcheck/Cargo.toml
+++ b/ci/big_quickcheck/Cargo.toml
@@ -3,6 +3,7 @@ name = "big_quickcheck"
 version = "0.1.0"
 authors = ["Josh Stone <cuviper@gmail.com>"]
 edition = "2018"
+rust-version = "1.60"
 
 [dependencies]
 num-integer = "0.1.42"

--- a/ci/big_rand/Cargo.toml
+++ b/ci/big_rand/Cargo.toml
@@ -3,6 +3,7 @@ name = "big_rand"
 version = "0.1.0"
 authors = ["Josh Stone <cuviper@gmail.com>"]
 edition = "2018"
+rust-version = "1.60"
 
 [dependencies]
 num-traits = "0.2.11"

--- a/ci/big_serde/Cargo.toml
+++ b/ci/big_serde/Cargo.toml
@@ -3,6 +3,7 @@ name = "big_serde"
 version = "0.1.0"
 authors = ["Josh Stone <cuviper@gmail.com>"]
 edition = "2018"
+rust-version = "1.60"
 
 [dependencies]
 num-traits = "0.2.11"

--- a/ci/test_full.sh
+++ b/ci/test_full.sh
@@ -21,6 +21,14 @@ check_version() {
   ]]
 }
 
+export CARGO_RESOLVER_INCOMPATIBLE_RUST_VERSIONS=fallback
+generate_lockfile() {
+  cargo generate-lockfile
+  if ! check_version 1.85 ; then
+    cargo +stable update
+  fi
+}
+
 echo "Testing $CRATE on rustc $RUST_VERSION"
 if ! check_version $MSRV ; then
   echo "The minimum for $CRATE is rustc $MSRV"
@@ -34,10 +42,10 @@ if [ -n "${NO_STD_FEATURES[*]}" ]; then
   echo " no_std supported features: ${NO_STD_FEATURES[*]}"
 fi
 
-# arbitrary 1.1.4 started using array::from_fn
-check_version 1.63.0 || cargo update -p arbitrary --precise 1.1.3
+generate_lockfile
 
-check_version 1.63.0 || cargo update -p libc --precise 0.2.163
+# arbitrary 1.1.4 started using array::from_fn, but didn't set rust-version
+check_version 1.63.0 || cargo update -p arbitrary --precise 1.1.3
 
 set -x
 
@@ -81,18 +89,17 @@ fi
 case "${STD_FEATURES[*]}" in
   *serde*) (
       cd ci/big_serde
+      generate_lockfile
       cargo test
     ) ;;&
   *rand*) (
       cd ci/big_rand
-      check_version 1.63.0 || cargo update -p libc --precise 0.2.163
-      check_version 1.61.0 || cargo update -p ppv-lite86 --precise 0.2.17
+      generate_lockfile
       cargo test
     ) ;;&
   *quickcheck*) (
       cd ci/big_quickcheck
-      check_version 1.63.0 || cargo update -p libc --precise 0.2.163
-      check_version 1.61.0 || cargo update -p syn --precise 2.0.67
+      generate_lockfile
       cargo test
     ) ;;&
 esac

--- a/src/biguint/multiplication.rs
+++ b/src/biguint/multiplication.rs
@@ -48,12 +48,9 @@ fn mac_digit(acc: &mut [BigDigit], b: &[BigDigit], c: BigDigit) {
     }
 
     let (carry_hi, carry_lo) = big_digit::from_doublebigdigit(carry);
+    debug_assert_eq!(carry_hi, 0, "mac_with_carry never keeps high bits");
 
-    let final_carry = if carry_hi == 0 {
-        __add2(a_hi, &[carry_lo])
-    } else {
-        __add2(a_hi, &[carry_hi, carry_lo])
-    };
+    let final_carry = __add2(a_hi, &[carry_lo]);
     assert_eq!(final_carry, 0, "carry overflow during multiplication!");
 }
 


### PR DESCRIPTION
This code wrongly created a `[hi, lo]` array to add its final carry digit, when that should be little-endian `[lo, hi]`. However, this was dead code because `mac_with_carry` always shifts `>> BITS`, so the `carry` value **never** has high bits at this point. We'll keep a debug assertion for that, but otherwise it's safe to assume.