### PR TITLE
NTT multiplication: rewrite planner and improve comments

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ rand_core_0_9 = ["dep:rand_core_0_9"]
 rand_0_10 = ["rand_core_0_10", "dep:rand_0_10"]
 rand_core_0_10 = ["dep:rand_core_0_10"]
 serde = ["dep:serde"]
+bench-internals = []
 
 [package.metadata.docs.rs]
 features = ["std", "serde", "rand_0_10", "rand_0_9", "quickcheck", "arbitrary"]
@@ -46,6 +47,10 @@ required-features = ["rand_0_10"]
 [[bench]]
 harness = false
 name = "shootout-pidigits"
+
+[[bench]]
+name = "ntt_plan"
+required-features = ["bench-internals"]
 
 [dependencies]
 

--- a/benches/ntt_plan.rs
+++ b/benches/ntt_plan.rs
@@ -1,0 +1,55 @@
+#![feature(test)]
+
+extern crate test;
+
+// Run with: cargo bench --bench ntt_plan --features bench-internals
+
+use num_bigint::__benchmark_ntt_plan_build;
+use test::{black_box, Bencher};
+
+macro_rules! ntt_plan_bench {
+    ($name:ident, $prime:expr, $exponent:expr) => {
+        #[bench]
+        fn $name(bencher: &mut Bencher) {
+            let min_len = 1usize << $exponent;
+            bencher.iter(|| black_box(__benchmark_ntt_plan_build::<$prime>(black_box(min_len))));
+        }
+    };
+}
+
+ntt_plan_bench!(p1_2_09, 1, 9);
+ntt_plan_bench!(p1_2_10, 1, 10);
+ntt_plan_bench!(p1_2_11, 1, 11);
+ntt_plan_bench!(p1_2_12, 1, 12);
+ntt_plan_bench!(p1_2_13, 1, 13);
+ntt_plan_bench!(p1_2_14, 1, 14);
+ntt_plan_bench!(p1_2_15, 1, 15);
+ntt_plan_bench!(p1_2_16, 1, 16);
+ntt_plan_bench!(p1_2_17, 1, 17);
+ntt_plan_bench!(p1_2_18, 1, 18);
+ntt_plan_bench!(p1_2_19, 1, 19);
+ntt_plan_bench!(p1_2_20, 1, 20);
+ntt_plan_bench!(p2_2_09, 2, 9);
+ntt_plan_bench!(p2_2_10, 2, 10);
+ntt_plan_bench!(p2_2_11, 2, 11);
+ntt_plan_bench!(p2_2_12, 2, 12);
+ntt_plan_bench!(p2_2_13, 2, 13);
+ntt_plan_bench!(p2_2_14, 2, 14);
+ntt_plan_bench!(p2_2_15, 2, 15);
+ntt_plan_bench!(p2_2_16, 2, 16);
+ntt_plan_bench!(p2_2_17, 2, 17);
+ntt_plan_bench!(p2_2_18, 2, 18);
+ntt_plan_bench!(p2_2_19, 2, 19);
+ntt_plan_bench!(p2_2_20, 2, 20);
+ntt_plan_bench!(p3_2_09, 3, 9);
+ntt_plan_bench!(p3_2_10, 3, 10);
+ntt_plan_bench!(p3_2_11, 3, 11);
+ntt_plan_bench!(p3_2_12, 3, 12);
+ntt_plan_bench!(p3_2_13, 3, 13);
+ntt_plan_bench!(p3_2_14, 3, 14);
+ntt_plan_bench!(p3_2_15, 3, 15);
+ntt_plan_bench!(p3_2_16, 3, 16);
+ntt_plan_bench!(p3_2_17, 3, 17);
+ntt_plan_bench!(p3_2_18, 3, 18);
+ntt_plan_bench!(p3_2_19, 3, 19);
+ntt_plan_bench!(p3_2_20, 3, 20);

--- a/src/biguint.rs
+++ b/src/biguint.rs
@@ -25,6 +25,12 @@ mod convert;
 mod iter;
 mod monty;
 mod ntt;
+
+#[cfg(feature = "bench-internals")]
+#[doc(hidden)]
+pub fn __benchmark_ntt_plan_build<const PRIME: usize>(min_len: usize) -> (usize, usize, usize) {
+    ntt::benchmark_plan_build::<PRIME>(min_len)
+}
 mod power;
 mod roots;
 mod serde;

--- a/src/biguint/ntt.rs
+++ b/src/biguint/ntt.rs
@@ -5,16 +5,18 @@ use core::cmp::max;
 use core::iter::zip;
 
 mod arith {
-    // Extended Euclid algorithm:
+    // Extended Euclidean algorithm:
     //   (g, x, y) is a solution to ax + by = g, where g = gcd(a, b)
     const fn egcd(mut a: i128, mut b: i128) -> (i128, i128, i128) {
         assert!(a > 0 && b > 0);
+
+        // treat as a row-major 2x2 matrix
         let mut c = if a > b {
             (a, b) = (b, a);
             [0, 1, 1, 0]
         } else {
             [1, 0, 0, 1]
-        }; // treat as a row-major 2x2 matrix
+        };
         loop {
             if a == 0 {
                 break (b, c[1], c[3]);
@@ -81,9 +83,9 @@ impl<const P: u64> Arith<P> {
         // We only test p^((P-1)/q) != 1 for q in {2, 3, 5} — the prime
         // factors of MAX_NTT_LEN. This suffices because:
         //   - FACTORS_2/3/5 extract all factors of 2, 3, 5 from P-1, so
-        //     R = (P-1)/MAX_NTT_LEN is coprime to MAX_NTT_LEN by construction.
+        //     Q = (P-1)/MAX_NTT_LEN is coprime to MAX_NTT_LEN by construction.
         //   - Any remaining prime factors of P-1 (e.g. 7, 13, 17 for the
-        //     current primes) are absorbed by the p^R exponentiation and
+        //     current primes) are absorbed by the p^Q exponentiation and
         //     do not affect the order of ROOTR.
         //
         // P must be prime for Z/PZ to be a field; this is not checked here.
@@ -100,6 +102,7 @@ impl<const P: u64> Arith<P> {
         }
     };
 
+    // Explicit instantiations to ensure const evaluation at compile time.
     const FACTORS_2: u32 = Self::factors(2);
     const FACTORS_3: u32 = Self::factors(3);
     const FACTORS_5: u32 = Self::factors(5);
@@ -142,7 +145,7 @@ impl<const P: u64> Arith<P> {
         Self::mreduce(lo as u128 | ((hi as u128) << 64))
     }
 
-    // Computes base^exponent mod P with Montgomery reduction
+    // Computes base^exponent mod P with Montgomery reduction.
     const fn mpowmod(mut base: u64, mut exponent: u64) -> u64 {
         let mut cur = Self::R;
         while exponent > 0 {
@@ -157,7 +160,7 @@ impl<const P: u64> Arith<P> {
 
     // Computes c as u128 * mreduce(v) as u128, using d: u64 = mmulmod(P-1, c).
     //
-    // It is caller's responsibility to ensure that d is correct.
+    // It is the caller's responsibility to ensure that d is correct.
     // Note that d can be computed by calling mreducelo(c).
     const fn mmulmod_noreduce(v: u128, c: u64, d: u64) -> u128 {
         let a: u128 = c as u128 * (v >> 64);
@@ -176,12 +179,12 @@ impl<const P: u64> Arith<P> {
         ((m as u128 * P as u128) >> 64) as u64
     }
 
-    // Computes a + b mod P, output range [0, P)
+    // Computes a + b mod P, output range [0, P).
     const fn addmod(a: u64, b: u64) -> u64 {
         Self::submod(a, P.wrapping_sub(b))
     }
 
-    // Computes a + b mod P, output range [0, 2^64)
+    // Computes a + b mod P, output range [0, 2^64).
     const fn addmod64(a: u64, b: u64) -> u64 {
         let (out, overflow) = a.overflowing_add(b);
         if overflow {
@@ -191,7 +194,7 @@ impl<const P: u64> Arith<P> {
         }
     }
 
-    // Computes a + b mod P, selects addmod64 or addmod depending on INV && TWIDDLE
+    // Computes a + b mod P, selects addmod64 or addmod depending on INV && TWIDDLE.
     const fn addmodopt_invtw<const INV: bool, const TWIDDLE: bool>(a: u64, b: u64) -> u64 {
         if INV && TWIDDLE {
             Self::addmod64(a, b)
@@ -200,7 +203,7 @@ impl<const P: u64> Arith<P> {
         }
     }
 
-    // Computes a - b mod P, output range [0, P)
+    // Computes a - b mod P, output range [0, P).
     const fn submod(a: u64, b: u64) -> u64 {
         let (out, overflow) = a.overflowing_sub(b);
         if overflow {
@@ -212,144 +215,186 @@ impl<const P: u64> Arith<P> {
 }
 
 struct NttPlan {
-    n: usize, // n == g*m
-    g: usize, // g: size of the base case
-    m: usize, // m divides Arith::<P>::MAX_NTT_LEN
+    // The total convolution length, which equals g * m.
+    n: usize,
+    // The length of each base case handled by naive multiplication.
+    g: usize,
+    // The product of radices processed by NTT. Should divide `Arith::<P>::MAX_NTT_LEN`.
+    m: usize,
+    // The NTT radix scheduled closest to the naive multiplication.
     last_radix: usize,
+    // The list of tuples (current block size, radix) in DIF (forward) order.
     s_list: Vec<(usize, usize)>,
 }
 
+// Planner costs normally fit in usize. The wide variant keeps comparisons exact
+// for theoretical lengths where multiplying by the unit cost would overflow.
+// Its declaration order also matches its numeric order: every Large value is
+// greater than every Small value.
+#[derive(Clone, Copy, Eq, Ord, PartialEq, PartialOrd)]
+enum PlanCost {
+    Small(usize),
+    Large(u128),
+}
+
+impl PlanCost {
+    fn new(len: usize, unit_cost: u32) -> Self {
+        if let Ok(unit_cost_usize) = usize::try_from(unit_cost) {
+            if let Some(cost) = len.checked_mul(unit_cost_usize) {
+                return Self::Small(cost);
+            }
+        }
+        Self::Large(len as u128 * unit_cost as u128)
+    }
+}
+
 impl NttPlan {
+    fn ntt_len_to_radices(mut ntt_len: usize) -> [u32; 5] {
+        let m2 = ntt_len.trailing_zeros();
+        ntt_len >>= m2;
+        let mut m3 = 0;
+        while ntt_len % 3 == 0 {
+            ntt_len /= 3;
+            m3 += 1;
+        }
+        let mut m5 = 0;
+        while ntt_len % 5 == 0 {
+            ntt_len /= 5;
+            m5 += 1;
+        }
+
+        // Make sure `ntt_len` has no other factors besides 2, 3, and 5
+        assert_eq!(ntt_len, 1);
+
+        Self::ntt_len_factors_to_radices(m2, m3, m5)
+    }
+
+    fn ntt_len_factors_to_radices(mut m2: u32, mut m3: u32, m5: u32) -> [u32; 5] {
+        // radix-5 does not compete with other radices (2, 3, 4, 6).
+        let cnt5 = m5;
+
+        // Pick radix-6 and radix-4 greedily and assign the remaining factors to radix-2 and radix-3.
+        let cnt6 = m2.min(m3);
+        m2 -= cnt6;
+        m3 -= cnt6;
+        let cnt4 = m2 / 2;
+        m2 -= cnt4 * 2;
+        let [cnt2, cnt3] = [m2, m3];
+
+        [cnt2, cnt3, cnt4, cnt5, cnt6]
+    }
+
     fn build<const P: u64>(min_len: usize) -> Self {
-        assert!(min_len as u64 <= Arith::<P>::MAX_NTT_LEN);
-        let (mut len_max, mut len_max_cost, mut g) = (usize::MAX, usize::MAX, 1);
-        for m5 in 0..=Arith::<P>::FACTORS_5 {
-            for m3 in 0..=Arith::<P>::FACTORS_3 {
-                let len = 5u64.pow(m5) * 3u64.pow(m3);
-                if len >= 2 * min_len as u64 {
-                    break;
-                }
+        // Allowed values for naive multiplication chunk length (base case).
+        //
+        // Under the cost model, g = 2 and g = 3 cannot be optimal. If the NTT radix
+        // decomposition contains one of {4, 5, 6}, it can be exchanged with g to
+        // improve the cost. The combination g = 3 and NTT radix 4 is an exception,
+        // but g = 6 with NTT radix 2 is more favorable. If g is 2 or 3 and the
+        // decomposition contains only {2, 3}, those radices can instead be absorbed
+        // into g.
+        //
+        // Hence, we only consider g >= 4.
+        const G_MIN: usize = 4;
+        const G_MAX: usize = 9;
 
-                let (mut len, mut m2) = (len as usize, 0);
-                while len < min_len && m2 < Arith::<P>::FACTORS_2 {
-                    len *= 2;
-                    m2 += 1;
-                }
+        // Cost model for NTT length selection.
+        //
+        // For a candidate convolution length `len = g * m`, the estimated cost is
+        // `len * (G_COSTS[g - G_MIN] + sum(radix_counts[i] * RADIX_COSTS[i]))`.
+        // Each radix-r stage processes all `len` elements in `len / r` groups of
+        // r-point butterflies, so the cost of a stage is modeled as linear in
+        // `len`. The constants below represent the relative per-element costs of
+        // the naive base cases and radix butterflies and were calibrated
+        // empirically. `G_COSTS` covers g = G_MIN..=G_MAX, while `RADIX_COSTS`
+        // covers radix-2 through radix-6.
+        const G_COSTS: [u32; G_MAX - G_MIN + 1] = [218, 287, 337, 433, 564, 663];
+        const RADIX_COSTS: [u32; 5] = [458, 791, 756, 1230, 915];
 
-                if len >= min_len && len < len_max_cost {
-                    let (mut tmp, mut cost) = (len, 0);
-                    let mut g_new = 1;
+        // Short cases do not require an NTT.
+        // The threshold could be larger, but we keep it minimal for simplicity.
+        // (Short cases will not invoke the NTT anyway.)
+        if min_len <= G_MAX {
+            // Special case for short `min_len`.
+            let g = min_len.max(1);
+            return Self::from_params::<P>(g, g);
+        }
 
-                    // Cost model for NTT length selection.
-                    //
-                    // Each radix-R stage processes N elements in N/R groups of R-point
-                    // butterflies. The per-stage cost is approximated as N * weight / 100,
-                    // where weight reflects the butterfly's arithmetic cost and cache
-                    // behavior, calibrated empirically:
-                    //   - radix-2: weight 85 (small) / 100 (large)
-                    //   - radix-3: weight 100 (reference)
-                    //   - radix-4: weight 90 (small) / 100 (large)
-                    //   - radix-5: weight 156-186 (length-dependent)
-                    //   - radix-6: weight 110 (small) / 115 (large)
-                    //
-                    // The small/large threshold (2^20 elements) approximates L2 cache
-                    // residency. Radix-5 has the highest weight due to its mul-heavy
-                    // butterfly (5 modular multiplications vs. 1 for radix-3/4).
+        let max_ntt_len = usize::try_from(Arith::<P>::MAX_NTT_LEN).unwrap_or(usize::MAX);
+        assert!(min_len <= max_ntt_len.saturating_mul(G_MAX));
 
-                    let small_transform = len <= 1 << 20;
-                    let radix6_weight = if small_transform { 110 } else { 115 };
-                    let radix5_weight =
-                        156 + 30 * len.saturating_sub(5 << 14).min(1 << 16) / (1 << 16);
-                    let radix4_weight = if small_transform { 90 } else { 100 };
-                    let radix3_weight = 100;
-                    let radix2_weight = if small_transform { 85 } else { 100 };
-
-                    if len % 5 == 0 {
-                        (g_new, tmp, cost) = (5, tmp / 5, cost + len * 89 / 100);
-                    } else if m3 >= m2 + 2 {
-                        (g_new, tmp, cost) = (9, tmp / 9, cost + len * 180 / 100);
-                    } else if m2 >= m3 + 3 && (m2 - m3) % 2 == 1 {
-                        (g_new, tmp, cost) = (8, tmp / 8, cost + len * 130 / 100);
-                    } else if m2 >= m3 + 2 && m3 == 0 {
-                        (g_new, tmp, cost) = (4, tmp / 4, cost + len * 87 / 100);
-                    } else if m2 == 0 && m3 >= 1 {
-                        (g_new, tmp, cost) = (3, tmp / 3, cost + len * 86 / 100);
-                    } else if m3 == 0 && m2 >= 1 {
-                        (g_new, tmp, cost) = (2, tmp / 2, cost + len * 86 / 100);
-                    } else if len % 6 == 0 {
-                        (g_new, tmp, cost) = (6, tmp / 6, cost + len * 91 / 100);
+        // The NTT length `m` contains only factors of 2, 3, and 5, but the single
+        // base-case length `g` may have any factorization: it is handled directly
+        // by the naive quadratic kernel rather than by radix-specific NTT stages.
+        // Thus `g = 7` can contribute one factor of 7 to `len = g * m`, reducing
+        // padding for some input lengths without requiring a radix-7 NTT kernel.
+        let mut best: Option<(usize, usize, PlanCost)> = None;
+        for g in G_MIN..=G_MAX {
+            let ntt_min_len = min_len / g + usize::from(min_len % g != 0);
+            for m5 in 0..=Arith::<P>::FACTORS_5 {
+                let pow5 = match 5usize.checked_pow(m5) {
+                    Some(pow5) => pow5,
+                    None => break,
+                };
+                for m3 in 0..=Arith::<P>::FACTORS_3 {
+                    // Compute the length of the transform
+                    let pow3 = match 3usize.checked_pow(m3) {
+                        Some(pow3) => pow3,
+                        None => break,
+                    };
+                    let mut ntt_len = match pow5.checked_mul(pow3) {
+                        Some(ntt_len) => ntt_len,
+                        None => break,
+                    };
+                    if ntt_len / 2 >= ntt_min_len {
+                        // Too much padding will not be computationally optimal
+                        break;
                     }
+                    let mut m2 = 0;
+                    while ntt_len < ntt_min_len && m2 < Arith::<P>::FACTORS_2 {
+                        ntt_len = match ntt_len.checked_mul(2) {
+                            Some(ntt_len) => ntt_len,
+                            None => break,
+                        };
+                        m2 += 1;
+                    }
+                    if ntt_len < ntt_min_len {
+                        continue;
+                    }
+                    let len = match g.checked_mul(ntt_len) {
+                        Some(len) => len,
+                        None => continue,
+                    };
 
-                    let (mut b6, mut b2) = (false, false);
-                    while tmp % 6 == 0 {
-                        (tmp, cost) = (tmp / 6, cost + len * radix6_weight / 100);
-                        b6 = true;
-                    }
-                    while tmp % 5 == 0 {
-                        (tmp, cost) = (tmp / 5, cost + len * radix5_weight / 100);
-                    }
-                    while tmp % 4 == 0 {
-                        (tmp, cost) = (tmp / 4, cost + len * radix4_weight / 100);
-                    }
-                    while tmp % 3 == 0 {
-                        (tmp, cost) = (tmp / 3, cost + len * radix3_weight / 100);
-                    }
-                    while tmp % 2 == 0 {
-                        (tmp, cost) = (tmp / 2, cost + len * radix2_weight / 100);
-                        b2 = true;
-                    }
+                    // Compute the cost of the transform
+                    let radix_counts = Self::ntt_len_factors_to_radices(m2, m3, m5);
+                    let unit_cost = G_COSTS[g - G_MIN]
+                        + radix_counts
+                            .into_iter()
+                            .zip(RADIX_COSTS)
+                            .map(|(radix_count, radix_cost)| radix_count * radix_cost)
+                            .sum::<u32>();
+                    let cost = PlanCost::new(len, unit_cost);
 
-                    if b6 && b2 {
-                        // One radix-6 stage and the remaining radix-2 stage are
-                        // executed as radix-4 and radix-3 stages.
-                        cost -= len * radix6_weight / 100;
-                        cost -= len * radix2_weight / 100;
-                        cost += len * radix4_weight / 100;
-                        cost += len * radix3_weight / 100;
-                    }
-
-                    // Account for work that scales with transform length but is
-                    // independent of the chosen stage decomposition.
-                    cost += len * 4 / 100;
-                    if cost < len_max_cost {
-                        (len_max, len_max_cost, g) = (len, cost, g_new);
+                    // Record the transform with the minimum cost
+                    if best.map_or(true, |(_, _, best_cost)| cost < best_cost) {
+                        best = Some((len, g, cost));
                     }
                 }
             }
         }
+        let (best_len, best_g, _) = best.expect("NTT length is too large");
+        Self::from_params::<P>(best_len, best_g)
+    }
 
-        let (mut cnt6, mut cnt5, mut cnt4, mut cnt3, mut cnt2) = (0, 0, 0, 0, 0);
-        let mut tmp = len_max / g;
-        while tmp % 6 == 0 {
-            tmp /= 6;
-            cnt6 += 1;
-        }
-        while tmp % 5 == 0 {
-            tmp /= 5;
-            cnt5 += 1;
-        }
-        while tmp % 4 == 0 {
-            tmp /= 4;
-            cnt4 += 1;
-        }
-        while tmp % 3 == 0 {
-            tmp /= 3;
-            cnt3 += 1;
-        }
-        while tmp % 2 == 0 {
-            tmp /= 2;
-            cnt2 += 1;
-        }
-        while cnt6 > 0 && cnt2 > 0 {
-            cnt6 -= 1;
-            cnt2 -= 1;
-            cnt4 += 1;
-            cnt3 += 1;
-        }
-
+    fn from_params<const P: u64>(len: usize, g: usize) -> Self {
+        assert!(len % g == 0);
+        let ntt_len = len / g;
+        let [cnt2, cnt3, cnt4, cnt5, cnt6] = Self::ntt_len_to_radices(ntt_len);
         let s_list = {
-            let mut out = vec![];
-            let mut tmp = len_max;
+            let capacity = (cnt2 + cnt3 + cnt4 + cnt5 + cnt6) as usize;
+            let mut out = Vec::with_capacity(capacity);
+            let mut tmp = len;
             for _ in 0..cnt2 {
                 out.push((tmp, 2));
                 tmp /= 2;
@@ -374,9 +419,9 @@ impl NttPlan {
         };
 
         Self {
-            n: len_max,
+            n: len,
             g,
-            m: len_max / g,
+            m: ntt_len,
             last_radix: s_list.last().unwrap_or(&(1, 1)).1,
             s_list,
         }
@@ -751,7 +796,7 @@ fn calc_twiddle_factors<const P: u64, const INV: bool>(
 }
 
 // Performs (cyclic) integer convolution modulo P using NTT.
-// Modifies the input buffers in-place.
+// Modifies the input buffers in place.
 // The output is saved in the slice `x`.
 // The input slices must have the same length.
 fn conv<const P: u64>(
@@ -838,6 +883,10 @@ fn conv<const P: u64>(
 
 ////////////////////////////////////////////////////////////////////////////////
 
+// Prime selection balances two goals: a modulus close to 2^64 increases the
+// packing density, while large powers of 2, 3, and 5 dividing P - 1 provide
+// more supported NTT lengths. The NTT primes used by this module were found
+// by exhaustive search subject to both requirements.
 const P1: u64 = 14_259_017_916_245_606_401; // Max NTT length = 2^22 * 3^21 * 5^2 = 1_096_847_532_018_892_800
 const P2: u64 = 17_984_575_660_032_000_001; // Max NTT length = 2^19 * 3^17 * 5^6 = 1_057_916_215_296_000_000
 const P3: u64 = 17_995_154_822_184_960_001; // Max NTT length = 2^17 * 3^22 * 5^4 = 2_570_736_403_169_280_000
@@ -960,7 +1009,7 @@ fn mac3_two_primes(acc: &mut [u64], b: &[u64], c: &[u64], bits: u64) {
             acc[j] = w;
             carry_acc = u64::from(overflow1 || overflow2);
 
-            // roll-over
+            // roll over
             (j, p) = (j + 1, p - 64);
             bitbuf = out >> (bits - p);
         }
@@ -1071,6 +1120,8 @@ fn mac3_three_primes(acc: &mut [u64], b: &[u64], c: &[u64]) {
 }
 
 fn mac3_u64(acc: &mut [u64], b: &[u64], c: &[u64]) {
+    // Computes the largest safe packed-digit width from the maximum operand length,
+    // ensuring the convolution coefficients fit below P2 * P3.
     const fn compute_bits(l: u64) -> u64 {
         let total_bits = l * 64;
         let (mut lo, mut hi) = (42, 62);
@@ -1098,8 +1149,8 @@ fn mac3_u64(acc: &mut [u64], b: &[u64], c: &[u64]) {
     // depends on the length of the arrays being multiplied (convolved).
     // If the arrays are too long, the resulting values may exceed the
     // modulus range P2 * P3, which leads to incorrect results.
-    // Hence, we compute the number of bits required by the length of NTT,
-    // and use it to determine whether to use two-prime or three-prime.
+    // Hence, we compute the maximum number of bits that can be packed in one
+    // u64, and use it to determine whether to use two-prime or three-prime.
     // Since we can pack 64 bits per u64 in three-prime NTT, the effective
     // number of bits in three-prime NTT is 64/3 = 21.3333..., which means
     // two-prime NTT can only do better when at least 43 bits per u64 can
@@ -1148,4 +1199,19 @@ cfg_digit! {
     pub fn mac3(acc: &mut [BigDigit], b: &[BigDigit], c: &[BigDigit]) {
        mac3_u64(acc, b, c);
     }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+#[cfg(feature = "bench-internals")]
+pub(super) fn benchmark_plan_build<const PRIME_INDEX: usize>(
+    min_len: usize,
+) -> (usize, usize, usize) {
+    let plan = match PRIME_INDEX {
+        1 => NttPlan::build::<P1>(min_len),
+        2 => NttPlan::build::<P2>(min_len),
+        3 => NttPlan::build::<P3>(min_len),
+        _ => panic!("PRIME_INDEX must be 1, 2, or 3"),
+    };
+    (plan.n, plan.g, plan.s_list.len())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -229,6 +229,9 @@ pub use crate::biguint::BigUint;
 pub use crate::biguint::ToBigUint;
 pub use crate::biguint::U32Digits;
 pub use crate::biguint::U64Digits;
+#[cfg(feature = "bench-internals")]
+#[doc(hidden)]
+pub use crate::biguint::__benchmark_ntt_plan_build;
 
 pub use crate::bigint::BigInt;
 pub use crate::bigint::Sign;


### PR DESCRIPTION
* Rewrote the NTT planner. The planner now considers all possible values of the base naive-multiplication chunk length `g`, which was previously chosen heuristically and then fixed. The timing data was recollected by enumerating all possible `g` values for input lengths up to 300M bits, and the coefficients were then rederived via linear regression. The new fit, which takes `g` into account, achieved `R^2 > 0.99`, and the length-dependent weights turned out to be unnecessary. The `radix-6 + radix-2 → radix-4 + radix-3` plan rewrite also turned out to be slower, so it was removed. The planner now considers `g` in the range `[4, 9]`, since `g = 2` and `g = 3` are never selected by an optimal plan.
* Added and improved comments.