### PR TITLE
Remove unnecessary casts

### DIFF
--- a/src/bigint/bits.rs
+++ b/src/bigint/bits.rs
@@ -474,7 +474,7 @@ pub(super) fn set_negative_bit(x: &mut BigInt, bit: u64, value: bool) {
             // so initially we have `carry_in` = `carry_out` = 1. Furthermore, we
             // stop traversing the digits when there are no more carries.
             let bit_index = (bit / bits_per_digit).to_usize().unwrap();
-            let bit_mask = (1 as BigDigit) << (bit % bits_per_digit);
+            let bit_mask: BigDigit = 1 << (bit % bits_per_digit);
             let mut digit_iter = data.digits_mut().iter_mut().skip(bit_index);
             let mut carry_in = 1;
             let mut carry_out = 1;

--- a/src/biguint.rs
+++ b/src/biguint.rs
@@ -1038,7 +1038,7 @@ impl BigUint {
         let bits_per_digit = u64::from(big_digit::BITS);
         if let Some(digit_index) = (bit / bits_per_digit).to_usize() {
             if let Some(digit) = self.data.get(digit_index) {
-                let bit_mask = (1 as BigDigit) << (bit % bits_per_digit);
+                let bit_mask: BigDigit = 1 << (bit % bits_per_digit);
                 return (digit & bit_mask) != 0;
             }
         }
@@ -1054,7 +1054,7 @@ impl BigUint {
         // fail allocation, and that's more consistent than adding our own overflow panics.
         let bits_per_digit = u64::from(big_digit::BITS);
         let digit_index = (bit / bits_per_digit).to_usize().unwrap_or(usize::MAX);
-        let bit_mask = (1 as BigDigit) << (bit % bits_per_digit);
+        let bit_mask: BigDigit = 1 << (bit % bits_per_digit);
         if value {
             if digit_index >= self.data.len() {
                 let new_len = digit_index.saturating_add(1);

--- a/src/biguint/convert.rs
+++ b/src/biguint/convert.rs
@@ -81,7 +81,7 @@ fn from_inexact_bitwise_digits_le(v: &[u8], bits: u8) -> BigUint {
 
     if dbits > 0 {
         debug_assert!(dbits < big_digit::BITS);
-        data.push(d as BigDigit);
+        data.push(d);
     }
 
     biguint_from_vec(data)


### PR DESCRIPTION
I believe these casts can be safely removed, as the source type is already the target type.

For reference, these changes were found by an optimizer developed as a research project.

CC @nunoplopes