### PR TITLE
Allocate with headroom when `BigDigits` spills to the heap

### DIFF
--- a/benches/bigint.rs
+++ b/benches/bigint.rs
@@ -66,6 +66,46 @@ fn fib2(n: usize) -> BigUint {
     f0
 }
 
+/// Accumulate a decimal integer 18 digits at a time, the shape of a decimal parser.
+/// `chunks` is chosen so the result brackets the `Inline` -> `Heap` transition.
+fn scalar_accumulate_bench(b: &mut Bencher, chunks: u32) {
+    let m = 10u64.pow(18);
+
+    b.iter(|| {
+        let mut x = BigUint::from(u64::MAX);
+        for _ in 0..chunks {
+            x *= m;
+            x += m - 1;
+        }
+        x
+    });
+}
+
+#[bench]
+fn scalar_accumulate_2_digits(b: &mut Bencher) {
+    scalar_accumulate_bench(b, 1);
+}
+
+#[bench]
+fn scalar_accumulate_3_digits(b: &mut Bencher) {
+    scalar_accumulate_bench(b, 2);
+}
+
+#[bench]
+fn scalar_accumulate_4_digits(b: &mut Bencher) {
+    scalar_accumulate_bench(b, 3);
+}
+
+#[bench]
+fn scalar_accumulate_6_digits(b: &mut Bencher) {
+    scalar_accumulate_bench(b, 5);
+}
+
+#[bench]
+fn scalar_accumulate_20_digits(b: &mut Bencher) {
+    scalar_accumulate_bench(b, 19);
+}
+
 #[bench]
 fn multiply_8_8(b: &mut Bencher) {
     multiply_bench(b, 1 << 8, 1 << 8);

--- a/src/big_digit.rs
+++ b/src/big_digit.rs
@@ -41,6 +41,14 @@ pub(crate) fn to_doublebigdigit(hi: BigDigit, lo: BigDigit) -> DoubleBigDigit {
     DoubleBigDigit::from(lo) | (DoubleBigDigit::from(hi) << BITS)
 }
 
+/// The smallest capacity a `Vec` allocates for itself, so that spilling from inline to the heap
+/// lands on the growth sequence `Vec::push` would have used rather than one realloc behind it.
+///
+/// This is `RawVec::MIN_NON_ZERO_CAP`, which is 4 for elements of 2 to 1024 bytes — `BigDigit` at
+/// either digit width:
+/// <https://github.com/rust-lang/rust/blob/e71c0f1e3395b10a8c331317be1a5c107bdf7b2e/library/alloc/src/raw_vec/mod.rs#L153-L166>
+const MIN_NON_ZERO_CAP: usize = 4;
+
 pub(crate) enum BigDigits {
     Inline(Option<BigDigit>),
     Heap(Vec<BigDigit>),
@@ -86,10 +94,7 @@ impl BigDigits {
         match &mut *self {
             BigDigits::Inline(x @ None) => *x = Some(y),
             BigDigits::Inline(Some(x)) => {
-                // Capacity 2 here would make growth run 2 -> 4 -> 8, one realloc more than
-                // `Vec::push` does on its own: its minimum non-zero capacity is 4 for
-                // `BigDigit`, at either digit width.
-                let mut xs = Vec::with_capacity(4);
+                let mut xs = Vec::with_capacity(MIN_NON_ZERO_CAP);
                 xs.push(*x);
                 xs.push(y);
                 *self = BigDigits::Heap(xs);

--- a/src/big_digit.rs
+++ b/src/big_digit.rs
@@ -85,7 +85,15 @@ impl BigDigits {
     pub(crate) fn push(&mut self, y: BigDigit) {
         match &mut *self {
             BigDigits::Inline(x @ None) => *x = Some(y),
-            BigDigits::Inline(Some(x)) => *self = BigDigits::Heap([*x, y].to_vec()),
+            BigDigits::Inline(Some(x)) => {
+                // Capacity 2 here would make growth run 2 -> 4 -> 8, one realloc more than
+                // `Vec::push` does on its own: its minimum non-zero capacity is 4 for
+                // `BigDigit`, at either digit width.
+                let mut xs = Vec::with_capacity(4);
+                xs.push(*x);
+                xs.push(y);
+                *self = BigDigits::Heap(xs);
+            }
             BigDigits::Heap(xs) => xs.push(y),
         }
     }

--- a/src/big_digit.rs
+++ b/src/big_digit.rs
@@ -44,17 +44,16 @@ pub(crate) fn to_doublebigdigit(hi: BigDigit, lo: BigDigit) -> DoubleBigDigit {
 /// The smallest capacity a `Vec` allocates for itself, so that spilling from inline to the heap
 /// lands on the growth sequence `Vec::push` would have used rather than one realloc behind it.
 ///
-/// This is `RawVec::MIN_NON_ZERO_CAP`, which is 4 for elements of 2 to 1024 bytes — `BigDigit` at
-/// either digit width:
+/// This follows the standard library's `fn min_non_zero_cap(size)`, which returns 4 for sizes of 2
+/// to 1024 bytes, including `BigDigit`'s size at either digit width.
 /// <https://github.com/rust-lang/rust/blob/e71c0f1e3395b10a8c331317be1a5c107bdf7b2e/library/alloc/src/raw_vec/mod.rs#L153-L166>
 const MIN_NON_ZERO_CAP: usize = 4;
 
 /// A heap buffer with room for at least `capacity` digits.
 ///
-/// `Vec::with_capacity` allocates exactly what it is asked for, while the methods that grow a
-/// `Vec` — `push`, `reserve`, `resize`, `extend` — never allocate less than [`MIN_NON_ZERO_CAP`],
-/// so going through this leaves an `Inline` -> `Heap` spill holding the allocation the same
-/// operation on a `Heap` would have produced.
+/// `Vec::with_capacity` allocates exactly what it is asked for, while methods like `Vec::push` use
+/// amortized growth, never less than `min_non_zero_cap(size)`. So when we're spilling from
+/// `Inline` to `Heap`, we use the same minimum capacity that we'd have with a pure `Vec`.
 #[inline]
 fn heap_with_capacity(capacity: usize) -> Vec<BigDigit> {
     Vec::with_capacity(capacity.max(MIN_NON_ZERO_CAP))

--- a/src/big_digit.rs
+++ b/src/big_digit.rs
@@ -166,7 +166,7 @@ impl BigDigits {
                 match **xs {
                     [] => *self = BigDigits::ZERO,
                     [x] => *self = BigDigits::Inline(Some(x)),
-                    _ => xs.shrink_to(xs.len() + 1),
+                    _ => xs.shrink_to((xs.len() + 1).max(MIN_NON_ZERO_CAP)),
                 }
             }
         }
@@ -197,13 +197,7 @@ impl BigDigits {
                     let len = xs.iter().rposition(|&d| d != 0).map_or(0, |i| i + 1);
                     xs.truncate(len);
                 }
-                if xs.len() < xs.capacity() / 2 {
-                    match **xs {
-                        [] => *self = BigDigits::ZERO,
-                        [x] => *self = BigDigits::Inline(Some(x)),
-                        _ => xs.shrink_to(xs.len() + 1),
-                    }
-                }
+                self.shrink();
             }
         }
     }

--- a/src/big_digit.rs
+++ b/src/big_digit.rs
@@ -49,6 +49,17 @@ pub(crate) fn to_doublebigdigit(hi: BigDigit, lo: BigDigit) -> DoubleBigDigit {
 /// <https://github.com/rust-lang/rust/blob/e71c0f1e3395b10a8c331317be1a5c107bdf7b2e/library/alloc/src/raw_vec/mod.rs#L153-L166>
 const MIN_NON_ZERO_CAP: usize = 4;
 
+/// A heap buffer with room for at least `capacity` digits.
+///
+/// `Vec::with_capacity` allocates exactly what it is asked for, while the methods that grow a
+/// `Vec` — `push`, `reserve`, `resize`, `extend` — never allocate less than [`MIN_NON_ZERO_CAP`],
+/// so going through this leaves an `Inline` -> `Heap` spill holding the allocation the same
+/// operation on a `Heap` would have produced.
+#[inline]
+fn heap_with_capacity(capacity: usize) -> Vec<BigDigit> {
+    Vec::with_capacity(capacity.max(MIN_NON_ZERO_CAP))
+}
+
 pub(crate) enum BigDigits {
     Inline(Option<BigDigit>),
     Heap(Vec<BigDigit>),
@@ -72,7 +83,11 @@ impl BigDigits {
         match slice {
             &[] => BigDigits::ZERO,
             &[x] => BigDigits::Inline(Some(x)),
-            xs => BigDigits::Heap(xs.to_vec()),
+            xs => {
+                let mut vec = heap_with_capacity(xs.len());
+                vec.extend_from_slice(xs);
+                BigDigits::Heap(vec)
+            }
         }
     }
 
@@ -226,7 +241,7 @@ impl BigDigits {
             BigDigits::Inline(opt_x) => {
                 let capacity = usize::from(opt_x.is_some()) + additional;
                 if capacity > 1 {
-                    let mut vec = Vec::with_capacity(capacity);
+                    let mut vec = heap_with_capacity(capacity);
                     if let Some(x) = *opt_x {
                         vec.push(x);
                     }
@@ -247,7 +262,7 @@ impl BigDigits {
                     }
                 }
                 _ => {
-                    let mut xs = Vec::with_capacity(len);
+                    let mut xs = heap_with_capacity(len);
                     if let Some(x) = *x {
                         xs.push(x);
                     }
@@ -265,7 +280,7 @@ impl BigDigits {
             BigDigits::Inline(Some(x)) => {
                 let len = ys.len() + 1;
                 if len > 1 {
-                    let mut xs = Vec::with_capacity(len);
+                    let mut xs = heap_with_capacity(len);
                     xs.push(*x);
                     xs.extend_from_slice(ys);
                     *self = BigDigits::Heap(xs);
@@ -289,7 +304,7 @@ impl BigDigits {
                 }
                 if let Some(y) = iter.next() {
                     let len = iter.len().saturating_add(2);
-                    let mut xs = Vec::with_capacity(len);
+                    let mut xs = heap_with_capacity(len);
                     xs.push(x.unwrap());
                     xs.push(y);
                     xs.extend(iter);
@@ -346,4 +361,85 @@ impl core::ops::DerefMut for BigDigits {
             BigDigits::Heap(xs) => xs,
         }
     }
+}
+
+/// The capacity of a one digit `BigDigits` after `op`.
+#[cfg(test)]
+fn capacity_after(op: impl FnOnce(&mut BigDigits)) -> usize {
+    let mut x = BigDigits::from_digit(1);
+    op(&mut x);
+    x.capacity()
+}
+
+/// Spilling from inline to the heap should land on the capacity `Vec` would have allocated for
+/// itself, so that the next push doesn't immediately reallocate.
+#[test]
+fn spills_allocate_at_least_the_minimum() {
+    const MIN: usize = MIN_NON_ZERO_CAP;
+
+    assert_eq!(capacity_after(|x| x.push(2)), MIN, "push");
+    assert_eq!(capacity_after(|x| x.reserve(1)), MIN, "reserve");
+    assert_eq!(capacity_after(|x| x.resize(2, 0)), MIN, "resize");
+    assert_eq!(
+        capacity_after(|x| x.extend_from_slice(&[2])),
+        MIN,
+        "extend_from_slice"
+    );
+    assert_eq!(
+        capacity_after(|x| x.extend([2, 3].into_iter())),
+        MIN,
+        "extend"
+    );
+    assert_eq!(BigDigits::from_slice(&[1, 2]).capacity(), MIN, "from_slice");
+    assert_eq!(
+        BigDigits::from_slice(&[1, 2]).clone().capacity(),
+        MIN,
+        "clone"
+    );
+
+    // above the floor each site still asks for exactly what it needs
+    assert_eq!(capacity_after(|x| x.reserve(5)), 6, "reserve");
+    assert_eq!(capacity_after(|x| x.resize(6, 0)), 6, "resize");
+    assert_eq!(
+        capacity_after(|x| x.extend_from_slice(&[2, 3, 4, 5, 6])),
+        6,
+        "extend_from_slice"
+    );
+    assert_eq!(
+        capacity_after(|x| x.extend([2, 3, 4, 5, 6].into_iter())),
+        6,
+        "extend"
+    );
+    assert_eq!(
+        BigDigits::from_slice(&[1, 2, 3, 4, 5, 6]).capacity(),
+        6,
+        "from_slice"
+    );
+
+    // `from_vec` is the exception, it keeps the allocation it is given
+    assert_eq!(BigDigits::from_vec(vec![1, 2]).capacity(), 2, "from_vec");
+}
+
+/// A value that still fits inline shouldn't reach the heap at all.
+#[test]
+fn small_values_stay_inline() {
+    assert_eq!(capacity_after(|x| x.reserve(0)), 1, "reserve");
+    assert_eq!(capacity_after(|x| x.resize(1, 0)), 1, "resize");
+    assert_eq!(
+        capacity_after(|x| x.extend_from_slice(&[])),
+        1,
+        "extend_from_slice"
+    );
+    assert_eq!(
+        capacity_after(|x| x.extend(core::iter::empty())),
+        1,
+        "extend"
+    );
+
+    let mut x = BigDigits::ZERO;
+    x.push(1);
+    assert_eq!(x.capacity(), 1, "push");
+
+    assert_eq!(BigDigits::from_slice(&[1]).capacity(), 1, "from_slice");
+    assert_eq!(BigDigits::from_slice(&[]).capacity(), 1, "from_slice empty");
 }


### PR DESCRIPTION
The below description is written with AI, but I've researched this at length manually, and I think on balance this change smoothes out the changes. See https://github.com/pydantic/jiter/pull/264#issuecomment-5316895247 for a severe example which I chanced upon.

---

`BigDigits::push` moves from `Inline` to `Heap` with `[*x, y].to_vec()`, which allocates capacity exactly 2, so growth then runs 2 -> 4 -> 8. Before #307 the first allocation came from `Vec::push`, whose minimum non-zero capacity is 4 for `BigDigit` at either digit width, so growth ran 4 -> 8. Values that grow past one digit do one more `realloc` than they did in 0.4.6, and each growth step happens one push earlier.

Measured with the benchmarks this PR adds, Apple M3 Max, rustc 1.97.1-nightly:

| bench | before | after |
| --- | ---: | ---: |
| `scalar_accumulate_2_digits` | 14.40 ns | 18.00 ns |
| `scalar_accumulate_3_digits` | 49.15 ns | 21.50 ns |
| `scalar_accumulate_4_digits` | 54.15 ns | 25.46 ns |
| `scalar_accumulate_6_digits` | 88.73 ns | 60.49 ns |
| `scalar_accumulate_20_digits` | 253.35 ns | 213.80 ns |

The 2-digit case gets slower. A value that reaches two digits and stops now takes a 32-byte allocation instead of 16, and nothing at the transition distinguishes it from a value that keeps growing. That measurement is macOS system malloc; 16 and 32 bytes may fall in the same chunk size class on glibc.

Found from [jiter](https://github.com/pydantic/jiter), which parses integers as repeated `x *= 10^18; x += chunk`. Its `massive_ints_array` benchmark, 1000 integers of ~60 decimal digits or 4 `BigDigit`s, is 46-55% slower on 0.4.8 than on 0.4.6, and returns to 0.4.6 timings with this change.
